### PR TITLE
sql/analyzer: use comparison operator instead of reflect.DeepEqual

### DIFF
--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -2,7 +2,6 @@ package analyzer
 
 import (
 	"fmt"
-	"reflect"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -57,7 +56,7 @@ func (a *Analyzer) Analyze(n sql.Node) (sql.Node, error) {
 	}
 
 	i := 0
-	for !reflect.DeepEqual(prev, cur) {
+	for prev != cur {
 		prev = cur
 		cur, err = a.analyzeOnce(cur)
 		if err != nil {


### PR DESCRIPTION
Due to the immutable nature of the execution plan, any change in any part of the tree means the outermost node will change, so we don't need to use `!reflect.DeepEqual` but just the `!=` operator for doing the comparison in the analyzer.

As long as the pointer to the node is the same, the two `Node` interface values are equal.

Proof: https://play.golang.org/p/Jb2rya-enQO