### PR TITLE
sql/*: implement rule for column resolution

### DIFF
--- a/mem/table.go
+++ b/mem/table.go
@@ -47,13 +47,13 @@ func (t *Table) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformer interface.
-func (t *Table) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+func (t *Table) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
 	return f(t)
 }
 
 // TransformExpressionsUp implements the Transformer interface.
-func (t *Table) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return t
+func (t *Table) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	return t, nil
 }
 
 // Insert a new row into the table.

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -124,14 +124,15 @@ func Test_GroupBy_Err(t *testing.T) {
 
 type dummyNode struct{ resolved bool }
 
-func (n dummyNode) Resolved() bool                             { return n.resolved }
-func (dummyNode) Schema() sql.Schema                           { return sql.Schema{} }
-func (dummyNode) Children() []sql.Node                         { return nil }
-func (dummyNode) RowIter(sql.Session) (sql.RowIter, error)     { return nil, nil }
-func (dummyNode) TransformUp(func(sql.Node) sql.Node) sql.Node { return nil }
+func (n dummyNode) Resolved() bool                                               { return n.resolved }
+func (dummyNode) Schema() sql.Schema                                             { return sql.Schema{} }
+func (dummyNode) Children() []sql.Node                                           { return nil }
+func (dummyNode) RowIter(sql.Session) (sql.RowIter, error)                       { return nil, nil }
+func (dummyNode) TransformUp(func(sql.Node) (sql.Node, error)) (sql.Node, error) { return nil, nil }
 func (dummyNode) TransformExpressionsUp(
-	func(sql.Expression) sql.Expression) sql.Node {
-	return nil
+	func(sql.Expression) (sql.Expression, error),
+) (sql.Node, error) {
+	return nil, nil
 }
 
 func getValidationRule(name string) analyzer.ValidationRule {

--- a/sql/core.go
+++ b/sql/core.go
@@ -19,10 +19,10 @@ type Resolvable interface {
 // Transformable is a node which can be transformed.
 type Transformable interface {
 	// TransformUp transforms all nodes and returns the result of this transformation.
-	TransformUp(func(Node) Node) Node
+	TransformUp(func(Node) (Node, error)) (Node, error)
 	// TransformExpressionsUp transforms all expressions inside the node and all its
 	// children and returns a node with the result of the transformations.
-	TransformExpressionsUp(func(Expression) Expression) Node
+	TransformExpressionsUp(func(Expression) (Expression, error)) (Node, error)
 }
 
 // Expression is a combination of one or more SQL expressions.
@@ -38,7 +38,7 @@ type Expression interface {
 	Eval(Session, Row) (interface{}, error)
 	// TransformUp transforms the expression and all its children with the
 	// given transform function.
-	TransformUp(func(Expression) Expression) Expression
+	TransformUp(func(Expression) (Expression, error)) (Expression, error)
 }
 
 // Aggregation implements an aggregation expression, where an

--- a/sql/expression/aggregation.go
+++ b/sql/expression/aggregation.go
@@ -47,8 +47,12 @@ func (c *Count) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (c *Count) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewCount(c.Child.TransformUp(f)))
+func (c *Count) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := c.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewCount(child))
 }
 
 // Update implements the Aggregation interface.
@@ -117,8 +121,12 @@ func (m *Min) IsNullable() bool {
 }
 
 // TransformUp implements the Transformable interface.
-func (m *Min) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewMin(m.Child.TransformUp(f)))
+func (m *Min) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := m.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewMin(child))
 }
 
 // NewBuffer creates a new buffer to compute the result.
@@ -190,8 +198,12 @@ func (m *Max) IsNullable() bool {
 }
 
 // TransformUp implements the Transformable interface.
-func (m *Max) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewMax(m.Child.TransformUp(f)))
+func (m *Max) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := m.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewMax(child))
 }
 
 // NewBuffer creates a new buffer to compute the result.
@@ -278,8 +290,12 @@ func (a *Avg) Eval(session sql.Session, buffer sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements AggregationExpression interface. (AggregationExpression[Expression]])
-func (a *Avg) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewAvg(a.Child.TransformUp(f)))
+func (a *Avg) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := a.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewAvg(child))
 }
 
 // NewBuffer implements AggregationExpression interface. (AggregationExpression)

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -29,6 +29,10 @@ func (e *Alias) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (e *Alias) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewAlias(e.Child.TransformUp(f), e.name))
+func (e *Alias) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := e.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewAlias(child, e.name))
 }

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -81,10 +81,21 @@ func (b *Between) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (b *Between) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewBetween(
-		b.Val.TransformUp(f),
-		b.Lower.TransformUp(f),
-		b.Upper.TransformUp(f),
-	))
+func (b *Between) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	val, err := b.Val.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	lower, err := b.Lower.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	upper, err := b.Upper.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewBetween(val, lower, upper))
 }

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -39,6 +39,10 @@ func (e Not) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (e *Not) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewNot(e.Child.TransformUp(f)))
+func (e *Not) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := e.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewNot(child))
 }

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -63,8 +63,18 @@ func (e Equals) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (e *Equals) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewEquals(e.Left.TransformUp(f), e.Right.TransformUp(f)))
+func (e *Equals) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := e.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := e.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewEquals(left, right))
 }
 
 // Name implements the Expression interface.
@@ -113,8 +123,18 @@ func (re Regexp) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (re *Regexp) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewRegexp(re.Left.TransformUp(f), re.Right.TransformUp(f)))
+func (re *Regexp) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := re.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := re.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewRegexp(left, right))
 }
 
 // Name implements the Expression interface.
@@ -155,8 +175,18 @@ func (gt GreaterThan) Eval(
 }
 
 // TransformUp implements the Expression interface.
-func (gt *GreaterThan) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewGreaterThan(gt.Left.TransformUp(f), gt.Right.TransformUp(f)))
+func (gt *GreaterThan) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := gt.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := gt.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewGreaterThan(left, right))
 }
 
 // LessThan is a comparison that checks an expression is less than another.
@@ -189,8 +219,18 @@ func (lt LessThan) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (lt *LessThan) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewLessThan(lt.Left.TransformUp(f), lt.Right.TransformUp(f)))
+func (lt *LessThan) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := lt.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := lt.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewLessThan(left, right))
 }
 
 // GreaterThanOrEqual is a comparison that checks an expression is greater or equal to
@@ -227,8 +267,18 @@ func (gte GreaterThanOrEqual) Eval(
 }
 
 // TransformUp implements the Expression interface.
-func (gte *GreaterThanOrEqual) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewGreaterThanOrEqual(gte.Left.TransformUp(f), gte.Right.TransformUp(f)))
+func (gte *GreaterThanOrEqual) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := gte.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := gte.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewGreaterThanOrEqual(left, right))
 }
 
 // LessThanOrEqual is a comparison that checks an expression is equal or lower than
@@ -265,6 +315,16 @@ func (lte LessThanOrEqual) Eval(
 }
 
 // TransformUp implements the Expression interface.
-func (lte *LessThanOrEqual) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewLessThanOrEqual(lte.Left.TransformUp(f), lte.Right.TransformUp(f)))
+func (lte *LessThanOrEqual) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := lte.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := lte.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewLessThanOrEqual(left, right))
 }

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -4,6 +4,7 @@ import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
 // GetField is an expression to get the field of a table.
 type GetField struct {
+	table      string
 	fieldIndex int
 	fieldName  string
 	fieldType  sql.Type
@@ -12,12 +13,23 @@ type GetField struct {
 
 // NewGetField creates a GetField expression.
 func NewGetField(index int, fieldType sql.Type, fieldName string, nullable bool) *GetField {
+	return NewGetFieldWithTable(index, fieldType, "", fieldName, nullable)
+}
+
+// NewGetFieldWithTable creates a GetField expression with table name.
+func NewGetFieldWithTable(index int, fieldType sql.Type, table, fieldName string, nullable bool) *GetField {
 	return &GetField{
+		table:      table,
 		fieldIndex: index,
 		fieldType:  fieldType,
 		fieldName:  fieldName,
 		nullable:   nullable,
 	}
+}
+
+// Table returns the name of the field table.
+func (p GetField) Table() string {
+	return p.table
 }
 
 // Resolved implements the Expression interface.
@@ -46,7 +58,7 @@ func (p GetField) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (p *GetField) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
+func (p *GetField) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
 	n := *p
 	return f(&n)
 }

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -38,6 +38,10 @@ func (e *IsNull) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (e *IsNull) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewIsNull(e.Child.TransformUp(f)))
+func (e *IsNull) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	child, err := e.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewIsNull(child))
 }

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -44,7 +44,7 @@ func (p Literal) Name() string {
 }
 
 // TransformUp implements the Expression interface.
-func (p *Literal) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
+func (p *Literal) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
 	n := *p
 	return f(&n)
 }

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -50,11 +50,18 @@ func (a *And) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (a *And) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewAnd(
-		a.Left.TransformUp(f),
-		a.Right.TransformUp(f),
-	))
+func (a *And) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := a.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := a.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewAnd(left, right))
 }
 
 // Or checks whether one of the two given expressions is true.
@@ -101,9 +108,16 @@ func (o *Or) Eval(session sql.Session, row sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (o *Or) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
-	return f(NewOr(
-		o.Left.TransformUp(f),
-		o.Right.TransformUp(f),
-	))
+func (o *Or) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := o.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := o.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewOr(left, right))
 }

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -38,7 +38,7 @@ func (Star) Eval(session sql.Session, r sql.Row) (interface{}, error) {
 }
 
 // TransformUp implements the Expression interface.
-func (s *Star) TransformUp(f func(sql.Expression) sql.Expression) sql.Expression {
+func (s *Star) TransformUp(f func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
 	n := *s
 	return f(&n)
 }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -433,6 +433,12 @@ func exprToExpression(e sqlparser.Expr) (sql.Expression, error) {
 		return expression.NewLiteral(nil, sql.Null), nil
 	case *sqlparser.ColName:
 		//TODO: add handling of case sensitiveness.
+		if !v.Qualifier.IsEmpty() {
+			return expression.NewUnresolvedQualifiedColumn(
+				v.Qualifier.Name.String(),
+				v.Name.Lowered(),
+			), nil
+		}
 		return expression.NewUnresolvedColumn(v.Name.Lowered()), nil
 	case *sqlparser.FuncExpr:
 		exprs, err := selectExprsToExpressions(v.Exprs)

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -336,6 +336,12 @@ var fixtures = map[string]sql.Node{
 			),
 		),
 	),
+	`SELECT foo.a FROM foo`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedQualifiedColumn("foo", "a"),
+		},
+		plan.NewUnresolvedTable("foo"),
+	),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/plan/common.go
+++ b/sql/plan/common.go
@@ -48,14 +48,17 @@ func expressionsResolved(exprs ...sql.Expression) bool {
 	return true
 }
 
-func transformExpressionsUp(f func(sql.Expression) sql.Expression,
-	exprs []sql.Expression) []sql.Expression {
+func transformExpressionsUp(f func(sql.Expression) (sql.Expression, error),
+	exprs []sql.Expression) ([]sql.Expression, error) {
 
 	var es []sql.Expression
 	for _, e := range exprs {
-		te := e.TransformUp(f)
+		te, err := e.TransformUp(f)
+		if err != nil {
+			return nil, err
+		}
 		es = append(es, te)
 	}
 
-	return es
+	return es, nil
 }

--- a/sql/plan/cross_join.go
+++ b/sql/plan/cross_join.go
@@ -46,16 +46,33 @@ func (p *CrossJoin) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (p *CrossJoin) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewCrossJoin(p.Left.TransformUp(f), p.Right.TransformUp(f)))
+func (p *CrossJoin) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	left, err := p.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := p.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewCrossJoin(left, right))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (p *CrossJoin) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewCrossJoin(
-		p.Left.TransformExpressionsUp(f),
-		p.Right.TransformExpressionsUp(f),
-	)
+func (p *CrossJoin) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	left, err := p.Left.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := p.Right.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCrossJoin(left, right), nil
 }
 
 type rowIterProvider interface {

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -33,13 +33,21 @@ func (d *Describe) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (d *Describe) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewDescribe(d.Child.TransformUp(f)))
+func (d *Describe) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	child, err := d.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewDescribe(child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (d *Describe) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewDescribe(d.Child.TransformExpressionsUp(f))
+func (d *Describe) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	child, err := d.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return NewDescribe(child), nil
 }
 
 type describeIter struct {

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -34,13 +34,21 @@ func (d *Distinct) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (d *Distinct) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewDistinct(d.Child.TransformUp(f)))
+func (d *Distinct) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	child, err := d.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewDistinct(child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (d *Distinct) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewDistinct(d.Child.TransformExpressionsUp(f))
+func (d *Distinct) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	child, err := d.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return NewDistinct(child), nil
 }
 
 // distinctIter keeps track of the hashes of all rows that have been emitted.

--- a/sql/plan/innerjoin.go
+++ b/sql/plan/innerjoin.go
@@ -48,15 +48,36 @@ func (j *InnerJoin) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (j *InnerJoin) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewInnerJoin(j.Left.TransformUp(f), j.Right.TransformUp(f), j.Cond))
+func (j *InnerJoin) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	left, err := j.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := j.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewInnerJoin(left, right, j.Cond))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (j *InnerJoin) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewInnerJoin(
-		j.Left.TransformExpressionsUp(f),
-		j.Right.TransformExpressionsUp(f),
-		j.Cond.TransformUp(f),
-	)
+func (j *InnerJoin) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	left, err := j.Left.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := j.Right.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	cond, err := j.Cond.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewInnerJoin(left, right, cond), nil
 }

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -98,19 +98,31 @@ func (p *InsertInto) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (p *InsertInto) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewInsertInto(
-		p.Left.TransformUp(f),
-		p.Right.TransformUp(f),
-		p.Columns,
-	))
+func (p *InsertInto) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	left, err := p.Left.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := p.Right.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewInsertInto(left, right, p.Columns))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (p *InsertInto) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewInsertInto(
-		p.Left.TransformExpressionsUp(f),
-		p.Right.TransformExpressionsUp(f),
-		p.Columns,
-	)
+func (p *InsertInto) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	left, err := p.Left.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := p.Right.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewInsertInto(left, right, p.Columns), nil
 }

--- a/sql/plan/limit.go
+++ b/sql/plan/limit.go
@@ -37,13 +37,21 @@ func (l *Limit) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (l *Limit) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewLimit(l.size, l.Child.TransformUp(f)))
+func (l *Limit) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	child, err := l.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewLimit(l.size, child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (l *Limit) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewLimit(l.size, l.Child.TransformExpressionsUp(f))
+func (l *Limit) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	child, err := l.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return NewLimit(l.size, child), nil
 }
 
 type limitIter struct {

--- a/sql/plan/offset.go
+++ b/sql/plan/offset.go
@@ -31,13 +31,21 @@ func (o *Offset) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (o *Offset) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewOffset(o.n, o.Child.TransformUp(f)))
+func (o *Offset) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	child, err := o.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewOffset(o.n, child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (o *Offset) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewOffset(o.n, o.Child.TransformExpressionsUp(f))
+func (o *Offset) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	child, err := o.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return NewOffset(o.n, child), nil
 }
 
 type offsetIter struct {

--- a/sql/plan/show_tables.go
+++ b/sql/plan/show_tables.go
@@ -52,13 +52,13 @@ func (p *ShowTables) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (p *ShowTables) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+func (p *ShowTables) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
 	return f(NewShowTables(p.database))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (p *ShowTables) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return p
+func (p *ShowTables) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	return p, nil
 }
 
 type showTablesIter struct {

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -19,13 +19,21 @@ func (t *TableAlias) Name() string {
 }
 
 // TransformUp implements the Transformable interface.
-func (t *TableAlias) TransformUp(f func(sql.Node) sql.Node) sql.Node {
-	return f(NewTableAlias(t.name, t.Child.TransformUp(f)))
+func (t *TableAlias) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	child, err := t.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return f(NewTableAlias(t.name, child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (t *TableAlias) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return NewTableAlias(t.name, t.Child.TransformExpressionsUp(f))
+func (t *TableAlias) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	child, err := t.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+	return NewTableAlias(t.name, child), nil
 }
 
 // RowIter implements the Node interface.

--- a/sql/plan/transform_test.go
+++ b/sql/plan/transform_test.go
@@ -24,14 +24,15 @@ func TestTransformUp(t *testing.T) {
 	}
 	table := mem.NewTable("resolved", schema)
 
-	pt := p.TransformUp(func(n sql.Node) sql.Node {
+	pt, err := p.TransformUp(func(n sql.Node) (sql.Node, error) {
 		switch n.(type) {
 		case *UnresolvedTable:
-			return table
+			return table, nil
 		default:
-			return n
+			return n, nil
 		}
 	})
+	require.NoError(err)
 
 	ep := NewProject([]sql.Expression{aCol, bCol}, NewFilter(expression.NewEquals(aCol, bCol), table))
 	require.Equal(ep, pt)

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -38,11 +38,11 @@ func (*UnresolvedTable) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (t *UnresolvedTable) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+func (t *UnresolvedTable) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
 	return f(NewUnresolvedTable(t.Name))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (t *UnresolvedTable) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
-	return t
+func (t *UnresolvedTable) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	return t, nil
 }

--- a/sql/plan/values.go
+++ b/sql/plan/values.go
@@ -69,16 +69,20 @@ func (p *Values) RowIter(session sql.Session) (sql.RowIter, error) {
 }
 
 // TransformUp implements the Transformable interface.
-func (p *Values) TransformUp(f func(sql.Node) sql.Node) sql.Node {
+func (p *Values) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
 	return f(p)
 }
 
 // TransformExpressionsUp implements the Transformable interface.
-func (p *Values) TransformExpressionsUp(f func(sql.Expression) sql.Expression) sql.Node {
+func (p *Values) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
 	ets := make([][]sql.Expression, len(p.ExpressionTuples))
+	var err error
 	for i, et := range p.ExpressionTuples {
-		ets[i] = transformExpressionsUp(f, et)
+		ets[i], err = transformExpressionsUp(f, et)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return NewValues(ets)
+	return NewValues(ets), nil
 }


### PR DESCRIPTION
- Added rule that qualifies all columns resolving aliases.
- Changed the transform method signatures so they may return an error.
- Added support for qualified column names.

**NOTE:** even if this resolves the columns and annotates them with the table they belong to, getting the correct value is still TODO. That is, if you join two tables with the same column name, there is no way to get the last one. This only adds the info to the `GetField`s so they may be pushed down.
