### PR TITLE
sql/(plan,expression): simplify and fix transforms

### DIFF
--- a/sql/expression/aggregation.go
+++ b/sql/expression/aggregation.go
@@ -48,8 +48,7 @@ func (c *Count) Name() string {
 
 // TransformUp implements the Expression interface.
 func (c *Count) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	nc := c.UnaryExpression.Child.TransformUp(f)
-	return f(NewCount(nc))
+	return f(NewCount(c.Child.TransformUp(f)))
 }
 
 // Update implements the Aggregation interface.

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -30,8 +30,5 @@ func (e *Alias) Name() string {
 
 // TransformUp implements the Expression interface.
 func (e *Alias) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	c := e.Child.TransformUp(f)
-	n := NewAlias(c, e.name)
-
-	return f(n)
+	return f(NewAlias(e.Child.TransformUp(f), e.name))
 }

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -36,8 +36,5 @@ func (e Not) Name() string {
 
 // TransformUp implements the Expression interface.
 func (e *Not) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	c := e.UnaryExpression.Child.TransformUp(f)
-	n := &Not{UnaryExpression{c}}
-
-	return f(n)
+	return f(NewNot(e.Child.TransformUp(f)))
 }

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -64,10 +64,7 @@ func (e Equals) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (e *Equals) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := e.BinaryExpression.Left.TransformUp(f)
-	rc := e.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewEquals(lc, rc))
+	return f(NewEquals(e.Left.TransformUp(f), e.Right.TransformUp(f)))
 }
 
 // Name implements the Expression interface.
@@ -117,10 +114,7 @@ func (re Regexp) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (re *Regexp) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := re.BinaryExpression.Left.TransformUp(f)
-	rc := re.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewRegexp(lc, rc))
+	return f(NewRegexp(re.Left.TransformUp(f), re.Right.TransformUp(f)))
 }
 
 // Name implements the Expression interface.
@@ -157,10 +151,7 @@ func (gt GreaterThan) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (gt *GreaterThan) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := gt.BinaryExpression.Left.TransformUp(f)
-	rc := gt.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewGreaterThan(lc, rc))
+	return f(NewGreaterThan(gt.Left.TransformUp(f), gt.Right.TransformUp(f)))
 }
 
 // LessThan is a comparison that checks an expression is less than another.
@@ -193,10 +184,7 @@ func (lt LessThan) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (lt *LessThan) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := lt.BinaryExpression.Left.TransformUp(f)
-	rc := lt.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewLessThan(lc, rc))
+	return f(NewLessThan(lt.Left.TransformUp(f), lt.Right.TransformUp(f)))
 }
 
 // GreaterThanOrEqual is a comparison that checks an expression is greater or equal to
@@ -231,10 +219,7 @@ func (gte GreaterThanOrEqual) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (gte *GreaterThanOrEqual) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := gte.BinaryExpression.Left.TransformUp(f)
-	rc := gte.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewGreaterThanOrEqual(lc, rc))
+	return f(NewGreaterThanOrEqual(gte.Left.TransformUp(f), gte.Right.TransformUp(f)))
 }
 
 // LessThanOrEqual is a comparison that checks an expression is equal or lower than
@@ -268,8 +253,5 @@ func (lte LessThanOrEqual) Eval(row sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (lte *LessThanOrEqual) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	lc := lte.BinaryExpression.Left.TransformUp(f)
-	rc := lte.BinaryExpression.Right.TransformUp(f)
-
-	return f(NewLessThanOrEqual(lc, rc))
+	return f(NewLessThanOrEqual(lte.Left.TransformUp(f), lte.Right.TransformUp(f)))
 }

--- a/sql/expression/function.go
+++ b/sql/expression/function.go
@@ -44,7 +44,7 @@ func (ib *IsBinary) Name() string {
 
 // TransformUp implements the Expression interface.
 func (ib *IsBinary) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return NewIsBinary(f(ib.Child))
+	return NewIsBinary(ib.Child.TransformUp(f))
 }
 
 // Type implements the Expression interface.
@@ -184,9 +184,9 @@ func (s *Substring) TransformUp(f func(sql.Expression) sql.Expression) sql.Expre
 	// and that's the only error NewSubstring can return.
 	var sub sql.Expression
 	if s.len != nil {
-		sub, _ = NewSubstring(f(s.str), f(s.start), f(s.len))
+		sub, _ = NewSubstring(s.str.TransformUp(f), s.start.TransformUp(f), s.len.TransformUp(f))
 	} else {
-		sub, _ = NewSubstring(f(s.str), f(s.start))
+		sub, _ = NewSubstring(s.str.TransformUp(f), s.start.TransformUp(f))
 	}
 	return f(sub)
 }

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -39,8 +39,5 @@ func (e *IsNull) Name() string {
 
 // TransformUp implements the Expression interface.
 func (e *IsNull) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	c := e.UnaryExpression.Child.TransformUp(f)
-	n := &IsNull{UnaryExpression{c}}
-
-	return f(n)
+	return f(NewIsNull(e.Child.TransformUp(f)))
 }

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -44,8 +44,8 @@ func (a *And) Eval(row sql.Row) (interface{}, error) {
 // TransformUp implements the Expression interface.
 func (a *And) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
 	return f(NewAnd(
-		f(a.Left),
-		f(a.Right),
+		a.Left.TransformUp(f),
+		a.Right.TransformUp(f),
 	))
 }
 
@@ -91,7 +91,7 @@ func (o *Or) Eval(row sql.Row) (interface{}, error) {
 // TransformUp implements the Expression interface.
 func (o *Or) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
 	return f(NewOr(
-		f(o.Left),
-		f(o.Right),
+		o.Left.TransformUp(f),
+		o.Right.TransformUp(f),
 	))
 }

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -39,5 +39,6 @@ func (Star) Eval(r sql.Row) (interface{}, error) {
 
 // TransformUp implements the Expression interface.
 func (s *Star) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(s)
+	n := *s
+	return f(&n)
 }

--- a/sql/expression/unresolved.go
+++ b/sql/expression/unresolved.go
@@ -94,7 +94,7 @@ func (UnresolvedFunction) Eval(r sql.Row) (interface{}, error) {
 func (uf *UnresolvedFunction) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
 	var rc []sql.Expression
 	for _, c := range uf.Children {
-		rc = append(rc, f(c))
+		rc = append(rc, c.TransformUp(f))
 	}
 
 	return f(NewUnresolvedFunction(uf.name, uf.IsAggregate, rc...))

--- a/sql/plan/cross_join.go
+++ b/sql/plan/cross_join.go
@@ -51,20 +51,15 @@ func (p *CrossJoin) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *CrossJoin) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	ln := p.BinaryNode.Left.TransformUp(f)
-	rn := p.BinaryNode.Right.TransformUp(f)
-
-	n := NewCrossJoin(ln, rn)
-
-	return f(n)
+	return f(NewCrossJoin(p.Left.TransformUp(f), p.Right.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *CrossJoin) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	ln := p.BinaryNode.Left.TransformExpressionsUp(f)
-	rn := p.BinaryNode.Right.TransformExpressionsUp(f)
-
-	return NewCrossJoin(ln, rn)
+	return NewCrossJoin(
+		p.Left.TransformExpressionsUp(f),
+		p.Right.TransformExpressionsUp(f),
+	)
 }
 
 type crossJoinIterator struct {

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -34,18 +34,12 @@ func (d *Describe) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (d *Describe) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := d.UnaryNode.Child.TransformUp(f)
-	n := NewDescribe(c)
-
-	return f(n)
+	return f(NewDescribe(d.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (d *Describe) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := d.UnaryNode.Child.TransformExpressionsUp(f)
-	n := NewDescribe(c)
-
-	return n
+	return NewDescribe(d.Child.TransformExpressionsUp(f))
 }
 
 type describeIter struct {

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -32,19 +32,12 @@ func (p *Filter) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *Filter) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := p.UnaryNode.Child.TransformUp(f)
-	n := NewFilter(p.expression, c)
-
-	return f(n)
+	return f(NewFilter(p.expression, p.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *Filter) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := p.UnaryNode.Child.TransformExpressionsUp(f)
-	e := p.expression.TransformUp(f)
-	n := NewFilter(e, c)
-
-	return n
+	return NewFilter(p.expression.TransformUp(f), p.Child.TransformExpressionsUp(f))
 }
 
 type filterIter struct {

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -65,20 +65,16 @@ func (p *GroupBy) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *GroupBy) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := p.UnaryNode.Child.TransformUp(f)
-	n := NewGroupBy(p.Aggregate, p.Grouping, c)
-
-	return f(n)
+	return f(NewGroupBy(p.Aggregate, p.Grouping, p.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *GroupBy) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := p.UnaryNode.Child.TransformExpressionsUp(f)
-	aes := transformExpressionsUp(f, p.Aggregate)
-	ges := transformExpressionsUp(f, p.Grouping)
-	n := NewGroupBy(aes, ges, c)
-
-	return n
+	return NewGroupBy(
+		transformExpressionsUp(f, p.Aggregate),
+		transformExpressionsUp(f, p.Grouping),
+		p.Child.TransformExpressionsUp(f),
+	)
 }
 
 type groupByIter struct {

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -99,17 +99,18 @@ func (p *InsertInto) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *InsertInto) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	ln := p.BinaryNode.Left.TransformUp(f)
-	rn := p.BinaryNode.Right.TransformUp(f)
-
-	n := NewInsertInto(ln, rn, p.Columns)
-	return f(n)
+	return f(NewInsertInto(
+		p.Left.TransformUp(f),
+		p.Right.TransformUp(f),
+		p.Columns,
+	))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *InsertInto) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	ln := p.BinaryNode.Left.TransformExpressionsUp(f)
-	rn := p.BinaryNode.Right.TransformExpressionsUp(f)
-
-	return NewInsertInto(ln, rn, p.Columns)
+	return NewInsertInto(
+		p.Left.TransformExpressionsUp(f),
+		p.Right.TransformExpressionsUp(f),
+		p.Columns,
+	)
 }

--- a/sql/plan/limit.go
+++ b/sql/plan/limit.go
@@ -36,14 +36,12 @@ func (l *Limit) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (l *Limit) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := l.Child.TransformUp(f)
-	return f(NewLimit(l.size, c))
+	return f(NewLimit(l.size, l.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (l *Limit) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := l.Child.TransformExpressionsUp(f)
-	return NewLimit(l.size, c)
+	return NewLimit(l.size, l.Child.TransformExpressionsUp(f))
 }
 
 type limitIter struct {

--- a/sql/plan/offset.go
+++ b/sql/plan/offset.go
@@ -32,14 +32,12 @@ func (o *Offset) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (o *Offset) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := o.Child.TransformUp(f)
-	return f(NewOffset(o.n, c))
+	return f(NewOffset(o.n, o.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (o *Offset) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := o.Child.TransformExpressionsUp(f)
-	return NewOffset(o.n, c)
+	return NewOffset(o.n, o.Child.TransformExpressionsUp(f))
 }
 
 type offsetIter struct {

--- a/sql/plan/project.go
+++ b/sql/plan/project.go
@@ -50,19 +50,15 @@ func (p *Project) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *Project) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := p.UnaryNode.Child.TransformUp(f)
-	n := NewProject(p.Expressions, c)
-
-	return f(n)
+	return f(NewProject(p.Expressions, p.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *Project) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := p.UnaryNode.Child.TransformExpressionsUp(f)
-	es := transformExpressionsUp(f, p.Expressions)
-	n := NewProject(es, c)
-
-	return n
+	return NewProject(
+		transformExpressionsUp(f, p.Expressions),
+		p.Child.TransformExpressionsUp(f),
+	)
 }
 
 type iter struct {

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -78,22 +78,17 @@ func (s *Sort) RowIter() (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (s *Sort) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	c := s.UnaryNode.Child.TransformUp(f)
-	n := NewSort(s.SortFields, c)
-
-	return f(n)
+	return f(NewSort(s.SortFields, s.Child.TransformUp(f)))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (s *Sort) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	c := s.UnaryNode.Child.TransformExpressionsUp(f)
-	sfs := []SortField{}
-	for _, sf := range s.SortFields {
-		sfs = append(sfs, SortField{sf.Column.TransformUp(f), sf.Order, sf.NullOrdering})
+	var sfs = make([]SortField, len(s.SortFields))
+	for i, sf := range s.SortFields {
+		sfs[i] = SortField{sf.Column.TransformUp(f), sf.Order, sf.NullOrdering}
 	}
-	n := NewSort(sfs, c)
 
-	return n
+	return NewSort(sfs, s.Child.TransformExpressionsUp(f))
 }
 
 type sortIter struct {


### PR DESCRIPTION
There were some transforms that were not correctly propagating the transformation.
Also, there were some transforms that were unnecessarily verbose, so I simplified them while I was at it.