### PR TITLE
sql/analyzer: improve error message when column with no table is not found

### DIFF
--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -334,7 +334,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	result, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(ErrColumnTableNotFound.Is(err))
+	require.True(ErrColumnNotFound.Is(err))
 
 	node = plan.NewProject(
 		[]sql.Expression{
@@ -356,7 +356,7 @@ func TestQualifyColumns(t *testing.T) {
 
 	_, err = f.Apply(nil, node)
 	require.Error(err)
-	require.True(ErrColumnTableNotFound.Is(err))
+	require.True(ErrColumnNotFound.Is(err))
 
 	node = plan.NewProject(
 		[]sql.Expression{


### PR DESCRIPTION
Closes #93 

Could not reproduce the "not resolved because of node *" error message, I guess that's fixed and other errors take its place now. I found this error message that could be improved tho.