### PR TITLE
sql: better coverage of star rule and clarify it's a placeholder

### DIFF
--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
@@ -11,7 +12,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
 
-func Test_resolveTables(t *testing.T) {
+func TestResolveTables(t *testing.T) {
 	require := require.New(t)
 
 	f := getRule("resolve_tables")
@@ -39,7 +40,7 @@ func Test_resolveTables(t *testing.T) {
 
 }
 
-func Test_resolveTables_Nested(t *testing.T) {
+func TestResolveTablesNested(t *testing.T) {
 	require := require.New(t)
 
 	f := getRule("resolve_tables")
@@ -61,6 +62,32 @@ func Test_resolveTables_Nested(t *testing.T) {
 	analyzed := f.Apply(a, notAnalyzed)
 	expected := plan.NewProject(
 		[]sql.Expression{expression.NewGetField(0, sql.Int32, "i", true)},
+		table,
+	)
+	require.Equal(expected, analyzed)
+}
+
+func TestResolveStar(t *testing.T) {
+	require := require.New(t)
+	f := getRule("resolve_star")
+
+	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
+	db := mem.NewDatabase("mydb")
+	db.AddTable("mytable", table)
+
+	catalog := &sql.Catalog{Databases: []sql.Database{db}}
+
+	a := analyzer.New(catalog)
+	a.Rules = []analyzer.Rule{f}
+	a.CurrentDatabase = "mydb"
+
+	notAnalyzed := plan.NewProject(
+		[]sql.Expression{expression.NewStar()},
+		table,
+	)
+	analyzed := f.Apply(a, notAnalyzed)
+	expected := plan.NewProject(
+		[]sql.Expression{expression.NewGetField(0, sql.Int32, "i", false)},
 		table,
 	)
 	require.Equal(expected, analyzed)

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -3,12 +3,13 @@ package expression
 import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
 // Star represents the selection of all available fields.
-type Star struct {
-}
+// This is just a placeholder node, it will not actually be evaluated
+// but converted to a series of GetFields when the query is analyzed.
+type Star struct{}
 
 // NewStar returns a new Star expression.
 func NewStar() *Star {
-	return &Star{}
+	return new(Star)
 }
 
 // Resolved implements the Resolvable interface.
@@ -18,12 +19,12 @@ func (Star) Resolved() bool {
 
 // IsNullable implements the Expression interface.
 func (Star) IsNullable() bool {
-	return true
+	panic("star is just a placeholder node, but IsNullable was called")
 }
 
 // Type implements the Expression interface.
 func (Star) Type() sql.Type {
-	return sql.Text //FIXME
+	panic("star is just a placeholder node, but Type was called")
 }
 
 // Name implements the Expression interface.
@@ -32,9 +33,8 @@ func (Star) Name() string {
 }
 
 // Eval implements the Expression interface.
-// TODO: this is not implemented yet.
 func (Star) Eval(r sql.Row) interface{} {
-	return "FAIL" //FIXME
+	panic("star is just a placeholder node, but Eval was called")
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/expression/star_test.go
+++ b/sql/expression/star_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -197,6 +197,12 @@ var fixtures = map[string]sql.Node{
 			plan.NewUnresolvedTable("foo"),
 		),
 	),
+	`SELECT * FROM foo`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewStar(),
+		},
+		plan.NewUnresolvedTable("foo"),
+	),
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
This PR adds tests for the rule that resolves the Star node and it adds a case to check the star is correctly parsed.
Also, clarifies in the docs that Star is just a placeholder node. Some methods with FIXMES have been replaced with panics, as Star methods should never be called.