### PR TITLE
*: implement distinct clause

### DIFF
--- a/mem/table.go
+++ b/mem/table.go
@@ -55,7 +55,7 @@ func (t *Table) Insert(row sql.Row) error {
 	for idx, value := range row {
 		c := t.schema[idx]
 		if !c.Check(value) {
-			return sql.ErrInvalidType
+			return sql.ErrInvalidType.New(value)
 		}
 	}
 

--- a/sql/core.go
+++ b/sql/core.go
@@ -1,7 +1,7 @@
 package sql
 
 import (
-	"errors"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 type Nameable interface {
@@ -70,4 +70,4 @@ type Database interface {
 	Tables() map[string]Table
 }
 
-var ErrInvalidType = errors.New("invalid type")
+var ErrInvalidType = errors.NewKind("invalid type: %s")

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -68,10 +68,6 @@ func convertSelect(s *sqlparser.Select) (sql.Node, error) {
 		return nil, err
 	}
 
-	if s.Distinct != "" {
-		return nil, errUnsupportedFeature("DISTINCT")
-	}
-
 	if s.Having != nil {
 		return nil, errUnsupportedFeature("HAVING")
 	}
@@ -93,6 +89,10 @@ func convertSelect(s *sqlparser.Select) (sql.Node, error) {
 	node, err = selectToProjectOrGroupBy(s.SelectExprs, s.GroupBy, node)
 	if err != nil {
 		return nil, err
+	}
+
+	if s.Distinct != "" {
+		node = plan.NewDistinct(node)
 	}
 
 	if s.Limit != nil {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -189,6 +189,15 @@ var fixtures = map[string]sql.Node{
 		[]string{"col1", "col2"},
 	),
 	`SHOW TABLES`: plan.NewShowTables(&sql.UnresolvedDatabase{}),
+	`SELECT DISTINCT foo, bar FROM foo;`: plan.NewDistinct(
+		plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewUnresolvedTable("foo"),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/plan/common_test.go
+++ b/sql/plan/common_test.go
@@ -1,0 +1,60 @@
+package plan
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+var benchtable = func() *mem.Table {
+	schema := sql.Schema{
+		{Name: "strfield", Type: sql.Text, Nullable: true},
+		{Name: "floatfield", Type: sql.Float64, Nullable: true},
+		{Name: "boolfield", Type: sql.Boolean, Nullable: false},
+		{Name: "intfield", Type: sql.Int32, Nullable: false},
+		{Name: "bigintfield", Type: sql.Int64, Nullable: false},
+		{Name: "blobfield", Type: sql.Blob, Nullable: false},
+	}
+	t := mem.NewTable("test", schema)
+
+	for i := 0; i < 100; i++ {
+		n := fmt.Sprint(i)
+		err := t.Insert(sql.NewRow(
+			repeatStr(n, i%10+1),
+			float64(i),
+			i%2 == 0,
+			int32(i),
+			int64(i),
+			[]byte(repeatStr(n, 100+(i%100))),
+		))
+		if err != nil {
+			panic(err)
+		}
+
+		if i%2 == 0 {
+			err := t.Insert(sql.NewRow(
+				repeatStr(n, i%10+1),
+				float64(i),
+				i%2 == 0,
+				int32(i),
+				int64(i),
+				[]byte(repeatStr(n, 100+(i%100))),
+			))
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	return t
+}()
+
+func repeatStr(str string, n int) string {
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		buf.WriteString(str)
+	}
+	return buf.String()
+}

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -7,20 +7,24 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
+// Distinct is a node that ensures all rows that come from it are unique.
 type Distinct struct {
 	UnaryNode
 }
 
+// NewDistinct creates a new Distinct node.
 func NewDistinct(child sql.Node) *Distinct {
 	return &Distinct{
 		UnaryNode: UnaryNode{Child: child},
 	}
 }
 
+// Resolved implements the Resolvable interface.
 func (d *Distinct) Resolved() bool {
 	return d.UnaryNode.Child.Resolved()
 }
 
+// RowIter implements the Node interface.
 func (d *Distinct) RowIter() (sql.RowIter, error) {
 	it, err := d.Child.RowIter()
 	if err != nil {
@@ -29,10 +33,12 @@ func (d *Distinct) RowIter() (sql.RowIter, error) {
 	return newDistinctIter(it), nil
 }
 
+// TransformUp implements the Transformable interface.
 func (d *Distinct) TransformUp(f func(sql.Node) sql.Node) sql.Node {
 	return f(NewDistinct(d.Child.TransformUp(f)))
 }
 
+// TransformExpressionsUp implements the Transformable interface.
 func (d *Distinct) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
 	return NewDistinct(d.Child.TransformExpressionsUp(f))
 }

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -1,0 +1,83 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+type Distinct struct {
+	UnaryNode
+}
+
+func NewDistinct(child sql.Node) *Distinct {
+	return &Distinct{
+		UnaryNode: UnaryNode{Child: child},
+	}
+}
+
+func (d *Distinct) Resolved() bool {
+	return d.UnaryNode.Child.Resolved()
+}
+
+func (d *Distinct) RowIter() (sql.RowIter, error) {
+	it, err := d.Child.RowIter()
+	if err != nil {
+		return nil, err
+	}
+	return newDistinctIter(it), nil
+}
+
+func (d *Distinct) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+	return f(NewDistinct(d.Child.TransformUp(f)))
+}
+
+func (d *Distinct) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
+	return NewDistinct(d.Child.TransformExpressionsUp(f))
+}
+
+// distinctIter keeps track of the hashes of all rows that have been emitted.
+// It does not emit any rows whose hashes have been seen already.
+// TODO: come up with a way to use less memory than keeping all hashes in mem.
+// Even though they are just 64-bit integers, this could be a problem in large
+// result sets.
+type distinctIter struct {
+	currentPos int64
+	childIter  sql.RowIter
+	seen       map[uint64]struct{}
+}
+
+func newDistinctIter(child sql.RowIter) *distinctIter {
+	return &distinctIter{
+		currentPos: 0,
+		childIter:  child,
+		seen:       make(map[uint64]struct{}),
+	}
+}
+
+func (di *distinctIter) Next() (sql.Row, error) {
+	for {
+		childRow, err := di.childIter.Next()
+		di.currentPos++
+		if err != nil {
+			return nil, err
+		}
+
+		hash, err := hashstructure.Hash(childRow, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to hash row: %s", err)
+		}
+
+		if _, ok := di.seen[hash]; ok {
+			continue
+		}
+
+		di.seen[hash] = struct{}{}
+		return childRow, nil
+	}
+}
+
+func (di *distinctIter) Close() error {
+	return di.childIter.Close()
+}

--- a/sql/plan/distinct_test.go
+++ b/sql/plan/distinct_test.go
@@ -1,0 +1,80 @@
+package plan
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestDistinct(t *testing.T) {
+	require := require.New(t)
+	childSchema := sql.Schema{
+		{Name: "name", Type: sql.Text, Nullable: true},
+		{Name: "email", Type: sql.Text, Nullable: true},
+	}
+	child := mem.NewTable("test", childSchema)
+	require.NoError(child.Insert(sql.NewRow("john", "john@doe.com")))
+	require.NoError(child.Insert(sql.NewRow("jane", "jane@doe.com")))
+	require.NoError(child.Insert(sql.NewRow("john", "johnx@doe.com")))
+	require.NoError(child.Insert(sql.NewRow("martha", "marthax@doe.com")))
+	require.NoError(child.Insert(sql.NewRow("martha", "martha@doe.com")))
+
+	p := NewProject([]sql.Expression{
+		expression.NewGetField(0, sql.Text, "name", true),
+	}, child)
+	d := NewDistinct(p)
+
+	iter, err := d.RowIter()
+	require.Nil(err)
+	require.NotNil(iter)
+
+	var results []string
+	for {
+		row, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+
+		require.NoError(err)
+		result, ok := row[0].(string)
+		require.True(ok, "first row column should be string, but is %T", row[0])
+		results = append(results, result)
+	}
+
+	require.Equal([]string{"john", "jane", "martha"}, results)
+}
+
+func BenchmarkDistinct(b *testing.B) {
+	require := require.New(b)
+	for i := 0; i < b.N; i++ {
+		p := NewProject([]sql.Expression{
+			expression.NewGetField(0, sql.Text, "strfield", true),
+			expression.NewGetField(1, sql.Float64, "floatfield", true),
+			expression.NewGetField(2, sql.Boolean, "boolfield", false),
+			expression.NewGetField(3, sql.Int32, "intfield", false),
+			expression.NewGetField(4, sql.Int64, "bigintfield", false),
+			expression.NewGetField(5, sql.Blob, "blobfield", false),
+		}, benchtable)
+		d := NewDistinct(p)
+
+		iter, err := d.RowIter()
+		require.Nil(err)
+		require.NotNil(iter)
+
+		var rows int
+		for {
+			_, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+
+			require.NoError(err)
+			rows++
+		}
+		require.Equal(100, rows)
+	}
+}

--- a/sql/plan/project_test.go
+++ b/sql/plan/project_test.go
@@ -57,3 +57,30 @@ func TestProject(t *testing.T) {
 	}
 	require.Equal(schema, p.Schema())
 }
+
+func BenchmarkProject(b *testing.B) {
+	require := require.New(b)
+	for i := 0; i < b.N; i++ {
+		d := NewProject([]sql.Expression{
+			expression.NewGetField(0, sql.Text, "strfield", true),
+			expression.NewGetField(1, sql.Float64, "floatfield", true),
+			expression.NewGetField(2, sql.Boolean, "boolfield", false),
+			expression.NewGetField(3, sql.Int32, "intfield", false),
+			expression.NewGetField(4, sql.Int64, "bigintfield", false),
+			expression.NewGetField(5, sql.Blob, "blobfield", false),
+		}, benchtable)
+
+		iter, err := d.RowIter()
+		require.Nil(err)
+		require.NotNil(iter)
+
+		for {
+			_, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+
+			require.NoError(err)
+		}
+	}
+}

--- a/sql/type.go
+++ b/sql/type.go
@@ -141,9 +141,10 @@ func (t numberT) Convert(v interface{}) (interface{}, error) {
 		return cast.ToFloat32E(v)
 	case sqltypes.Float64:
 		return cast.ToFloat64E(v)
+	default:
+		return nil, ErrInvalidType.New(t.t)
 	}
 
-	return nil, ErrInvalidType
 }
 
 // Compare implements Type interface.
@@ -220,7 +221,7 @@ func (t timestampT) Convert(v interface{}) (interface{}, error) {
 	default:
 		ts, err := Int64.Convert(v)
 		if err != nil {
-			return nil, ErrInvalidType
+			return nil, ErrInvalidType.New(reflect.TypeOf(v))
 		}
 
 		return time.Unix(ts.(int64), 0), nil
@@ -324,7 +325,7 @@ func (t blobT) Convert(v interface{}) (interface{}, error) {
 	case fmt.Stringer:
 		return []byte(value.String()), nil
 	default:
-		return nil, ErrInvalidType
+		return nil, ErrInvalidType.New(reflect.TypeOf(v))
 	}
 }
 
@@ -361,7 +362,6 @@ func (t jsonT) Compare(a interface{}, b interface{}) int {
 func MustConvert(t Type, v interface{}) interface{} {
 	c, err := t.Convert(v)
 	if err != nil {
-		fmt.Println(err)
 		panic(err)
 	}
 

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -108,7 +108,8 @@ func TestType_Blob(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal([]byte{}, v)
 	v, err = Blob.Convert(1)
-	assert.Equal(ErrInvalidType, err)
+	assert.NotNil(err)
+	assert.True(ErrInvalidType.Is(err))
 	assert.Nil(v)
 
 	assert.Equal(-1, Blob.Compare([]byte{'A'}, []byte{'B'}))


### PR DESCRIPTION
Closes #2 

This PR implements the DISTINCT SQL Node. Distinct wraps a projection and emits only rows that have not been previously seen before.

There is a common table with more than 100 rows to perform benchmarks. A Benchmark has been added for both Project and Distinct, which shows that Distinct is two orders of magnitude slower than Project. Although this is just a first approximation to have the feature, in the feature we should spend some time thinking on how to properly and efficiently implement the distinct and/or try to identify if the projection is sorted, which would eliminate the need to keep track of the hashes and make this way faster.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>