### PR TITLE
Add CREATE TABLE DDL statement

### DIFF
--- a/benchmark/tpc_h_test.go
+++ b/benchmark/tpc_h_test.go
@@ -86,6 +86,11 @@ func executeQueries(b *testing.B, e *sqle.Engine) error {
 func genDB(b *testing.B) (sql.Database, error) {
 	db := mem.NewDatabase("tpch")
 
+	memDb, ok := db.(*mem.Database)
+	if !ok {
+		b.Fatal("database cannot be casted to mem database")
+	}
+
 	for _, m := range tpchTableMetadata {
 		b.Log("generating table", m.name)
 		t := mem.NewTable(m.name, m.schema)
@@ -93,7 +98,7 @@ func genDB(b *testing.B) (sql.Database, error) {
 			return nil, err
 		}
 
-		db.AddTable(m.name, t)
+		memDb.AddTable(m.name, t)
 	}
 
 	return db, nil

--- a/engine_test.go
+++ b/engine_test.go
@@ -205,12 +205,12 @@ func TestDDL(t *testing.T) {
 	require.True(ok)
 
 	s := sql.Schema{
-		{Name: "a", Type: sql.Int32, Nullable: true},
-		{Name: "b", Type: sql.Text, Nullable: true},
-		{Name: "c", Type: sql.Date, Nullable: true},
-		{Name: "d", Type: sql.Timestamp, Nullable: true},
-		{Name: "e", Type: sql.Text, Nullable: true},
-		{Name: "f", Type: sql.Blob},
+		{Name: "a", Type: sql.Int32, Nullable: true, Source: "t1"},
+		{Name: "b", Type: sql.Text, Nullable: true, Source: "t1"},
+		{Name: "c", Type: sql.Date, Nullable: true, Source: "t1"},
+		{Name: "d", Type: sql.Timestamp, Nullable: true, Source: "t1"},
+		{Name: "e", Type: sql.Text, Nullable: true, Source: "t1"},
+		{Name: "f", Type: sql.Blob, Source: "t1"},
 	}
 
 	require.Equal(s, testTable.Schema())

--- a/example_test.go
+++ b/example_test.go
@@ -45,16 +45,19 @@ func checkIfError(err error) {
 	}
 }
 
-func createTestDatabase() *mem.Database {
+func createTestDatabase() gitqlsql.Database {
 	db := mem.NewDatabase("test")
 	table := mem.NewTable("mytable", gitqlsql.Schema{
 		{Name: "name", Type: gitqlsql.Text, Source: "mytable"},
 		{Name: "email", Type: gitqlsql.Text, Source: "mytable"},
 	})
-	db.AddTable("mytable", table)
+	memDb, _ := db.(*mem.Database)
+
+	memDb.AddTable("mytable", table)
 	table.Insert(gitqlsql.NewRow("John Doe", "john@doe.com"))
 	table.Insert(gitqlsql.NewRow("John Doe", "johnalt@doe.com"))
 	table.Insert(gitqlsql.NewRow("Jane Doe", "jane@doe.com"))
 	table.Insert(gitqlsql.NewRow("Evil Bob", "evilbob@gmail.com"))
+
 	return db
 }

--- a/mem/database.go
+++ b/mem/database.go
@@ -1,6 +1,10 @@
 package mem
 
-import "gopkg.in/src-d/go-mysql-server.v0/sql"
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
 
 // Database is an in-memory database.
 type Database struct {
@@ -9,7 +13,7 @@ type Database struct {
 }
 
 // NewDatabase creates a new database with the given name.
-func NewDatabase(name string) *Database {
+func NewDatabase(name string) sql.Database {
 	return &Database{
 		name:   name,
 		tables: map[string]sql.Table{},
@@ -29,4 +33,16 @@ func (d *Database) Tables() map[string]sql.Table {
 // AddTable adds a new table to the database.
 func (d *Database) AddTable(name string, t *Table) {
 	d.tables[name] = t
+}
+
+// Create creates a table with the given name and schema
+func (d *Database) Create(name string, schema sql.Schema) error {
+	_, ok := d.tables[name]
+	if ok {
+		return fmt.Errorf("table with name %s already exists", name)
+	}
+
+	d.tables[name] = NewTable(name, schema)
+
+	return nil
 }

--- a/mem/database_test.go
+++ b/mem/database_test.go
@@ -18,11 +18,19 @@ func TestDatabase_AddTable(t *testing.T) {
 	db := NewDatabase("test")
 	tables := db.Tables()
 	require.Equal(0, len(tables))
-	table := &Table{"test_table", sql.Schema{}, nil}
-	db.AddTable("test_table", table)
+
+	altDb, ok := db.(sql.Alterable)
+	require.True(ok)
+
+	err := altDb.Create("test_table", sql.Schema{})
+	require.NoError(err)
+
 	tables = db.Tables()
 	require.Equal(1, len(tables))
 	tt, ok := tables["test_table"]
 	require.True(ok)
 	require.NotNil(tt)
+
+	err = altDb.Create("test_table", sql.Schema{})
+	require.Error(err)
 }

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -18,8 +18,12 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32, Source: "mytable"}})
 	table2 := mem.NewTable("mytable2", sql.Schema{{Name: "i2", Type: sql.Int32, Source: "mytable2"}})
 	db := mem.NewDatabase("mydb")
-	db.AddTable("mytable", table)
-	db.AddTable("mytable2", table2)
+
+	memDb, ok := db.(*mem.Database)
+	require.True(ok)
+
+	memDb.AddTable("mytable", table)
+	memDb.AddTable("mytable2", table2)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 	a := New(catalog)

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -18,7 +18,10 @@ func TestResolveTables(t *testing.T) {
 
 	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
 	db := mem.NewDatabase("mydb")
-	db.AddTable("mytable", table)
+	memDb, ok := db.(*mem.Database)
+	require.True(ok)
+
+	memDb.AddTable("mytable", table)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 
@@ -48,7 +51,10 @@ func TestResolveTablesNested(t *testing.T) {
 
 	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
 	db := mem.NewDatabase("mydb")
-	db.AddTable("mytable", table)
+	memDb, ok := db.(*mem.Database)
+	require.True(ok)
+
+	memDb.AddTable("mytable", table)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 
@@ -75,7 +81,10 @@ func TestResolveStar(t *testing.T) {
 
 	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
 	db := mem.NewDatabase("mydb")
-	db.AddTable("mytable", table)
+	memDb, ok := db.(*mem.Database)
+	require.True(ok)
+
+	memDb.AddTable("mytable", table)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 

--- a/sql/catalog_test.go
+++ b/sql/catalog_test.go
@@ -33,15 +33,19 @@ func TestCatalog_Table(t *testing.T) {
 	require.EqualError(err, "database not found: foo")
 	require.Nil(table)
 
-	mydb := mem.NewDatabase("foo")
-	c.Databases = append(c.Databases, mydb)
+	db := mem.NewDatabase("foo")
+	c.Databases = append(c.Databases, db)
 
 	table, err = c.Table("foo", "bar")
 	require.EqualError(err, "table not found: bar")
 	require.Nil(table)
 
 	mytable := mem.NewTable("bar", sql.Schema{})
-	mydb.AddTable("bar", mytable)
+
+	memDb, ok := db.(*mem.Database)
+	require.True(ok)
+
+	memDb.AddTable("bar", mytable)
 
 	table, err = c.Table("foo", "bar")
 	require.NoError(err)

--- a/sql/core.go
+++ b/sql/core.go
@@ -111,6 +111,11 @@ type Database interface {
 	Tables() map[string]Table
 }
 
+// Alterable should be implemented by databases that can handle DDL statements
+type Alterable interface {
+	Create(name string, schema Schema) error
+}
+
 // ErrInvalidType is thrown when there is an unexpected type at some part of
 // the execution tree.
 var ErrInvalidType = errors.NewKind("invalid type: %s")

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -11,6 +11,35 @@ import (
 )
 
 var fixtures = map[string]sql.Node{
+	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL)`: plan.NewCreateTable(
+		&sql.UnresolvedDatabase{},
+		"t1",
+		sql.Schema{{
+			Name:     "a",
+			Type:     sql.Int32,
+			Nullable: true,
+		}, {
+			Name:     "b",
+			Type:     sql.Text,
+			Nullable: true,
+		}, {
+			Name:     "c",
+			Type:     sql.Date,
+			Nullable: true,
+		}, {
+			Name:     "d",
+			Type:     sql.Timestamp,
+			Nullable: true,
+		}, {
+			Name:     "e",
+			Type:     sql.Text,
+			Nullable: true,
+		}, {
+			Name:     "f",
+			Type:     sql.Blob,
+			Nullable: false,
+		}},
+	),
 	`DESCRIBE TABLE foo;`: plan.NewDescribe(
 		plan.NewUnresolvedTable("foo"),
 	),

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -1,0 +1,59 @@
+package plan
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// CreateTable is a node describing the creation of some table.
+type CreateTable struct {
+	Database sql.Database
+	name     string
+	schema   sql.Schema
+}
+
+// NewCreateTable creates a new CreateTable node
+func NewCreateTable(db sql.Database, name string, schema sql.Schema) *CreateTable {
+	return &CreateTable{
+		Database: db,
+		name:     name,
+		schema:   schema,
+	}
+}
+
+// Resolved implements the Resolvable interface.
+func (c *CreateTable) Resolved() bool {
+	_, ok := c.Database.(*sql.UnresolvedDatabase)
+	return !ok
+}
+
+// RowIter implements the Node interface.
+func (c *CreateTable) RowIter(s sql.Session) (sql.RowIter, error) {
+	d, ok := c.Database.(sql.Alterable)
+	if !ok {
+		return nil, fmt.Errorf("tables cannot be created on database %s", c.Database.Name())
+	}
+
+	return sql.RowsToRowIter(), d.Create(c.name, c.schema)
+}
+
+// Schema implements the Node interface.
+func (c *CreateTable) Schema() sql.Schema {
+	return sql.Schema{}
+}
+
+// Children implements the Node interface.
+func (c *CreateTable) Children() []sql.Node {
+	return nil
+}
+
+// TransformUp implements the Transformable interface.
+func (c *CreateTable) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	return f(NewCreateTable(c.Database, c.name, c.schema))
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (c *CreateTable) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
+	return c, nil
+}

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -15,6 +15,10 @@ type CreateTable struct {
 
 // NewCreateTable creates a new CreateTable node
 func NewCreateTable(db sql.Database, name string, schema sql.Schema) *CreateTable {
+	for _, s := range schema {
+		s.Source = name
+	}
+
 	return &CreateTable{
 		Database: db,
 		name:     name,

--- a/sql/plan/ddl_test.go
+++ b/sql/plan/ddl_test.go
@@ -39,4 +39,8 @@ func TestCreateTable(t *testing.T) {
 	require.True(ok)
 
 	require.Equal(newTable.Schema(), s)
+
+	for _, s := range newTable.Schema() {
+		require.Equal(newTable.Name(), s.Source)
+	}
 }

--- a/sql/plan/ddl_test.go
+++ b/sql/plan/ddl_test.go
@@ -1,0 +1,42 @@
+package plan
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestCreateTable(t *testing.T) {
+	require := require.New(t)
+
+	db := mem.NewDatabase("test")
+	tables := db.Tables()
+	_, ok := tables["testTable"]
+	require.False(ok)
+
+	s := sql.Schema{
+		{Name: "c1", Type: sql.Text},
+		{Name: "c2", Type: sql.Int32},
+	}
+
+	c := NewCreateTable(db, "testTable", s)
+
+	rows, err := c.RowIter(sql.NewBaseSession(context.TODO()))
+
+	require.NoError(err)
+
+	r, err := rows.Next()
+	require.Equal(err, io.EOF)
+	require.Nil(r)
+
+	tables = db.Tables()
+
+	newTable, ok := tables["testTable"]
+	require.True(ok)
+
+	require.Equal(newTable.Schema(), s)
+}

--- a/sql/plan/show_tables.go
+++ b/sql/plan/show_tables.go
@@ -9,19 +9,19 @@ import (
 
 // ShowTables is a node that shows the database tables.
 type ShowTables struct {
-	database sql.Database
+	Database sql.Database
 }
 
 // NewShowTables creates a new show tables node given a database.
 func NewShowTables(database sql.Database) *ShowTables {
 	return &ShowTables{
-		database: database,
+		Database: database,
 	}
 }
 
 // Resolved implements the Resolvable interface.
 func (p *ShowTables) Resolved() bool {
-	_, ok := p.database.(*sql.UnresolvedDatabase)
+	_, ok := p.Database.(*sql.UnresolvedDatabase)
 	return !ok
 }
 
@@ -42,7 +42,7 @@ func (*ShowTables) Schema() sql.Schema {
 // RowIter implements the Node interface.
 func (p *ShowTables) RowIter(session sql.Session) (sql.RowIter, error) {
 	tableNames := []string{}
-	for key := range p.database.Tables() {
+	for key := range p.Database.Tables() {
 		tableNames = append(tableNames, key)
 	}
 
@@ -53,7 +53,7 @@ func (p *ShowTables) RowIter(session sql.Session) (sql.RowIter, error) {
 
 // TransformUp implements the Transformable interface.
 func (p *ShowTables) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
-	return f(NewShowTables(p.database))
+	return f(NewShowTables(p.Database))
 }
 
 // TransformExpressionsUp implements the Transformable interface.

--- a/sql/plan/show_tables_test.go
+++ b/sql/plan/show_tables_test.go
@@ -20,9 +20,14 @@ func TestShowTables(t *testing.T) {
 	require.Nil(unresolvedShowTables.Children())
 
 	db := mem.NewDatabase("test")
-	db.AddTable("test1", mem.NewTable("test1", nil))
-	db.AddTable("test2", mem.NewTable("test2", nil))
-	db.AddTable("test3", mem.NewTable("test3", nil))
+
+	memDb, ok := db.(*mem.Database)
+
+	require.True(ok)
+
+	memDb.AddTable("test1", mem.NewTable("test1", nil))
+	memDb.AddTable("test2", mem.NewTable("test2", nil))
+	memDb.AddTable("test3", mem.NewTable("test3", nil))
 
 	resolvedShowTables := NewShowTables(db)
 	require.True(resolvedShowTables.Resolved())

--- a/sql/type.go
+++ b/sql/type.go
@@ -124,6 +124,40 @@ var (
 	Blob blobT
 )
 
+// MysqlTypeToType gets the column type using the mysql type
+func MysqlTypeToType(sql query.Type) (Type, error) {
+	switch sql {
+	case sqltypes.Null:
+		return Null, nil
+	case sqltypes.Int32:
+		return Int32, nil
+	case sqltypes.Int64:
+		return Int64, nil
+	case sqltypes.Uint32:
+		return Uint32, nil
+	case sqltypes.Uint64:
+		return Uint64, nil
+	case sqltypes.Float32:
+		return Float32, nil
+	case sqltypes.Float64:
+		return Float64, nil
+	case sqltypes.Timestamp:
+		return Timestamp, nil
+	case sqltypes.Date:
+		return Date, nil
+	case sqltypes.Text, sqltypes.VarChar:
+		return Text, nil
+	case sqltypes.Bit:
+		return Boolean, nil
+	case sqltypes.TypeJSON:
+		return JSON, nil
+	case sqltypes.Blob:
+		return Blob, nil
+	default:
+		return nil, fmt.Errorf("Type not supported: %s", sql)
+	}
+}
+
 type nullT struct{}
 
 // Type implements Type interface.


### PR DESCRIPTION
Also, memory DB implementation constructor now returns the sql.Database interface instead of the implementation itself.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>