### PR TITLE
Improve errors

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1,17 +1,10 @@
 package sqle
 
 import (
-	"errors"
-
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/parse"
-)
-
-var (
-	// ErrNotSupported is thrown when a feature which is not supported is used.
-	ErrNotSupported = errors.New("feature not supported yet")
 )
 
 // Engine is a SQL engine.

--- a/mem/database.go
+++ b/mem/database.go
@@ -1,8 +1,6 @@
 package mem
 
 import (
-	"fmt"
-
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -39,7 +37,7 @@ func (d *Database) AddTable(name string, t *Table) {
 func (d *Database) Create(name string, schema sql.Schema) error {
 	_, ok := d.tables[name]
 	if ok {
-		return fmt.Errorf("table with name %s already exists", name)
+		return sql.ErrTableAlreadyExist.New(name)
 	}
 
 	d.tables[name] = NewTable(name, schema)

--- a/mem/database.go
+++ b/mem/database.go
@@ -37,7 +37,7 @@ func (d *Database) AddTable(name string, t *Table) {
 func (d *Database) Create(name string, schema sql.Schema) error {
 	_, ok := d.tables[name]
 	if ok {
-		return sql.ErrTableAlreadyExist.New(name)
+		return sql.ErrTableAlreadyExists.New(name)
 	}
 
 	d.tables[name] = NewTable(name, schema)

--- a/mem/table.go
+++ b/mem/table.go
@@ -59,7 +59,7 @@ func (t *Table) TransformExpressionsUp(f func(sql.Expression) (sql.Expression, e
 // Insert a new row into the table.
 func (t *Table) Insert(row sql.Row) error {
 	if len(row) != len(t.schema) {
-		return fmt.Errorf("insert expected %d values, got %d", len(t.schema), len(row))
+		return sql.ErrUnexpectedRowLength.New(len(t.schema), len(row))
 	}
 
 	for idx, value := range row {

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -1,16 +1,19 @@
 package analyzer
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
 const maxAnalysisIterations = 1000
+
+// ErrMaxAnalysisIters is thrown when the analysis iterations are exceeded
+var ErrMaxAnalysisIters = errors.NewKind("exceeded max analysis iterations (%d)")
 
 // Analyzer analyzes nodes of the execution plan and applies rules and validations
 // to them.
@@ -84,7 +87,7 @@ func (a *Analyzer) Analyze(n sql.Node) (sql.Node, error) {
 
 		i++
 		if i >= maxAnalysisIterations {
-			return cur, fmt.Errorf("exceeded max analysis iterations (%d)", maxAnalysisIterations)
+			return cur, ErrMaxAnalysisIters.New(maxAnalysisIterations)
 		}
 	}
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -29,9 +29,6 @@ var (
 	// ErrAmbiguousColumnName is returned when there is a column reference that
 	// is present in more than one table.
 	ErrAmbiguousColumnName = errors.NewKind("ambiguous column name %q, it's present in all these tables: %v")
-	// ErrTableNotFound is returned when the table is not available from the
-	// current scope.
-	ErrTableNotFound = errors.NewKind("table not found in scope: %s")
 )
 
 func resolveSubqueries(a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -110,7 +107,7 @@ func qualifyColumns(a *Analyzer, n sql.Node) (sql.Node, error) {
 				}
 
 				if _, ok := tables[col.Table()]; !ok {
-					return nil, ErrTableNotFound.New(col.Table())
+					return nil, sql.ErrTableNotFound.New(col.Table())
 				}
 			}
 

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -263,7 +263,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	result, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(ErrTableNotFound.Is(err))
+	require.True(sql.ErrTableNotFound.Is(err))
 
 	node = plan.NewProject(
 		[]sql.Expression{

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -1,7 +1,7 @@
 package analyzer
 
 import (
-	errors "gopkg.in/src-d/go-errors.v0"
+	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -1,8 +1,11 @@
 package sql
 
 import (
-	"fmt"
+	"gopkg.in/src-d/go-errors.v1"
 )
+
+// ErrDatabaseNotFound is thrown when a database is not found
+var ErrDatabaseNotFound = errors.NewKind("database not found: %s")
 
 // Catalog holds databases, tables and functions.
 type Catalog struct {
@@ -29,7 +32,7 @@ func (d Databases) Database(name string) (Database, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("database not found: %s", name)
+	return nil, ErrDatabaseNotFound.New(name)
 }
 
 // Table returns the Table with the given name if it exists.
@@ -42,7 +45,7 @@ func (d Databases) Table(dbName string, tableName string) (Table, error) {
 	tables := db.Tables()
 	table, found := tables[tableName]
 	if !found {
-		return nil, fmt.Errorf("table not found: %s", tableName)
+		return nil, ErrTableNotFound.New(tableName)
 	}
 
 	return table, nil

--- a/sql/core.go
+++ b/sql/core.go
@@ -123,3 +123,14 @@ type Alterable interface {
 // ErrInvalidType is thrown when there is an unexpected type at some part of
 // the execution tree.
 var ErrInvalidType = errors.NewKind("invalid type: %s")
+
+// ErrTableAlreadyExist is thrown when someone tries to create a
+// table with a name of an existing one
+var ErrTableAlreadyExist = errors.NewKind("table with name %s already exists")
+
+// ErrTableNotFound is returned when the table is not available from the
+// current scope.
+var ErrTableNotFound = errors.NewKind("table not found: %s")
+
+//ErrUnexpectedRowLength is thrown when the obtained row has more columns than the schema
+var ErrUnexpectedRowLength = errors.NewKind("expected %d values, got %d")

--- a/sql/core.go
+++ b/sql/core.go
@@ -124,9 +124,9 @@ type Alterable interface {
 // the execution tree.
 var ErrInvalidType = errors.NewKind("invalid type: %s")
 
-// ErrTableAlreadyExist is thrown when someone tries to create a
+// ErrTableAlreadyExists is thrown when someone tries to create a
 // table with a name of an existing one
-var ErrTableAlreadyExist = errors.NewKind("table with name %s already exists")
+var ErrTableAlreadyExists = errors.NewKind("table with name %s already exists")
 
 // ErrTableNotFound is returned when the table is not available from the
 // current scope.

--- a/sql/functionregistry.go
+++ b/sql/functionregistry.go
@@ -1,10 +1,15 @@
 package sql
 
 import (
-	"fmt"
-
 	"gopkg.in/src-d/go-errors.v1"
 )
+
+// ErrFunctionNotFound is thrown when a function is not found
+var ErrFunctionNotFound = errors.NewKind("function not found: %s")
+
+// ErrInvalidArgumentNumber is returned when the number of arguments to call a
+// function is different from the function arity.
+var ErrInvalidArgumentNumber = errors.NewKind("expecting %v arguments for calling this function, %d received")
 
 // Function is a function defined by the user that can be applied in a SQL
 // query.
@@ -113,10 +118,6 @@ func (Function6) isFunction() {}
 func (Function7) isFunction() {}
 func (FunctionN) isFunction() {}
 
-// ErrInvalidArgumentNumber is returned when the number of arguments to call a
-// function is different from the function arity.
-var ErrInvalidArgumentNumber = errors.NewKind("expecting %v arguments for calling this function, %d received")
-
 // FunctionRegistry is used to register functions. It is used both for builtin
 // and User-Defined Functions.
 type FunctionRegistry map[string]Function
@@ -135,7 +136,7 @@ func (r FunctionRegistry) RegisterFunction(name string, f Function) {
 func (r FunctionRegistry) Function(name string) (Function, error) {
 	e, ok := r[name]
 	if !ok {
-		return nil, fmt.Errorf("function not found: %s", name)
+		return nil, ErrFunctionNotFound.New(name)
 	}
 
 	return e, nil

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -388,7 +388,7 @@ func TestParse(t *testing.T) {
 }
 
 var fixturesErrors = map[string]error{
-	`SHOW METHEMONEY`: errUnsupportedFeature(`SHOW METHEMONEY`),
+	`SHOW METHEMONEY`: ErrUnsupportedFeature.New(`SHOW METHEMONEY`),
 }
 
 func TestParseErrors(t *testing.T) {
@@ -398,7 +398,7 @@ func TestParseErrors(t *testing.T) {
 			session := sql.NewBaseSession(context.TODO())
 			_, err := Parse(session, query)
 			require.Error(err)
-			require.Equal(expectedError, err)
+			require.Equal(expectedError.Error(), err.Error())
 		})
 	}
 }

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -1,10 +1,12 @@
 package plan
 
 import (
-	"fmt"
-
+	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
+
+// ErrCreateTable is thrown when the database doesn't support table creation
+var ErrCreateTable = errors.NewKind("tables cannot be created on database %s")
 
 // CreateTable is a node describing the creation of some table.
 type CreateTable struct {
@@ -36,7 +38,7 @@ func (c *CreateTable) Resolved() bool {
 func (c *CreateTable) RowIter(s sql.Session) (sql.RowIter, error) {
 	d, ok := c.Database.(sql.Alterable)
 	if !ok {
-		return nil, fmt.Errorf("tables cannot be created on database %s", c.Database.Name())
+		return nil, ErrCreateTable.New(c.Database.Name())
 	}
 
 	return sql.RowsToRowIter(), d.Create(c.name, c.schema)

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	errors "gopkg.in/src-d/go-errors.v0"
+	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -1,13 +1,16 @@
 package plan
 
 import (
-	"errors"
 	"io"
 	"strings"
 
+	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
+
+// ErrInsertIntoNotSupported is thrown when a table doesn't support inserts
+var ErrInsertIntoNotSupported = errors.NewKind("table doesn't support INSERT INTO")
 
 // InsertInto is a node describing the insertion into some table.
 type InsertInto struct {
@@ -37,7 +40,7 @@ func (p *InsertInto) Schema() sql.Schema {
 func (p *InsertInto) Execute(session sql.Session) (int, error) {
 	insertable, ok := p.Left.(sql.Inserter)
 	if !ok {
-		return 0, errors.New("destination table does not support INSERT TO")
+		return 0, ErrInsertIntoNotSupported.New()
 	}
 
 	dstSchema := p.Left.Schema()

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -6,8 +6,12 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
+
+// ErrUnableSort is thrown when something happens on sorting
+var ErrUnableSort = errors.NewKind("unable to sort")
 
 // Sort is the sort node.
 type Sort struct {
@@ -215,13 +219,13 @@ func (s *sorter) Less(i, j int) bool {
 		typ := sf.Column.Type()
 		av, err := sf.Column.Eval(s.session, a)
 		if err != nil {
-			s.lastError = fmt.Errorf("unable to sort: %s", err)
+			s.lastError = ErrUnableSort.Wrap(err)
 			return false
 		}
 
 		bv, err := sf.Column.Eval(s.session, b)
 		if err != nil {
-			s.lastError = fmt.Errorf("unable to sort: %s", err)
+			s.lastError = ErrUnableSort.Wrap(err)
 			return false
 		}
 

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -3,8 +3,12 @@ package plan
 import (
 	"fmt"
 
+	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
+
+// ErrUnresolvedTable is thrown when a table cannot be resolved
+var ErrUnresolvedTable = errors.NewKind("unresolved table")
 
 // UnresolvedTable is a table that has not been resolved yet but whose name is known.
 type UnresolvedTable struct {
@@ -34,7 +38,7 @@ func (*UnresolvedTable) Schema() sql.Schema {
 
 // RowIter implements the RowIter interface.
 func (*UnresolvedTable) RowIter(session sql.Session) (sql.RowIter, error) {
-	return nil, fmt.Errorf("unresolved table")
+	return nil, ErrUnresolvedTable.New()
 }
 
 // TransformUp implements the Transformable interface.


### PR DESCRIPTION
- Use src-d/go-errors.v1 instead of src-d/go-errors.v0
- Use go-errors library instead of errors or fmt
- Unify common errors

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>