### PR TITLE
sql/(parse,plan): implement inner join

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -229,6 +229,34 @@ func tableExprToTable(te sqlparser.TableExpr) (sql.Node, error) {
 		}
 
 		return node, nil
+	case *sqlparser.JoinTableExpr:
+		// TODO: add support for the rest of joins
+		if t.Join != sqlparser.JoinStr {
+			return nil, errUnsupportedFeature(t.Join)
+		}
+
+		// TODO: add support for using, once we have proper table
+		// qualification of fields
+		if len(t.Condition.Using) > 0 {
+			return nil, errUnsupportedFeature("using clause on join")
+		}
+
+		left, err := tableExprToTable(t.LeftExpr)
+		if err != nil {
+			return nil, err
+		}
+
+		right, err := tableExprToTable(t.RightExpr)
+		if err != nil {
+			return nil, err
+		}
+
+		cond, err := exprToExpression(t.Condition.On)
+		if err != nil {
+			return nil, err
+		}
+
+		return plan.NewInnerJoin(left, right, cond), nil
 	}
 }
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -300,7 +300,6 @@ var fixtures = map[string]sql.Node{
 			),
 		),
 	),
-<<<<<<< HEAD
 	`SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`: plan.NewProject(
 		[]sql.Expression{expression.NewStar()},
 		plan.NewFilter(
@@ -323,7 +322,8 @@ var fixtures = map[string]sql.Node{
 				expression.NewLiteral(int64(5), sql.Int64),
 			),
 			plan.NewUnresolvedTable("foo"),
-=======
+		),
+	),
 	`SELECT * FROM foo INNER JOIN bar ON a = b`: plan.NewProject(
 		[]sql.Expression{expression.NewStar()},
 		plan.NewInnerJoin(
@@ -333,7 +333,6 @@ var fixtures = map[string]sql.Node{
 				expression.NewUnresolvedColumn("a"),
 				expression.NewUnresolvedColumn("b"),
 			),
->>>>>>> sql/(parse,plan): implement inner join
 		),
 	),
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -300,6 +300,7 @@ var fixtures = map[string]sql.Node{
 			),
 		),
 	),
+<<<<<<< HEAD
 	`SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`: plan.NewProject(
 		[]sql.Expression{expression.NewStar()},
 		plan.NewFilter(
@@ -322,6 +323,17 @@ var fixtures = map[string]sql.Node{
 				expression.NewLiteral(int64(5), sql.Int64),
 			),
 			plan.NewUnresolvedTable("foo"),
+=======
+	`SELECT * FROM foo INNER JOIN bar ON a = b`: plan.NewProject(
+		[]sql.Expression{expression.NewStar()},
+		plan.NewInnerJoin(
+			plan.NewUnresolvedTable("foo"),
+			plan.NewUnresolvedTable("bar"),
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("a"),
+				expression.NewUnresolvedColumn("b"),
+			),
+>>>>>>> sql/(parse,plan): implement inner join
 		),
 	),
 }

--- a/sql/plan/common_test.go
+++ b/sql/plan/common_test.go
@@ -82,3 +82,20 @@ func assertRows(t *testing.T, iter sql.RowIter, expected int64) {
 
 	require.Equal(expected, rows)
 }
+
+func collectRows(t *testing.T, node sql.Node) []sql.Row {
+	t.Helper()
+
+	iter, err := node.RowIter()
+	require.NoError(t, err)
+
+	var rows []sql.Row
+	for {
+		row, err := iter.Next()
+		if err == io.EOF {
+			return rows
+		}
+		require.NoError(t, err)
+		rows = append(rows, row)
+	}
+}

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -27,7 +27,7 @@ func (p *Filter) RowIter() (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &filterIter{p, i}, nil
+	return &filterIter{p.expression, i}, nil
 }
 
 // TransformUp implements the Transformable interface.
@@ -41,7 +41,7 @@ func (p *Filter) TransformExpressionsUp(f func(sql.Expression) sql.Expression) s
 }
 
 type filterIter struct {
-	f         *Filter
+	cond      sql.Expression
 	childIter sql.RowIter
 }
 
@@ -52,7 +52,7 @@ func (i *filterIter) Next() (sql.Row, error) {
 			return nil, err
 		}
 
-		result, err := i.f.expression.Eval(row)
+		result, err := i.cond.Eval(row)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/plan/innerjoin.go
+++ b/sql/plan/innerjoin.go
@@ -1,8 +1,6 @@
 package plan
 
 import (
-	"io"
-
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -40,9 +38,11 @@ func (j *InnerJoin) RowIter() (sql.RowIter, error) {
 		return nil, err
 	}
 
-	return &innerJoinIterator{
-		l:    l,
-		rp:   j.Right,
+	return &filterIter{
+		childIter: &crossJoinIterator{
+			l:  l,
+			rp: j.Right,
+		},
 		cond: j.Cond,
 	}, nil
 }
@@ -59,75 +59,4 @@ func (j *InnerJoin) TransformExpressionsUp(f func(sql.Expression) sql.Expression
 		j.Right.TransformExpressionsUp(f),
 		j.Cond.TransformUp(f),
 	)
-}
-
-type rowIterProvider interface {
-	RowIter() (sql.RowIter, error)
-}
-
-type innerJoinIterator struct {
-	l    sql.RowIter
-	rp   rowIterProvider
-	r    sql.RowIter
-	cond sql.Expression
-
-	leftRow sql.Row
-}
-
-func (i *innerJoinIterator) Next() (sql.Row, error) {
-	for {
-		if i.leftRow == nil {
-			r, err := i.l.Next()
-			if err != nil {
-				return nil, err
-			}
-
-			i.leftRow = r
-		}
-
-		if i.r == nil {
-			iter, err := i.rp.RowIter()
-			if err != nil {
-				return nil, err
-			}
-
-			i.r = iter
-		}
-
-		rightRow, err := i.r.Next()
-		if err == io.EOF {
-			i.r = nil
-			i.leftRow = nil
-			continue
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		row := append(i.leftRow, rightRow...)
-		result, err := i.cond.Eval(row)
-		if err != nil {
-			return nil, err
-		}
-
-		if result == true {
-			return row, nil
-		}
-	}
-}
-
-func (i *innerJoinIterator) Close() error {
-	if err := i.l.Close(); err != nil {
-		if i.r != nil {
-			_ = i.r.Close()
-		}
-		return err
-	}
-
-	if i.r != nil {
-		return i.r.Close()
-	}
-
-	return nil
 }

--- a/sql/plan/innerjoin.go
+++ b/sql/plan/innerjoin.go
@@ -1,0 +1,133 @@
+package plan
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// InnerJoin is an inner join between two tables.
+type InnerJoin struct {
+	BinaryNode
+	Cond sql.Expression
+}
+
+// NewInnerJoin creates a new inner join node from two tables.
+func NewInnerJoin(left, right sql.Node, cond sql.Expression) *InnerJoin {
+	return &InnerJoin{
+		BinaryNode: BinaryNode{
+			Left:  left,
+			Right: right,
+		},
+		Cond: cond,
+	}
+}
+
+// Schema implements the Node interface.
+func (j *InnerJoin) Schema() sql.Schema {
+	return append(j.Left.Schema(), j.Right.Schema()...)
+}
+
+// Resolved implements the Resolvable interface.
+func (j *InnerJoin) Resolved() bool {
+	return j.Left.Resolved() && j.Right.Resolved()
+}
+
+// RowIter implements the Node interface.
+func (j *InnerJoin) RowIter() (sql.RowIter, error) {
+	l, err := j.Left.RowIter()
+	if err != nil {
+		return nil, err
+	}
+
+	return &innerJoinIterator{
+		l:    l,
+		rp:   j.Right,
+		cond: j.Cond,
+	}, nil
+}
+
+// TransformUp implements the Transformable interface.
+func (j *InnerJoin) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+	return f(NewInnerJoin(j.Left.TransformUp(f), j.Right.TransformUp(f), j.Cond))
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (j *InnerJoin) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
+	return NewInnerJoin(
+		j.Left.TransformExpressionsUp(f),
+		j.Right.TransformExpressionsUp(f),
+		j.Cond.TransformUp(f),
+	)
+}
+
+type rowIterProvider interface {
+	RowIter() (sql.RowIter, error)
+}
+
+type innerJoinIterator struct {
+	l    sql.RowIter
+	rp   rowIterProvider
+	r    sql.RowIter
+	cond sql.Expression
+
+	leftRow sql.Row
+}
+
+func (i *innerJoinIterator) Next() (sql.Row, error) {
+	for {
+		if i.leftRow == nil {
+			r, err := i.l.Next()
+			if err != nil {
+				return nil, err
+			}
+
+			i.leftRow = r
+		}
+
+		if i.r == nil {
+			iter, err := i.rp.RowIter()
+			if err != nil {
+				return nil, err
+			}
+
+			i.r = iter
+		}
+
+		rightRow, err := i.r.Next()
+		if err == io.EOF {
+			i.r = nil
+			i.leftRow = nil
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		row := append(i.leftRow, rightRow...)
+		result, err := i.cond.Eval(row)
+		if err != nil {
+			return nil, err
+		}
+
+		if result == true {
+			return row, nil
+		}
+	}
+}
+
+func (i *innerJoinIterator) Close() error {
+	if err := i.l.Close(); err != nil {
+		if i.r != nil {
+			_ = i.r.Close()
+		}
+		return err
+	}
+
+	if i.r != nil {
+		return i.r.Close()
+	}
+
+	return nil
+}

--- a/sql/plan/innerjoin_test.go
+++ b/sql/plan/innerjoin_test.go
@@ -1,0 +1,50 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestInnerJoin(t *testing.T) {
+	require := require.New(t)
+	finalSchema := append(lSchema, rSchema...)
+
+	ltable := mem.NewTable("left", lSchema)
+	rtable := mem.NewTable("right", rSchema)
+	insertData(t, ltable)
+	insertData(t, rtable)
+
+	j := NewInnerJoin(ltable, rtable, expression.NewEquals(
+		expression.NewGetField(0, sql.Text, "lcol1", false),
+		expression.NewGetField(4, sql.Text, "rcol1", false),
+	))
+
+	require.Equal(finalSchema, j.Schema())
+
+	rows := collectRows(t, j)
+	require.Len(rows, 2)
+
+	require.Equal([]sql.Row{
+		{"col1_1", "col2_1", int32(1111), int64(2222), "col1_1", "col2_1", int32(1111), int64(2222)},
+		{"col1_2", "col2_2", int32(3333), int64(4444), "col1_2", "col2_2", int32(3333), int64(4444)},
+	}, rows)
+}
+
+func TestInnerJoinEmpty(t *testing.T) {
+	require := require.New(t)
+	ltable := mem.NewTable("left", lSchema)
+	rtable := mem.NewTable("right", rSchema)
+
+	j := NewInnerJoin(ltable, rtable, expression.NewEquals(
+		expression.NewGetField(0, sql.Text, "lcol1", false),
+		expression.NewGetField(4, sql.Text, "rcol1", false),
+	))
+
+	iter, err := j.RowIter()
+	require.NoError(err)
+	assertRows(t, iter, 0)
+}


### PR DESCRIPTION
Closes #57

Implements the INNER JOIN node, which right now is basically a `Filter(cond, CrossJoin(left, right))` given it has no indexes whatsoever.

The only clause of the INNER JOIN implemented is the ON clause. USING does not make sense to implement until we have a proper handling of column qualifiers.

The implementation of INNER JOIN differs from the one in CROSS JOIN. While the cross join loads all the right rows in memory and iterates the left rows, the inner join creates a new iterator for each iteration of the left iterator, saving huge amounts of memory on large tables.
