### PR TITLE
sql/(plan,analyzer): implement OrderedDistinct for sorted results

### DIFF
--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -10,9 +10,8 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
 
-var GroupByErr = errors.NewKind("group by aggregation '%v' not supported")
-
-var _ sql.Node = &GroupBy{}
+// ErrGroupBy is returned when the aggregation is not supported.
+var ErrGroupBy = errors.NewKind("group by aggregation '%v' not supported")
 
 // GroupBy groups the rows by some expressions.
 type GroupBy struct {
@@ -263,6 +262,6 @@ func updateBuffer(
 		buffers[idx] = row
 		return nil
 	default:
-		return GroupByErr.New(n.Name())
+		return ErrGroupBy.New(n.Name())
 	}
 }

--- a/sql/row.go
+++ b/sql/row.go
@@ -19,6 +19,22 @@ func (r Row) Copy() Row {
 	return NewRow(r...)
 }
 
+// Equals checks whether two rows are equal given a schema.
+func (r Row) Equals(row Row, schema Schema) bool {
+	if len(row) != len(r) || len(row) != len(schema) {
+		return false
+	}
+
+	for i, colLeft := range r {
+		colRight := row[i]
+		if schema[i].Type.Compare(colLeft, colRight) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 // RowIter is an iterator that produces rows.
 type RowIter interface {
 	// Next retrieves the next row. It will return io.EOF if it's the last row.


### PR DESCRIPTION
This improves the performance of the Distinct operation by two orders of magnitude (both in CPU and memory) when the result set is sorted.

Also adds an `Equals` method to `Row`, which can come in handy for some other operations.

Benchmark results:
```
pkg: gopkg.in/src-d/go-mysql-server.v0/sql/plan
BenchmarkDistinct-4          	     100	  13723600 ns/op	 2183356 B/op	  264693 allocs/op
BenchmarkOrderedDistinct-4   	   10000	    117517 ns/op	   65904 B/op	     925 allocs/op
BenchmarkProject-4           	   20000	     99851 ns/op	   65324 B/op	     913 allocs/op
PASS
ok  	gopkg.in/src-d/go-mysql-server.v0/sql/plan	5.600s
```