### PR TITLE
 sql/analyzer: resolve GetField on schemas with repeated column names 

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -48,8 +48,8 @@ func checkIfError(err error) {
 func createTestDatabase() *mem.Database {
 	db := mem.NewDatabase("test")
 	table := mem.NewTable("mytable", gitqlsql.Schema{
-		{Name: "name", Type: gitqlsql.Text},
-		{Name: "email", Type: gitqlsql.Text},
+		{Name: "name", Type: gitqlsql.Text, Source: "mytable"},
+		{Name: "email", Type: gitqlsql.Text, Source: "mytable"},
 	})
 	db.AddTable("mytable", table)
 	table.Insert(gitqlsql.NewRow("John Doe", "john@doe.com"))

--- a/mem/table_test.go
+++ b/mem/table_test.go
@@ -11,7 +11,7 @@ import (
 func TestTable_Name(t *testing.T) {
 	require := require.New(t)
 	s := sql.Schema{
-		{"col1", sql.Text, nil, true},
+		{"col1", sql.Text, nil, true, ""},
 	}
 	table := NewTable("test", s)
 	require.Equal("test", table.Name())
@@ -22,7 +22,7 @@ func TestTable_Insert_RowIter(t *testing.T) {
 	session := sql.NewBaseSession(context.TODO())
 
 	s := sql.Schema{
-		{"col1", sql.Text, nil, true},
+		{"col1", sql.Text, nil, true, ""},
 	}
 
 	table := NewTable("test", s)

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -1,4 +1,4 @@
-package analyzer_test
+package analyzer
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
-	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 
@@ -16,14 +15,14 @@ import (
 func TestAnalyzer_Analyze(t *testing.T) {
 	require := require.New(t)
 
-	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
-	table2 := mem.NewTable("mytable2", sql.Schema{{Name: "i2", Type: sql.Int32}})
+	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32, Source: "mytable"}})
+	table2 := mem.NewTable("mytable2", sql.Schema{{Name: "i2", Type: sql.Int32, Source: "mytable2"}})
 	db := mem.NewDatabase("mydb")
 	db.AddTable("mytable", table)
 	db.AddTable("mytable2", table2)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
-	a := analyzer.New(catalog)
+	a := New(catalog)
 	a.CurrentDatabase = "mydb"
 
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("mytable")
@@ -191,14 +190,14 @@ func TestAnalyzer_Analyze_MaxIterations(t *testing.T) {
 	require := require.New(t)
 
 	catalog := &sql.Catalog{}
-	a := analyzer.New(catalog)
+	a := New(catalog)
 	a.CurrentDatabase = "mydb"
 
 	i := 0
-	a.Rules = []analyzer.Rule{{
+	a.Rules = []Rule{{
 		Name: "infinite",
-		Apply: func(a *analyzer.Analyzer, n sql.Node) (sql.Node, error) {
-			i += 1
+		Apply: func(a *Analyzer, n sql.Node) (sql.Node, error) {
+			i++
 			return plan.NewUnresolvedTable(fmt.Sprintf("table%d", i)), nil
 		},
 	}}

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -1,4 +1,4 @@
-package analyzer_test
+package analyzer
 
 import (
 	"testing"
@@ -7,7 +7,6 @@ import (
 
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
-	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
@@ -23,8 +22,8 @@ func TestResolveTables(t *testing.T) {
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 
-	a := analyzer.New(catalog)
-	a.Rules = []analyzer.Rule{f}
+	a := New(catalog)
+	a.Rules = []Rule{f}
 
 	a.CurrentDatabase = "mydb"
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("mytable")
@@ -53,8 +52,8 @@ func TestResolveTablesNested(t *testing.T) {
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 
-	a := analyzer.New(catalog)
-	a.Rules = []analyzer.Rule{f}
+	a := New(catalog)
+	a.Rules = []Rule{f}
 	a.CurrentDatabase = "mydb"
 
 	notAnalyzed := plan.NewProject(
@@ -80,8 +79,8 @@ func TestResolveStar(t *testing.T) {
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 
-	a := analyzer.New(catalog)
-	a.Rules = []analyzer.Rule{f}
+	a := New(catalog)
+	a.Rules = []Rule{f}
 	a.CurrentDatabase = "mydb"
 
 	notAnalyzed := plan.NewProject(
@@ -160,7 +159,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	result, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(analyzer.ErrTableNotFound.Is(err))
+	require.True(ErrTableNotFound.Is(err))
 
 	node = plan.NewProject(
 		[]sql.Expression{
@@ -171,7 +170,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	_, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(analyzer.ErrColumnTableNotFound.Is(err))
+	require.True(ErrColumnTableNotFound.Is(err))
 
 	node = plan.NewProject(
 		[]sql.Expression{
@@ -182,7 +181,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	_, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(analyzer.ErrAmbiguousColumnName.Is(err))
+	require.True(ErrAmbiguousColumnName.Is(err))
 }
 
 func TestOptimizeDistinct(t *testing.T) {
@@ -202,8 +201,8 @@ func TestOptimizeDistinct(t *testing.T) {
 	require.Equal(plan.NewOrderedDistinct(sorted.Child), analyzedSorted)
 }
 
-func getRule(name string) analyzer.Rule {
-	for _, rule := range analyzer.DefaultRules {
+func getRule(name string) Rule {
+	for _, rule := range DefaultRules {
 		if rule.Name == name {
 			return rule
 		}

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -5,7 +5,8 @@ import "gopkg.in/src-d/go-mysql-server.v0/sql"
 // TableAlias is a node that acts as a table with a given name.
 type TableAlias struct {
 	*UnaryNode
-	name string
+	name   string
+	schema sql.Schema
 }
 
 // NewTableAlias returns a new Table alias node.
@@ -16,6 +17,26 @@ func NewTableAlias(name string, node sql.Node) *TableAlias {
 // Name implements the Nameable interface.
 func (t *TableAlias) Name() string {
 	return t.name
+}
+
+// Schema implements the Node interface.
+func (t *TableAlias) Schema() sql.Schema {
+	if t.schema == nil {
+		// only add the name to it if it's a subquery what is being aliased
+		if _, ok := t.Child.(*Project); ok {
+			schema := t.Child.Schema()
+			t.schema = make(sql.Schema, len(schema))
+			for i, col := range schema {
+				c := *col
+				c.Source = t.Name()
+				t.schema[i] = &c
+			}
+		} else {
+			t.schema = t.Child.Schema()
+		}
+	}
+
+	return t.schema
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/plan/tablealias_test.go
+++ b/sql/plan/tablealias_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
 
 func TestTableAlias(t *testing.T) {
@@ -47,4 +48,38 @@ func TestTableAlias(t *testing.T) {
 	}
 
 	require.Equal(len(rows), i)
+}
+
+func TestTableAliasSchema(t *testing.T) {
+	require := require.New(t)
+
+	tableSchema := sql.Schema{
+		{Name: "foo", Type: sql.Text, Nullable: false, Source: "bar"},
+		{Name: "baz", Type: sql.Text, Nullable: false, Source: "bar"},
+	}
+
+	subquerySchema := sql.Schema{
+		{Name: "foo", Type: sql.Text, Nullable: false, Source: "alias"},
+		{Name: "baz", Type: sql.Text, Nullable: false, Source: "alias"},
+	}
+
+	table := mem.NewTable("bar", tableSchema)
+
+	subquery := NewProject(
+		[]sql.Expression{
+			expression.NewGetField(0, sql.Text, "foo", false),
+			expression.NewGetField(1, sql.Text, "baz", false),
+		},
+		nil,
+	)
+
+	require.Equal(
+		tableSchema,
+		NewTableAlias("alias", table).Schema(),
+	)
+
+	require.Equal(
+		subquerySchema,
+		NewTableAlias("alias", subquery).Schema(),
+	)
 }

--- a/sql/type.go
+++ b/sql/type.go
@@ -54,6 +54,8 @@ type Column struct {
 	// Nullable is true if the column can contain NULL values, or false
 	// otherwise.
 	Nullable bool
+	// Source is the name of the table this column came from.
+	Source string
 }
 
 // Check ensures the value is correct for this column.


### PR DESCRIPTION
Depends on #82 

Fixes #88

Because of the way we access the fields in the rows using GetField with the index in which they appear and only by name, there was no way of knowing which field was the correct when there were multiple fields with the same name.

Now, all columns include a "Source", which is defined by the table and must match the table name (this is validated by an analyzer validation rule), so that we can identify from which table we should get the field.

One notable exception to this is TableAlias, which avoids this limitation only when its child node is not a Projection (that is, a subquery).