### PR TITLE
sql/parse: support more than 2 tables on cross join

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -193,12 +193,12 @@ func tableExprsToTable(te sqlparser.TableExprs) (sql.Node, error) {
 		return nodes[0], nil
 	}
 
-	if len(nodes) == 2 {
-		return plan.NewCrossJoin(nodes[0], nodes[1]), nil
+	join := plan.NewCrossJoin(nodes[0], nodes[1])
+	for i := 2; i < len(nodes); i++ {
+		join = plan.NewCrossJoin(join, nodes[i])
 	}
 
-	//TODO: Support N tables in JOIN.
-	return nil, errUnsupportedFeature("more than 2 tables in JOIN")
+	return join, nil
 }
 
 func tableExprToTable(te sqlparser.TableExpr) (sql.Node, error) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -224,6 +224,19 @@ var fixtures = map[string]sql.Node{
 			plan.NewUnresolvedTable("foo"),
 		),
 	),
+	`SELECT * FROM foo, bar, baz, qux`: plan.NewProject(
+		[]sql.Expression{expression.NewStar()},
+		plan.NewCrossJoin(
+			plan.NewCrossJoin(
+				plan.NewCrossJoin(
+					plan.NewUnresolvedTable("foo"),
+					plan.NewUnresolvedTable("bar"),
+				),
+				plan.NewUnresolvedTable("baz"),
+			),
+			plan.NewUnresolvedTable("qux"),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
Fix #38 

Also, this is not inner join as said in the issue, is cross join, because INNER JOIN is not implemented right now.