### PR TITLE
sql/(plan,analyzer): implement pushdown of filters and cols

### DIFF
--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -1,0 +1,84 @@
+package analyzer
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+type filters map[string][]sql.Expression
+
+func (f filters) merge(f2 filters) {
+	for k, exprs := range f2 {
+		f[k] = append(f[k], exprs...)
+	}
+}
+
+func exprToTableFilters(expr sql.Expression) filters {
+	filtersByTable := make(filters)
+	for _, expr := range splitExpression(expr) {
+		var tables []string
+		_, _ = expr.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+			f, ok := e.(*expression.GetField)
+			if ok {
+				tables = append(tables, f.Table())
+			}
+
+			return e, nil
+		})
+
+		if len(tables) == 1 {
+			filtersByTable[tables[0]] = append(filtersByTable[tables[0]], expr)
+		}
+	}
+
+	return filtersByTable
+}
+
+func splitExpression(expr sql.Expression) []sql.Expression {
+	and, ok := expr.(*expression.And)
+	if !ok {
+		return []sql.Expression{expr}
+	}
+
+	return append(
+		splitExpression(and.Left),
+		splitExpression(and.Right)...,
+	)
+}
+
+func filtersToExpression(filters []sql.Expression) sql.Expression {
+	switch len(filters) {
+	case 0:
+		return nil
+	case 1:
+		return filters[0]
+	default:
+		node := expression.NewAnd(filters[0], filters[1])
+		for _, f := range filters[2:] {
+			node = expression.NewAnd(node, f)
+		}
+		return node
+	}
+}
+
+func getUnhandledFilters(all, handled []sql.Expression) []sql.Expression {
+	var unhandledFilters []sql.Expression
+
+	for _, f := range all {
+		var isHandled bool
+		for _, hf := range handled {
+			if reflect.DeepEqual(f, hf) {
+				isHandled = true
+				break
+			}
+		}
+
+		if !isHandled {
+			unhandledFilters = append(unhandledFilters, f)
+		}
+	}
+
+	return unhandledFilters
+}

--- a/sql/analyzer/filters_test.go
+++ b/sql/analyzer/filters_test.go
@@ -1,0 +1,131 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestFiltersMerge(t *testing.T) {
+	f1 := filters{
+		"1": []sql.Expression{
+			expression.NewLiteral("1", sql.Text),
+		},
+		"2": []sql.Expression{
+			expression.NewLiteral("2", sql.Text),
+		},
+	}
+
+	f2 := filters{
+		"2": []sql.Expression{
+			expression.NewLiteral("2.2", sql.Text),
+		},
+		"3": []sql.Expression{
+			expression.NewLiteral("3", sql.Text),
+		},
+	}
+
+	f1.merge(f2)
+
+	require.Equal(t,
+		filters{
+			"1": []sql.Expression{
+				expression.NewLiteral("1", sql.Text),
+			},
+			"2": []sql.Expression{
+				expression.NewLiteral("2", sql.Text),
+				expression.NewLiteral("2.2", sql.Text),
+			},
+			"3": []sql.Expression{
+				expression.NewLiteral("3", sql.Text),
+			},
+		},
+		f1,
+	)
+}
+
+func TestSplitExpression(t *testing.T) {
+	e := expression.NewAnd(
+		expression.NewAnd(
+			expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
+			expression.NewNot(expression.NewUnresolvedColumn("foo")),
+		),
+		expression.NewAnd(
+			expression.NewOr(
+				expression.NewIsNull(expression.NewUnresolvedColumn("bar")),
+				expression.NewNot(expression.NewUnresolvedColumn("bar")),
+			),
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewLiteral("foo", sql.Text),
+			),
+		),
+	)
+
+	expected := []sql.Expression{
+		expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
+		expression.NewNot(expression.NewUnresolvedColumn("foo")),
+		expression.NewOr(
+			expression.NewIsNull(expression.NewUnresolvedColumn("bar")),
+			expression.NewNot(expression.NewUnresolvedColumn("bar")),
+		),
+		expression.NewEquals(
+			expression.NewUnresolvedColumn("foo"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+	}
+
+	require.Equal(t,
+		expected,
+		splitExpression(e),
+	)
+}
+
+func TestFiltersToExpression(t *testing.T) {
+	require := require.New(t)
+
+	require.Nil(filtersToExpression(nil))
+
+	require.Equal(
+		expression.NewNot(nil),
+		filtersToExpression([]sql.Expression{expression.NewNot(nil)}),
+	)
+
+	require.Equal(
+		expression.NewAnd(
+			expression.NewAnd(
+				expression.NewIsNull(nil),
+				expression.NewEquals(nil, nil),
+			),
+			expression.NewNot(nil),
+		),
+		filtersToExpression([]sql.Expression{
+			expression.NewIsNull(nil),
+			expression.NewEquals(nil, nil),
+			expression.NewNot(nil),
+		}),
+	)
+}
+
+func TestGetUnhandledFilters(t *testing.T) {
+	filters := []sql.Expression{
+		expression.NewIsNull(nil),
+		expression.NewNot(nil),
+		expression.NewEquals(nil, nil),
+		expression.NewGreaterThan(nil, nil),
+	}
+
+	handled := []sql.Expression{
+		filters[1],
+		filters[3],
+	}
+
+	unhandled := getUnhandledFilters(filters, handled)
+
+	require.Equal(t,
+		[]sql.Expression{filters[0], filters[2]},
+		unhandled,
+	)
+}

--- a/sql/core.go
+++ b/sql/core.go
@@ -75,6 +75,29 @@ type Table interface {
 	Node
 }
 
+// PushdownProjectionTable is a table that can produce a specific RowIter
+// that's more optimized given the columns that are projected.
+type PushdownProjectionTable interface {
+	Table
+	// WithProject replaces the RowIter method of the table and returns a new
+	// row iterator given the column names that are projected.
+	WithProject(session Session, colNames []string) (RowIter, error)
+}
+
+// PushdownProjectionAndFiltersTable is a table that can produce a specific
+// RowIter that's more optimized given the columns that are projected and
+// the filters for this table.
+type PushdownProjectionAndFiltersTable interface {
+	Table
+	// HandledFilters returns the subset of filters that can be handled by this
+	// table.
+	HandledFilters(filters []Expression) []Expression
+	// WithProjectAndFilters replaces the RowIter method of the table and
+	// return a new row iterator given the column names that are projected
+	// and the filters applied to this table.
+	WithProjectAndFilters(session Session, columns, filters []Expression) (RowIter, error)
+}
+
 // Inserter allow rows to be inserted in them.
 type Inserter interface {
 	// Insert the given row.

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -5,20 +5,20 @@ import "gopkg.in/src-d/go-mysql-server.v0/sql"
 // Filter skips rows that don't match a certain expression.
 type Filter struct {
 	UnaryNode
-	expression sql.Expression
+	Expression sql.Expression
 }
 
 // NewFilter creates a new filter node.
 func NewFilter(expression sql.Expression, child sql.Node) *Filter {
 	return &Filter{
 		UnaryNode:  UnaryNode{Child: child},
-		expression: expression,
+		Expression: expression,
 	}
 }
 
 // Resolved implements the Resolvable interface.
 func (p *Filter) Resolved() bool {
-	return p.UnaryNode.Child.Resolved() && p.expression.Resolved()
+	return p.UnaryNode.Child.Resolved() && p.Expression.Resolved()
 }
 
 // RowIter implements the Node interface.
@@ -27,7 +27,7 @@ func (p *Filter) RowIter(session sql.Session) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &filterIter{p.expression, i, session}, nil
+	return &filterIter{p.Expression, i, session}, nil
 }
 
 // TransformUp implements the Transformable interface.
@@ -36,12 +36,12 @@ func (p *Filter) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, erro
 	if err != nil {
 		return nil, err
 	}
-	return f(NewFilter(p.expression, child))
+	return f(NewFilter(p.Expression, child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *Filter) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, error)) (sql.Node, error) {
-	expr, err := p.expression.TransformUp(f)
+	expr, err := p.Expression.TransformUp(f)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/plan/innerjoin.go
+++ b/sql/plan/innerjoin.go
@@ -38,13 +38,14 @@ func (j *InnerJoin) RowIter(session sql.Session) (sql.RowIter, error) {
 		return nil, err
 	}
 
-	return &filterIter{
-		childIter: &crossJoinIterator{
+	return NewFilterIter(
+		session,
+		j.Cond,
+		&crossJoinIterator{
 			l:  l,
 			rp: j.Right,
 		},
-		cond: j.Cond,
-	}, nil
+	), nil
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/plan/pushdown.go
+++ b/sql/plan/pushdown.go
@@ -1,0 +1,79 @@
+package plan
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// PushdownProjectionTable is a node wrapping a table implementing the
+// sql.PushdownProjectionTable interface so it returns a RowIter with
+// custom logic given the set of used columns that need to be projected.
+type PushdownProjectionTable struct {
+	sql.PushdownProjectionTable
+	columns []string
+}
+
+// NewPushdownProjectionTable creates a new PushdownProjectionTable node.
+func NewPushdownProjectionTable(
+	columns []string,
+	table sql.PushdownProjectionTable,
+) *PushdownProjectionTable {
+	return &PushdownProjectionTable{table, columns}
+}
+
+// TransformUp implements the Node interface.
+func (t *PushdownProjectionTable) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	node, err := t.PushdownProjectionTable.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	table, ok := node.(sql.PushdownProjectionTable)
+	if !ok {
+		return node, nil
+	}
+
+	return f(NewPushdownProjectionTable(t.columns, table))
+}
+
+// RowIter implements the Node interface.
+func (t *PushdownProjectionTable) RowIter(session sql.Session) (sql.RowIter, error) {
+	return t.WithProject(session, t.columns)
+}
+
+// PushdownProjectionAndFiltersTable is a node wrapping a table implementing
+// the sql.PushdownProjectionAndFiltersTable interface so it returns a RowIter
+// with custom logic given the set of used columns that need to be projected
+// and the filters that apply to that table.
+type PushdownProjectionAndFiltersTable struct {
+	sql.PushdownProjectionAndFiltersTable
+	columns []sql.Expression
+	filters []sql.Expression
+}
+
+// NewPushdownProjectionAndFiltersTable creates a new
+// PushdownProjectionAndFiltersTable node.
+func NewPushdownProjectionAndFiltersTable(
+	columns []sql.Expression,
+	filters []sql.Expression,
+	table sql.PushdownProjectionAndFiltersTable,
+) *PushdownProjectionAndFiltersTable {
+	return &PushdownProjectionAndFiltersTable{table, columns, filters}
+}
+
+// TransformUp implements the Node interface.
+func (t *PushdownProjectionAndFiltersTable) TransformUp(f func(sql.Node) (sql.Node, error)) (sql.Node, error) {
+	node, err := t.PushdownProjectionAndFiltersTable.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	table, ok := node.(sql.PushdownProjectionAndFiltersTable)
+	if !ok {
+		return node, nil
+	}
+
+	return f(NewPushdownProjectionAndFiltersTable(t.columns, t.filters, table))
+}
+
+// RowIter implements the Node interface.
+func (t *PushdownProjectionAndFiltersTable) RowIter(session sql.Session) (sql.RowIter, error) {
+	return t.WithProjectAndFilters(session, t.columns, t.filters)
+}

--- a/sql/plan/pushdown_test.go
+++ b/sql/plan/pushdown_test.go
@@ -1,0 +1,169 @@
+package plan
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestPushdownProjectionTable(t *testing.T) {
+	require := require.New(t)
+	memTable := mem.NewTable("table", sql.Schema{
+		{Name: "a", Type: sql.Int64, Nullable: false},
+		{Name: "b", Type: sql.Int64, Nullable: false},
+		{Name: "c", Type: sql.Int64, Nullable: false},
+	})
+
+	table := NewPushdownProjectionTable(
+		[]string{"a", "c"},
+		&pushdownProjectionTable{memTable},
+	)
+
+	rows := collectRows(t, table)
+	expected := []sql.Row{
+		sql.Row{int64(1), nil, int64(1)},
+		sql.Row{int64(2), nil, int64(2)},
+		sql.Row{int64(3), nil, int64(3)},
+		sql.Row{int64(4), nil, int64(4)},
+	}
+
+	require.Equal(expected, rows)
+}
+
+func TestPushdownProjectionAndFiltersTable(t *testing.T) {
+	require := require.New(t)
+	memTable := mem.NewTable("table", sql.Schema{
+		{Name: "a", Type: sql.Int64, Nullable: false},
+		{Name: "b", Type: sql.Int64, Nullable: false},
+		{Name: "c", Type: sql.Int64, Nullable: false},
+	})
+
+	table := NewPushdownProjectionAndFiltersTable(
+		[]sql.Expression{
+			expression.NewGetField(0, sql.Int64, "a", false),
+			expression.NewGetField(2, sql.Int64, "c", false),
+		},
+		[]sql.Expression{
+			expression.NewNot(expression.NewEquals(
+				expression.NewGetField(0, sql.Int64, "a", false),
+				expression.NewLiteral(int64(1), sql.Int64),
+			)),
+			expression.NewNot(expression.NewEquals(
+				expression.NewGetField(0, sql.Int64, "a", false),
+				expression.NewLiteral(int64(3), sql.Int64),
+			)),
+		},
+		&pushdownProjectionAndFiltersTable{memTable},
+	)
+
+	rows := collectRows(t, table)
+	expected := []sql.Row{
+		sql.Row{int64(2), nil, int64(2)},
+		sql.Row{int64(4), nil, int64(4)},
+	}
+
+	require.Equal(expected, rows)
+}
+
+type pushdownProjectionTable struct {
+	sql.Table
+}
+
+func (t *pushdownProjectionTable) WithProject(_ sql.Session, cols []string) (sql.RowIter, error) {
+	var fields []int
+Loop:
+	for i, col := range t.Schema() {
+		for _, colName := range cols {
+			if colName == col.Name {
+				fields = append(fields, i)
+				continue Loop
+			}
+		}
+	}
+
+	return &pushdownProjectionIter{len(t.Schema()), fields, 0}, nil
+}
+
+type pushdownProjectionIter struct {
+	len    int
+	fields []int
+	iter   int64
+}
+
+func (it *pushdownProjectionIter) Next() (sql.Row, error) {
+	if it.iter > 3 {
+		return nil, io.EOF
+	}
+
+	var row = make(sql.Row, it.len)
+	it.iter++
+	for _, f := range it.fields {
+		row[f] = it.iter
+	}
+	return row, nil
+}
+
+func (it *pushdownProjectionIter) Close() error {
+	it.iter = 4
+	return nil
+}
+
+type pushdownProjectionAndFiltersTable struct {
+	sql.Table
+}
+
+func (pushdownProjectionAndFiltersTable) HandledFilters([]sql.Expression) []sql.Expression {
+	panic("not implemented")
+}
+
+func (t *pushdownProjectionAndFiltersTable) WithProjectAndFilters(session sql.Session, cols, filters []sql.Expression) (sql.RowIter, error) {
+	var fields []int
+Loop:
+	for i, col := range t.Schema() {
+		for _, c := range cols {
+			if c.Name() == col.Name {
+				fields = append(fields, i)
+				continue Loop
+			}
+		}
+	}
+
+	return &pushdownProjectionAndFiltersIter{
+		&pushdownProjectionIter{len(t.Schema()), fields, 0},
+		session,
+		filters,
+	}, nil
+}
+
+type pushdownProjectionAndFiltersIter struct {
+	sql.RowIter
+	session sql.Session
+	filters []sql.Expression
+}
+
+func (it *pushdownProjectionAndFiltersIter) Next() (sql.Row, error) {
+Loop:
+	for {
+		row, err := it.RowIter.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, f := range it.filters {
+			result, err := f.Eval(it.session, row)
+			if err != nil {
+				return nil, err
+			}
+
+			if result != true {
+				continue Loop
+			}
+		}
+
+		return row, nil
+	}
+}

--- a/sql/type.go
+++ b/sql/type.go
@@ -40,6 +40,16 @@ func (s Schema) CheckRow(row Row) error {
 	return nil
 }
 
+// Contains returns whether the schema contains a column with the given name.
+func (s Schema) Contains(column string) bool {
+	for _, col := range s {
+		if col.Name == column {
+			return true
+		}
+	}
+	return false
+}
+
 // Column is the definition of a table column.
 // As SQL:2016 puts it:
 //   A column is a named component of a table. It has a data type, a default,


### PR DESCRIPTION
Depends on #82 

Closes #27 
Closes #28 

Supersedes #83 

### Implementation details

Only columns and filters that apply to a column are pushed down to that column. That is, if you have `42 > 5` that filter will not be pushed down to any table, and if you have `a.foo = 5` that filter will only be pushed down to table `a`.

If more than one table is mentioned in a filter, it's not pushed down to neither. E.g. `a.foo = b.foo` is not pushed down.

Perhaps we want the opposite and we want all filters pushed down to the table, regardless of whether it mentions the table or not?

Also, join conditions are not being pushed down as filters, should we also push those down?