### PR TITLE
sql/expression: implement substring function

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -34,12 +34,12 @@ func TestQueries(t *testing.T) {
 	)
 
 	testQuery(t, e,
-		"SELECT i FROM mytable WHERE s = 'a' ORDER BY i DESC;",
+		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC;",
 		[][]interface{}{{int64(1)}},
 	)
 
 	testQuery(t, e,
-		"SELECT i FROM mytable WHERE s = 'a' ORDER BY i DESC LIMIT 1;",
+		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
 		[][]interface{}{{int64(1)}},
 	)
 
@@ -56,6 +56,11 @@ func TestQueries(t *testing.T) {
 	testQuery(t, e,
 		"SELECT COUNT(*) AS c FROM mytable;",
 		[][]interface{}{{int32(3)}},
+	)
+
+	testQuery(t, e,
+		"SELECT substring(s, 2, 3) FROM mytable",
+		[][]interface{}{{"irs"}, {"eco"}, {"hir"}},
 	)
 }
 
@@ -105,9 +110,9 @@ func newEngine(t *testing.T) *sqle.Engine {
 		{Name: "i", Type: sql.Int64},
 		{Name: "s", Type: sql.Text},
 	})
-	require.Nil(table.Insert(sql.NewRow(int64(1), "a")))
-	require.Nil(table.Insert(sql.NewRow(int64(2), "b")))
-	require.Nil(table.Insert(sql.NewRow(int64(3), "c")))
+	require.Nil(table.Insert(sql.NewRow(int64(1), "first row")))
+	require.Nil(table.Insert(sql.NewRow(int64(2), "second row")))
+	require.Nil(table.Insert(sql.NewRow(int64(3), "third row")))
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable("mytable", table)

--- a/sql/expression/common.go
+++ b/sql/expression/common.go
@@ -41,6 +41,7 @@ var defaultFunctions = map[string]sql.Function{
 		return NewFirst(e)
 	}),
 	"is_binary": sql.Function1(NewIsBinary),
+	"substring": sql.FunctionN(NewSubstring),
 }
 
 // RegisterDefaults registers the aggregations in the catalog.

--- a/sql/expression/function.go
+++ b/sql/expression/function.go
@@ -2,6 +2,7 @@ package expression
 
 import (
 	"bytes"
+	"reflect"
 
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
@@ -64,4 +65,127 @@ func isBinary(data []byte) bool {
 	}
 
 	return true
+}
+
+// Substring is a function to return a part of a string.
+// This function behaves as the homonym MySQL function.
+// Since Go strings are UTF8, this function does not return a direct sub
+// string str[start:start+length], instead returns the substring of rune
+// s. That is, "á"[0:1] does not return a partial unicode glyph, but "á"
+// itself.
+type Substring struct {
+	str   sql.Expression
+	start sql.Expression
+	len   sql.Expression
+}
+
+// NewSubstring creates a new substring UDF.
+func NewSubstring(args ...sql.Expression) (sql.Expression, error) {
+	var str, start, ln sql.Expression
+	switch len(args) {
+	case 2:
+		str = args[0]
+		start = args[1]
+		ln = nil
+	case 3:
+		str = args[0]
+		start = args[1]
+		ln = args[2]
+	default:
+		return nil, sql.ErrInvalidArgumentNumber.New("2 or 3", len(args))
+	}
+	return &Substring{str, start, ln}, nil
+}
+
+// Eval implements the Expression interface.
+func (s *Substring) Eval(row sql.Row) (interface{}, error) {
+	str, err := s.str.Eval(row)
+	if err != nil {
+		return nil, err
+	}
+
+	var text []rune
+	switch str := str.(type) {
+	case string:
+		text = []rune(str)
+	case []byte:
+		text = []rune(string(str))
+	case nil:
+		return nil, nil
+	default:
+		return nil, sql.ErrInvalidType.New(reflect.TypeOf(str).String())
+	}
+
+	start, err := s.start.Eval(row)
+	if err != nil {
+		return nil, err
+	}
+
+	start, err = sql.Int64.Convert(start)
+	if err != nil {
+		return nil, err
+	}
+
+	var length int64
+	runeCount := int64(len(text))
+	if s.len != nil {
+		len, err := s.len.Eval(row)
+		if err != nil {
+			return nil, err
+		}
+
+		len, err = sql.Int64.Convert(len)
+		if err != nil {
+			return nil, err
+		}
+
+		length = len.(int64)
+	} else {
+		length = runeCount
+	}
+
+	var startIdx int64
+	if start := start.(int64); start < 0 {
+		startIdx = runeCount + start
+	} else {
+		startIdx = start - 1
+	}
+
+	if startIdx < 0 || startIdx >= runeCount || length <= 0 {
+		return "", nil
+	}
+
+	if startIdx+length > runeCount {
+		length = int64(runeCount) - startIdx
+	}
+
+	return string(text[startIdx : startIdx+length]), nil
+}
+
+// IsNullable implements the Expression interface.
+func (s *Substring) IsNullable() bool { return true }
+
+// Name implements the Expression interface.
+func (Substring) Name() string {
+	return "substring"
+}
+
+// Resolved implements the Expression interface.
+func (Substring) Resolved() bool { return true }
+
+// Type implements the Expression interface.
+func (Substring) Type() sql.Type { return sql.Text }
+
+// TransformUp implements the Expression interface.
+func (s *Substring) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
+	// It is safe to omit the errors of NewSubstring here because to be able to call
+	// this method, you need a valid instance of Substring, so the arity must be correct
+	// and that's the only error NewSubstring can return.
+	var sub sql.Expression
+	if s.len != nil {
+		sub, _ = NewSubstring(f(s.str), f(s.start), f(s.len))
+	} else {
+		sub, _ = NewSubstring(f(s.str), f(s.start))
+	}
+	return f(sub)
 }

--- a/sql/expression/function_test.go
+++ b/sql/expression/function_test.go
@@ -26,3 +26,72 @@ func TestIsBinary(t *testing.T) {
 		})
 	}
 }
+
+func TestSubstringArity(t *testing.T) {
+	expr := NewGetField(0, sql.Int64, "foo", false)
+	testCases := []struct {
+		name string
+		args []sql.Expression
+		ok   bool
+	}{
+		{"0 args", nil, false},
+		{"1 args", []sql.Expression{expr}, false},
+		{"2 args", []sql.Expression{expr, expr}, true},
+		{"3 args", []sql.Expression{expr, expr, expr}, true},
+		{"4 args", []sql.Expression{expr, expr, expr, expr}, false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			f, err := NewSubstring(tt.args...)
+			if tt.ok {
+				require.NotNil(f)
+				require.NoError(err)
+			} else {
+				require.Error(err)
+			}
+		})
+	}
+}
+
+func TestSubstring(t *testing.T) {
+	f, err := NewSubstring(
+		NewGetField(0, sql.Text, "str", true),
+		NewGetField(1, sql.Int32, "start", false),
+		NewGetField(2, sql.Int64, "len", false),
+	)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		row      sql.Row
+		expected interface{}
+		err      bool
+	}{
+		{"null string", sql.NewRow(nil, 1, 1), nil, false},
+		{"negative start", sql.NewRow("foo", -1, 10), "o", false},
+		{"negative length", sql.NewRow("foo", 1, -1), "", false},
+		{"length 0", sql.NewRow("foo", 1, 0), "", false},
+		{"start bigger than string", sql.NewRow("foo", 50, 10), "", false},
+		{"negative start bigger than string", sql.NewRow("foo", -4, 10), "", false},
+		{"length overflows", sql.NewRow("foo", 2, 10), "oo", false},
+		{"length overflows by one", sql.NewRow("foo", 2, 2), "oo", false},
+		{"substring contained", sql.NewRow("foo", 1, 2), "fo", false},
+		{"negative start until str beginning", sql.NewRow("foo", -3, 2), "fo", false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			v, err := f.Eval(tt.row)
+			if tt.err {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, v)
+			}
+		})
+	}
+}

--- a/sql/functionregistry.go
+++ b/sql/functionregistry.go
@@ -115,7 +115,7 @@ func (FunctionN) isFunction() {}
 
 // ErrInvalidArgumentNumber is returned when the number of arguments to call a
 // function is different from the function arity.
-var ErrInvalidArgumentNumber = errors.NewKind("expecting %d arguments for calling this function, %d received")
+var ErrInvalidArgumentNumber = errors.NewKind("expecting %v arguments for calling this function, %d received")
 
 // FunctionRegistry is used to register functions. It is used both for builtin
 // and User-Defined Functions.


### PR DESCRIPTION
Fixes #42

This PR implements the substring(str, start[, length]) function with the same rules as its homonym function in MySQL.
Since Go strings are UTF8, this function does not return a direct substring `str[start:start+length]`, instead returns the substring of runes. That is, `"á"[0:1]` does not return a partial unicode glyph, but `"á"` itself.