### PR TITLE
Unified Aggregation's interfaces

### DIFF
--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -38,7 +38,7 @@ func validateOrderBy(n sql.Node) error {
 	case *plan.Sort:
 		for _, field := range n.SortFields {
 			switch field.Column.(type) {
-			case sql.AggregationExpression:
+			case sql.Aggregation:
 				return ValidationOrderByErr.New()
 			}
 		}
@@ -62,7 +62,7 @@ func validateGroupBy(n sql.Node) error {
 		}
 
 		for _, expr := range n.Aggregate {
-			if _, ok := expr.(sql.AggregationExpression); !ok {
+			if _, ok := expr.(sql.Aggregation); !ok {
 				if !isValidAgg(validAggs, expr) {
 					return ValidationGroupByErr.New(expr.Name())
 				}

--- a/sql/core.go
+++ b/sql/core.go
@@ -41,13 +41,13 @@ type Expression interface {
 	TransformUp(func(Expression) Expression) Expression
 }
 
-// AggregationExpression implements an aggregation expression, where an
+// Aggregation implements an aggregation expression, where an
 // aggregation buffer is created for each grouping (NewBuffer) and rows in the
 // grouping are fed to the buffer (Update). Multiple buffers can be merged
 // (Merge), making partial aggregations possible.
 // Note that Eval must be called with the final aggregation buffer in order to
 // get the final result.
-type AggregationExpression interface {
+type Aggregation interface {
 	Expression
 	// NewBuffer creates a new aggregation buffer and returns it as a Row.
 	NewBuffer() Row

--- a/sql/core.go
+++ b/sql/core.go
@@ -57,17 +57,6 @@ type AggregationExpression interface {
 	Merge(buffer, partial Row) error
 }
 
-// Aggregation is a node which take the value of several rows and produces a single
-// value with all that data grouped together.
-type Aggregation interface {
-	// Updates the current row with the given row.
-	Update(Row) (Row, error)
-	// Merge the given row, which is partially grouped, with the current one.
-	Merge(Row)
-	// Eval returns the value of the grouped data.
-	Eval() interface{}
-}
-
 // Node is a node in the execution plan tree.
 type Node interface {
 	Resolvable

--- a/sql/expression/aggregation.go
+++ b/sql/expression/aggregation.go
@@ -86,7 +86,7 @@ func (c *Count) Eval(buffer sql.Row) (interface{}, error) {
 }
 
 // Min aggregation returns the smallest value of the selected column.
-// It implements the AggregationExpression interface
+// It implements the Aggregation interface
 type Min struct {
 	UnaryExpression
 }
@@ -159,7 +159,7 @@ func (m *Min) Eval(buffer sql.Row) (interface{}, error) {
 }
 
 // Max agregation returns the greatest value of the selected column.
-// It implements the AggregationExpression interface
+// It implements the Aggregation interface
 type Max struct {
 	UnaryExpression
 }

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -207,7 +207,7 @@ func aggregate(exprs []sql.Expression, rows []sql.Row) (sql.Row, error) {
 
 func fillBuffer(expr sql.Expression) sql.Row {
 	switch n := expr.(type) {
-	case sql.AggregationExpression:
+	case sql.Aggregation:
 		return n.NewBuffer()
 	case *expression.Alias:
 		return fillBuffer(n.Child)
@@ -218,7 +218,7 @@ func fillBuffer(expr sql.Expression) sql.Row {
 
 func updateBuffer(buffers []sql.Row, idx int, expr sql.Expression, row sql.Row) error {
 	switch n := expr.(type) {
-	case sql.AggregationExpression:
+	case sql.Aggregation:
 		n.Update(buffers[idx], row)
 		return nil
 	case *expression.Alias:


### PR DESCRIPTION
The interface `Aggregation` is not used anywhere at all. We are using the interfaces `Expression` and `AggregationExpression` instead.

I removed the old `Aggregation` interface and renamed `AggregationExpression` to just `Aggregation`.