### PR TITLE
Walk the tree

### DIFF
--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -386,7 +386,7 @@ func pushdown(a *Analyzer, n sql.Node) (sql.Node, error) {
 
 	// First step is to find all col exprs and group them by the table they mention.
 	// Even if they appear multiple times, only the first one will be used.
-	_, _ = n.TransformExpressionsUp(func(e sql.Expression) (sql.Expression, error) {
+	plan.InspectExpressions(n, func(e sql.Expression) bool {
 		if e, ok := e.(*expression.GetField); ok {
 			tf := tableField{e.Table(), e.Name()}
 			if _, ok := tableFields[tf]; !ok {
@@ -396,7 +396,7 @@ func pushdown(a *Analyzer, n sql.Node) (sql.Node, error) {
 				exprsByTable[e.Table()] = append(exprsByTable[e.Table()], e)
 			}
 		}
-		return e, nil
+		return true
 	})
 
 	a.Log("finding filters in node")
@@ -404,20 +404,16 @@ func pushdown(a *Analyzer, n sql.Node) (sql.Node, error) {
 	// then find all filters, also by table. Note that filters that mention
 	// more than one table will not be passed to neither.
 	filters := make(filters)
-	node, err := n.TransformUp(func(node sql.Node) (sql.Node, error) {
-		a.Log("transforming node of type: %T", node)
+	plan.Inspect(n, func(node sql.Node) bool {
+		a.Log("inspecting node of type: %T", node)
 		switch node := node.(type) {
 		case *plan.Filter:
 			fs := exprToTableFilters(node.Expression)
 			a.Log("found filters for %d tables %s", len(fs), node.Expression)
 			filters.merge(fs)
 		}
-
-		return node, nil
+		return true
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	a.Log("transforming nodes with pushdown of filters and projections")
 
@@ -425,7 +421,7 @@ func pushdown(a *Analyzer, n sql.Node) (sql.Node, error) {
 	// from inner to outer the filters have to be processed first so they get
 	// to the tables.
 	var handledFilters []sql.Expression
-	return node.TransformUp(func(node sql.Node) (sql.Node, error) {
+	return n.TransformUp(func(node sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", node)
 		switch node := node.(type) {
 		case *plan.Filter:

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -323,7 +323,7 @@ func resolveFunctions(a *Analyzer, n sql.Node) (sql.Node, error) {
 				return nil, err
 			}
 
-			rf, err := f.Call(uf.Children...)
+			rf, err := f.Call(uf.Arguments...)
 			if err != nil {
 				return nil, err
 			}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -197,7 +197,7 @@ func resolveStar(a *Analyzer, n sql.Node) (sql.Node, error) {
 
 		var expressions []sql.Expression
 		schema := p.Child.Schema()
-		for _, e := range p.Expressions {
+		for _, e := range p.Projections {
 			if s, ok := e.(*expression.Star); ok {
 				var exprs []sql.Expression
 				for i, col := range schema {

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -131,7 +131,7 @@ func validateSchema(t sql.Table) error {
 func validateProjectTuples(n sql.Node) error {
 	switch n := n.(type) {
 	case *plan.Project:
-		for i, e := range n.Expressions {
+		for i, e := range n.Projections {
 			if sql.IsTuple(e.Type()) {
 				return ErrProjectTuple.New(i+1, sql.NumColumns(e.Type()))
 			}

--- a/sql/core.go
+++ b/sql/core.go
@@ -83,6 +83,12 @@ type Node interface {
 	RowIter(*Context) (RowIter, error)
 }
 
+// Expressioner is a node that contains expressions.
+type Expressioner interface {
+	// Expressions returns the list of expressions contained by the node.
+	Expressions() []Expression
+}
+
 // Table represents a SQL table.
 type Table interface {
 	Nameable

--- a/sql/core.go
+++ b/sql/core.go
@@ -50,6 +50,8 @@ type Expression interface {
 	// TransformUp transforms the expression and all its children with the
 	// given transform function.
 	TransformUp(TransformExprFunc) (Expression, error)
+	// Children returns the children expressions of this expression.
+	Children() []Expression
 }
 
 // Aggregation implements an aggregation expression, where an

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -22,6 +22,11 @@ func (b Between) String() string {
 	return fmt.Sprintf("BETWEEN(%s, %s, %s)", b.Val, b.Lower, b.Upper)
 }
 
+// Children implements the Expression interface.
+func (b Between) Children() []sql.Expression {
+	return []sql.Expression{b.Val, b.Lower, b.Upper}
+}
+
 // Type implements the Expression interface.
 func (Between) Type() sql.Type { return sql.Boolean }
 

--- a/sql/expression/common.go
+++ b/sql/expression/common.go
@@ -9,6 +9,11 @@ type UnaryExpression struct {
 	Child sql.Expression
 }
 
+// Children implements the Expression interface.
+func (p UnaryExpression) Children() []sql.Expression {
+	return []sql.Expression{p.Child}
+}
+
 // Resolved implements the Expression interface.
 func (p UnaryExpression) Resolved() bool {
 	return p.Child.Resolved()
@@ -23,6 +28,11 @@ func (p UnaryExpression) IsNullable() bool {
 type BinaryExpression struct {
 	Left  sql.Expression
 	Right sql.Expression
+}
+
+// Children implements the Expression interface.
+func (p BinaryExpression) Children() []sql.Expression {
+	return []sql.Expression{p.Left, p.Right}
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -516,6 +516,11 @@ func (in *In) String() string {
 	return fmt.Sprintf("%s IN %s", in.Left(), in.Right())
 }
 
+// Children implements the Expression interface.
+func (in *In) Children() []sql.Expression {
+	return []sql.Expression{in.Left(), in.Right()}
+}
+
 // NotIn is a comparison that checks an expression is not inside a list of expressions.
 type NotIn struct {
 	comparison
@@ -597,4 +602,9 @@ func (in *NotIn) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 
 func (in *NotIn) String() string {
 	return fmt.Sprintf("%s NOT IN %s", in.Left(), in.Right())
+}
+
+// Children implements the Expression interface.
+func (in *NotIn) Children() []sql.Expression {
+	return []sql.Expression{in.Left(), in.Right()}
 }

--- a/sql/expression/function/substring.go
+++ b/sql/expression/function/substring.go
@@ -37,6 +37,14 @@ func NewSubstring(args ...sql.Expression) (sql.Expression, error) {
 	return &Substring{str, start, ln}, nil
 }
 
+// Children implements the Expression interface.
+func (s Substring) Children() []sql.Expression {
+	if s.len == nil {
+		return []sql.Expression{s.str, s.start}
+	}
+	return []sql.Expression{s.str, s.start, s.len}
+}
+
 // Eval implements the Expression interface.
 func (s *Substring) Eval(
 	ctx *sql.Context,

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -31,6 +31,11 @@ func NewGetFieldWithTable(index int, fieldType sql.Type, table, fieldName string
 	}
 }
 
+// Children implements the Expression interface.
+func (GetField) Children() []sql.Expression {
+	return nil
+}
+
 // Table returns the name of the field table.
 func (p GetField) Table() string { return p.table }
 

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -56,3 +56,8 @@ func (p *Literal) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 	n := *p
 	return f(&n)
 }
+
+// Children implements the Expression interface.
+func (Literal) Children() []sql.Expression {
+	return nil
+}

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -28,6 +28,11 @@ func (Star) Resolved() bool {
 	return false
 }
 
+// Children implements the Expression interface.
+func (Star) Children() []sql.Expression {
+	return nil
+}
+
 // IsNullable implements the Expression interface.
 func (Star) IsNullable() bool {
 	panic("star is just a placeholder node, but IsNullable was called")

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -90,3 +90,8 @@ func (t Tuple) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 
 	return f(Tuple(exprs))
 }
+
+// Children implements the Expression interface.
+func (t Tuple) Children() []sql.Expression {
+	return t
+}

--- a/sql/expression/walk.go
+++ b/sql/expression/walk.go
@@ -1,0 +1,46 @@
+package expression
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// Visitor visits exprs in the plan.
+type Visitor interface {
+	// Visit method is invoked for each expr encountered by Walk.
+	// If the result Visitor is not nul, Walk visits each of the children
+	// of the expr with that visitor, followed by a call of Visit(nil)
+	// to the returned visitor.
+	Visit(expr sql.Expression) Visitor
+}
+
+// Walk traverses the plan tree in depth-first order. It starts by calling
+// v.Visit(expr); expr must not be nil. If the visitor returned by
+// v.Visit(expr) is not nil, Walk is invoked recursively with the returned
+// visitor for each children of the expr, followed by a call of v.Visit(nil)
+// to the returned visitor.
+func Walk(v Visitor, expr sql.Expression) {
+	if v = v.Visit(expr); v == nil {
+		return
+	}
+
+	for _, child := range expr.Children() {
+		Walk(v, child)
+	}
+
+	v.Visit(nil)
+}
+
+type inspector func(sql.Expression) bool
+
+func (f inspector) Visit(expr sql.Expression) Visitor {
+	if f(expr) {
+		return f
+	}
+	return nil
+}
+
+// Inspect traverses the plan in depth-first order: It starts by calling
+// f(expr); expr must not be nil. If f returns true, Inspect invokes f
+// recursively for each of the children of expr, followed by a call of
+// f(nil).
+func Inspect(expr sql.Expression, f func(sql.Expression) bool) {
+	Walk(inspector(f), expr)
+}

--- a/sql/expression/walk_test.go
+++ b/sql/expression/walk_test.go
@@ -1,0 +1,102 @@
+package expression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestWalk(t *testing.T) {
+	lit1 := NewLiteral(1, sql.Int64)
+	lit2 := NewLiteral(2, sql.Int64)
+	col := NewUnresolvedColumn("foo")
+	fn := NewUnresolvedFunction(
+		"bar",
+		false,
+		lit1,
+		lit2,
+	)
+	and := NewAnd(col, fn)
+	e := NewNot(and)
+
+	var f visitor
+	var visited []sql.Expression
+	f = func(node sql.Expression) Visitor {
+		visited = append(visited, node)
+		return f
+	}
+
+	Walk(f, e)
+
+	require.Equal(t,
+		[]sql.Expression{e, and, col, nil, fn, lit1, nil, lit2, nil, nil, nil, nil},
+		visited,
+	)
+
+	visited = nil
+	f = func(node sql.Expression) Visitor {
+		visited = append(visited, node)
+		if _, ok := node.(*UnresolvedFunction); ok {
+			return nil
+		}
+		return f
+	}
+
+	Walk(f, e)
+
+	require.Equal(t,
+		[]sql.Expression{e, and, col, nil, fn, nil, nil},
+		visited,
+	)
+}
+
+type visitor func(sql.Expression) Visitor
+
+func (f visitor) Visit(n sql.Expression) Visitor {
+	return f(n)
+}
+
+func TestInspect(t *testing.T) {
+	lit1 := NewLiteral(1, sql.Int64)
+	lit2 := NewLiteral(2, sql.Int64)
+	col := NewUnresolvedColumn("foo")
+	fn := NewUnresolvedFunction(
+		"bar",
+		false,
+		lit1,
+		lit2,
+	)
+	and := NewAnd(col, fn)
+	e := NewNot(and)
+
+	var f func(sql.Expression) bool
+	var visited []sql.Expression
+	f = func(node sql.Expression) bool {
+		visited = append(visited, node)
+		return true
+	}
+
+	Inspect(e, f)
+
+	require.Equal(t,
+		[]sql.Expression{e, and, col, nil, fn, lit1, nil, lit2, nil, nil, nil, nil},
+		visited,
+	)
+
+	visited = nil
+	f = func(node sql.Expression) bool {
+		visited = append(visited, node)
+		if _, ok := node.(*UnresolvedFunction); ok {
+			return false
+		}
+		return true
+	}
+
+	Inspect(e, f)
+
+	require.Equal(t,
+		[]sql.Expression{e, and, col, nil, fn, nil, nil},
+		visited,
+	)
+}

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -61,6 +61,11 @@ func (p Filter) String() string {
 	return pr.String()
 }
 
+// Expressions implements the Expressioner interface.
+func (p Filter) Expressions() []sql.Expression {
+	return []sql.Expression{p.Expression}
+}
+
 // FilterIter is an iterator that filters another iterator and skips rows that
 // don't match the given condition.
 type FilterIter struct {

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -122,6 +122,14 @@ func (p GroupBy) String() string {
 	return pr.String()
 }
 
+// Expressions implements the Expressioner interface.
+func (p GroupBy) Expressions() []sql.Expression {
+	var exprs []sql.Expression
+	exprs = append(exprs, p.Aggregate...)
+	exprs = append(exprs, p.Grouping...)
+	return exprs
+}
+
 type groupByIter struct {
 	p         *GroupBy
 	childIter sql.RowIter

--- a/sql/plan/innerjoin.go
+++ b/sql/plan/innerjoin.go
@@ -90,3 +90,8 @@ func (j InnerJoin) String() string {
 	_ = pr.WriteChildren(j.Left.String(), j.Right.String())
 	return pr.String()
 }
+
+// Expressions implements the Expressioner interface.
+func (j InnerJoin) Expressions() []sql.Expression {
+	return []sql.Expression{j.Cond}
+}

--- a/sql/plan/project.go
+++ b/sql/plan/project.go
@@ -10,21 +10,21 @@ import (
 type Project struct {
 	UnaryNode
 	// Expression projected.
-	Expressions []sql.Expression
+	Projections []sql.Expression
 }
 
 // NewProject creates a new projection.
 func NewProject(expressions []sql.Expression, child sql.Node) *Project {
 	return &Project{
 		UnaryNode:   UnaryNode{child},
-		Expressions: expressions,
+		Projections: expressions,
 	}
 }
 
 // Schema implements the Node interface.
 func (p *Project) Schema() sql.Schema {
-	var s = make(sql.Schema, len(p.Expressions))
-	for i, e := range p.Expressions {
+	var s = make(sql.Schema, len(p.Projections))
+	for i, e := range p.Projections {
 		var name string
 		if n, ok := e.(sql.Nameable); ok {
 			name = n.Name()
@@ -43,7 +43,7 @@ func (p *Project) Schema() sql.Schema {
 // Resolved implements the Resolvable interface.
 func (p *Project) Resolved() bool {
 	return p.UnaryNode.Child.Resolved() &&
-		expressionsResolved(p.Expressions...)
+		expressionsResolved(p.Projections...)
 }
 
 // RowIter implements the Node interface.
@@ -61,12 +61,12 @@ func (p *Project) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f(NewProject(p.Expressions, child))
+	return f(NewProject(p.Projections, child))
 }
 
 // TransformExpressionsUp implements the Transformable interface.
 func (p *Project) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	exprs, err := transformExpressionsUp(f, p.Expressions)
+	exprs, err := transformExpressionsUp(f, p.Projections)
 	if err != nil {
 		return nil, err
 	}
@@ -81,13 +81,18 @@ func (p *Project) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, err
 
 func (p Project) String() string {
 	pr := sql.NewTreePrinter()
-	var exprs = make([]string, len(p.Expressions))
-	for i, expr := range p.Expressions {
+	var exprs = make([]string, len(p.Projections))
+	for i, expr := range p.Projections {
 		exprs[i] = expr.String()
 	}
 	_ = pr.WriteNode("Project(%s)", strings.Join(exprs, ", "))
 	_ = pr.WriteChildren(p.Child.String())
 	return pr.String()
+}
+
+// Expressions implements the Expressioner interface.
+func (p Project) Expressions() []sql.Expression {
+	return p.Projections
 }
 
 type iter struct {
@@ -101,7 +106,7 @@ func (i *iter) Next() (sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filterRow(i.ctx, i.p.Expressions, childRow)
+	return filterRow(i.ctx, i.p.Projections, childRow)
 }
 
 func (i *iter) Close() error {

--- a/sql/plan/pushdown.go
+++ b/sql/plan/pushdown.go
@@ -135,3 +135,11 @@ func (t PushdownProjectionAndFiltersTable) String() string {
 
 	return pr.String()
 }
+
+// Expressions implements the Expressioner interface.
+func (t PushdownProjectionAndFiltersTable) Expressions() []sql.Expression {
+	var exprs []sql.Expression
+	exprs = append(exprs, t.columns...)
+	exprs = append(exprs, t.filters...)
+	return exprs
+}

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -130,6 +130,15 @@ func (s Sort) String() string {
 	return pr.String()
 }
 
+// Expressions implements the Expressioner interface.
+func (s Sort) Expressions() []sql.Expression {
+	var exprs = make([]sql.Expression, len(s.SortFields))
+	for i, f := range s.SortFields {
+		exprs[i] = f.Column
+	}
+	return exprs
+}
+
 type sortIter struct {
 	s          *Sort
 	childIter  sql.RowIter

--- a/sql/plan/values.go
+++ b/sql/plan/values.go
@@ -98,3 +98,12 @@ func (p *Values) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, erro
 func (p Values) String() string {
 	return fmt.Sprintf("Values(%d tuples)", len(p.ExpressionTuples))
 }
+
+// Expressions implements the Expressioner interface.
+func (p Values) Expressions() []sql.Expression {
+	var exprs []sql.Expression
+	for _, tuple := range p.ExpressionTuples {
+		exprs = append(exprs, tuple...)
+	}
+	return exprs
+}

--- a/sql/plan/walk.go
+++ b/sql/plan/walk.go
@@ -52,40 +52,9 @@ func Inspect(node sql.Node, f func(sql.Node) bool) {
 // expression it finds.
 func WalkExpressions(v expression.Visitor, node sql.Node) {
 	Inspect(node, func(node sql.Node) bool {
-		switch node := node.(type) {
-		case *Project:
-			for _, e := range node.Expressions {
+		if node, ok := node.(sql.Expressioner); ok {
+			for _, e := range node.Expressions() {
 				expression.Walk(v, e)
-			}
-		case *Filter:
-			expression.Walk(v, node.Expression)
-		case *Values:
-			for _, tuple := range node.ExpressionTuples {
-				for _, e := range tuple {
-					expression.Walk(v, e)
-				}
-			}
-		case *PushdownProjectionAndFiltersTable:
-			for _, f := range node.columns {
-				expression.Walk(v, f)
-			}
-
-			for _, f := range node.filters {
-				expression.Walk(v, f)
-			}
-		case *GroupBy:
-			for _, e := range node.Aggregate {
-				expression.Walk(v, e)
-			}
-
-			for _, e := range node.Grouping {
-				expression.Walk(v, e)
-			}
-		case *InnerJoin:
-			expression.Walk(v, node.Cond)
-		case *Sort:
-			for _, f := range node.SortFields {
-				expression.Walk(v, f.Column)
 			}
 		}
 		return true

--- a/sql/plan/walk.go
+++ b/sql/plan/walk.go
@@ -1,0 +1,46 @@
+package plan
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// Visitor visits nodes in the plan.
+type Visitor interface {
+	// Visit method is invoked for each node encountered by Walk.
+	// If the result Visitor is not nul, Walk visits each of the children
+	// of the node with that visitor, followed by a call of Visit(nil)
+	// to the returned visitor.
+	Visit(node sql.Node) Visitor
+}
+
+// Walk traverses the plan tree in depth-first order. It starts by calling
+// v.Visit(node); node must not be nil. If the visitor returned by
+// v.Visit(node) is not nil, Walk is invoked recursively with the returned
+// visitor for each children of the node, followed by a call of v.Visit(nil)
+// to the returned visitor.
+func Walk(v Visitor, node sql.Node) {
+	if v = v.Visit(node); v == nil {
+		return
+	}
+
+	for _, child := range node.Children() {
+		Walk(v, child)
+	}
+
+	v.Visit(nil)
+}
+
+type inspector func(sql.Node) bool
+
+func (f inspector) Visit(node sql.Node) Visitor {
+	if f(node) {
+		return f
+	}
+	return nil
+}
+
+// Inspect traverses the plan in depth-first order: It starts by calling
+// f(node); node must not be nil. If f returns true, Inspect invokes f
+// recursively for each of the children of node, followed by a call of
+// f(nil).
+func Inspect(node sql.Node, f func(sql.Node) bool) {
+	Walk(inspector(f), node)
+}

--- a/sql/plan/walk.go
+++ b/sql/plan/walk.go
@@ -1,6 +1,9 @@
 package plan
 
-import "gopkg.in/src-d/go-mysql-server.v0/sql"
+import (
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
 
 // Visitor visits nodes in the plan.
 type Visitor interface {
@@ -43,4 +46,63 @@ func (f inspector) Visit(node sql.Node) Visitor {
 // f(nil).
 func Inspect(node sql.Node, f func(sql.Node) bool) {
 	Walk(inspector(f), node)
+}
+
+// WalkExpressions traverses the plan and calls expression.Walk on any
+// expression it finds.
+func WalkExpressions(v expression.Visitor, node sql.Node) {
+	Inspect(node, func(node sql.Node) bool {
+		switch node := node.(type) {
+		case *Project:
+			for _, e := range node.Expressions {
+				expression.Walk(v, e)
+			}
+		case *Filter:
+			expression.Walk(v, node.Expression)
+		case *Values:
+			for _, tuple := range node.ExpressionTuples {
+				for _, e := range tuple {
+					expression.Walk(v, e)
+				}
+			}
+		case *PushdownProjectionAndFiltersTable:
+			for _, f := range node.columns {
+				expression.Walk(v, f)
+			}
+
+			for _, f := range node.filters {
+				expression.Walk(v, f)
+			}
+		case *GroupBy:
+			for _, e := range node.Aggregate {
+				expression.Walk(v, e)
+			}
+
+			for _, e := range node.Grouping {
+				expression.Walk(v, e)
+			}
+		case *InnerJoin:
+			expression.Walk(v, node.Cond)
+		case *Sort:
+			for _, f := range node.SortFields {
+				expression.Walk(v, f.Column)
+			}
+		}
+		return true
+	})
+}
+
+// InspectExpressions traverses the plan and calls expression.Inspect on any
+// expression it finds.
+func InspectExpressions(node sql.Node, f func(sql.Expression) bool) {
+	WalkExpressions(exprInspector(f), node)
+}
+
+type exprInspector func(sql.Expression) bool
+
+func (f exprInspector) Visit(e sql.Expression) expression.Visitor {
+	if f(e) {
+		return f
+	}
+	return nil
 }

--- a/sql/plan/walk_test.go
+++ b/sql/plan/walk_test.go
@@ -1,0 +1,90 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestWalk(t *testing.T) {
+	t1 := NewUnresolvedTable("foo")
+	t2 := NewUnresolvedTable("bar")
+	join := NewCrossJoin(t1, t2)
+	filter := NewFilter(nil, join)
+	project := NewProject(nil, filter)
+
+	var f visitor
+	var visited []sql.Node
+	f = func(node sql.Node) Visitor {
+		visited = append(visited, node)
+		return f
+	}
+
+	Walk(f, project)
+
+	require.Equal(t,
+		[]sql.Node{project, filter, join, t1, nil, t2, nil, nil, nil, nil},
+		visited,
+	)
+
+	visited = nil
+	f = func(node sql.Node) Visitor {
+		visited = append(visited, node)
+		if _, ok := node.(*CrossJoin); ok {
+			return nil
+		}
+		return f
+	}
+
+	Walk(f, project)
+
+	require.Equal(t,
+		[]sql.Node{project, filter, join, nil, nil},
+		visited,
+	)
+}
+
+type visitor func(sql.Node) Visitor
+
+func (f visitor) Visit(n sql.Node) Visitor {
+	return f(n)
+}
+
+func TestInspect(t *testing.T) {
+	t1 := NewUnresolvedTable("foo")
+	t2 := NewUnresolvedTable("bar")
+	join := NewCrossJoin(t1, t2)
+	filter := NewFilter(nil, join)
+	project := NewProject(nil, filter)
+
+	var f func(sql.Node) bool
+	var visited []sql.Node
+	f = func(node sql.Node) bool {
+		visited = append(visited, node)
+		return true
+	}
+
+	Inspect(project, f)
+
+	require.Equal(t,
+		[]sql.Node{project, filter, join, t1, nil, t2, nil, nil, nil, nil},
+		visited,
+	)
+
+	visited = nil
+	f = func(node sql.Node) bool {
+		visited = append(visited, node)
+		if _, ok := node.(*CrossJoin); ok {
+			return false
+		}
+		return true
+	}
+
+	Inspect(project, f)
+
+	require.Equal(t,
+		[]sql.Node{project, filter, join, nil, nil},
+		visited,
+	)
+}


### PR DESCRIPTION
Closes #106 
Closes #107 

It only diverges from the original proposal in that it adds `WalkExpressions` and `InspectExpressions` in `plan` package because of the limitation of `Expression`s not being `Node`s.