### PR TITLE
*: implement a configuration mechanism

### DIFF
--- a/benchmark/tpc_h_test.go
+++ b/benchmark/tpc_h_test.go
@@ -1,7 +1,6 @@
 package benchmark
 
 import (
-	"context"
 	"encoding/csv"
 	"io"
 	"io/ioutil"
@@ -47,7 +46,7 @@ func executeQueries(b *testing.B, e *sqle.Engine) error {
 		return err
 	}
 
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	for _, info := range infos {
 		if info.IsDir() {

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"sync"
+
+	errors "gopkg.in/src-d/go-errors.v0"
+)
+
+// Config is a thead-safe container for the application's configuration.
+// The configuration can have a parent configuration to be able to inherit
+// config values from it.
+type Config struct {
+	mu     sync.RWMutex
+	parent *Config
+	kv     map[string]interface{}
+}
+
+// New creates an empty configuration.
+func New() *Config {
+	return &Config{kv: make(map[string]interface{})}
+}
+
+// FromConfig creates a new configuration from the given parent. This parent
+// will be used only to read and will never be modified.
+func FromConfig(c *Config) *Config {
+	return &Config{parent: c, kv: make(map[string]interface{})}
+}
+
+func (c *Config) set(k string, v interface{}) {
+	c.mu.Lock()
+	c.kv[k] = v
+	c.mu.Unlock()
+}
+
+func (c *Config) get(k string) (interface{}, bool) {
+	c.mu.RLock()
+	v, ok := c.kv[k]
+	c.mu.RUnlock()
+
+	if !ok && c.parent != nil {
+		return c.parent.get(k)
+	}
+
+	return v, ok
+}
+
+// SetString stores a string value at key k.
+func (c *Config) SetString(k string, v string) {
+	c.set(k, v)
+}
+
+// SetInt stores an int64 value at key k.
+func (c *Config) SetInt(k string, v int64) {
+	c.set(k, v)
+}
+
+// SetBool stores a bool value at key k.
+func (c *Config) SetBool(k string, v bool) {
+	c.set(k, v)
+}
+
+// SetFloat stores a float64 value at key k.
+func (c *Config) SetFloat(k string, v float64) {
+	c.set(k, v)
+}
+
+// SetStringSlice stores a []string value at key k.
+func (c *Config) SetStringSlice(k string, v ...string) {
+	c.set(k, v)
+}
+
+// ErrInvalidType is returned when the type of the config value does not
+// match with the requested type.
+var ErrInvalidType = errors.NewKind("config: value is of type %T instead of %T for key %q")
+
+// String returns the string value for the given key.
+func (c *Config) String(k string, defaultValue string) (string, error) {
+	v, ok := c.get(k)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	if _, ok := v.(string); !ok {
+		return "", ErrInvalidType.New(v, defaultValue, k)
+	}
+
+	return v.(string), nil
+}
+
+// Int returns the int64 value for the given key.
+func (c *Config) Int(k string, defaultValue int64) (int64, error) {
+	v, ok := c.get(k)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	if _, ok := v.(int64); !ok {
+		return 0, ErrInvalidType.New(v, defaultValue, k)
+	}
+
+	return v.(int64), nil
+}
+
+// Bool returns the bool value for the given key.
+func (c *Config) Bool(k string, defaultValue bool) (bool, error) {
+	v, ok := c.get(k)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	if _, ok := v.(bool); !ok {
+		return false, ErrInvalidType.New(v, defaultValue, k)
+	}
+
+	return v.(bool), nil
+}
+
+// Float returns the float64 value for the given key.
+func (c *Config) Float(k string, defaultValue float64) (float64, error) {
+	v, ok := c.get(k)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	if _, ok := v.(float64); !ok {
+		return .0, ErrInvalidType.New(v, defaultValue, k)
+	}
+
+	return v.(float64), nil
+}
+
+// StringSlice returns the []string value for the given key.
+func (c *Config) StringSlice(k string, defaultValue []string) ([]string, error) {
+	v, ok := c.get(k)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	if _, ok := v.([]string); !ok {
+		return nil, ErrInvalidType.New(v, defaultValue, k)
+	}
+
+	return v.([]string), nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -142,3 +142,8 @@ func (c *Config) StringSlice(k string, defaultValue []string) ([]string, error) 
 
 	return v.([]string), nil
 }
+
+// Parent returns the parent config.
+func (c *Config) Parent() *Config {
+	return c.parent
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestString(t *testing.T) {
+	require := require.New(t)
+	cfg := config()
+
+	v, err := cfg.String("string", "default")
+	require.NoError(err)
+	require.Equal("foo", v)
+
+	v, err = cfg.String("missing", "default")
+	require.NoError(err)
+	require.Equal("default", v)
+
+	cfg.SetString("string", "overridden")
+	v, err = cfg.String("string", "default")
+	require.NoError(err)
+	require.Equal("overridden", v)
+
+	_, err = cfg.String("int", "default")
+	require.Error(err)
+	require.True(ErrInvalidType.Is(err))
+}
+
+func TestInt(t *testing.T) {
+	require := require.New(t)
+	cfg := config()
+
+	v, err := cfg.Int("int", 3)
+	require.NoError(err)
+	require.Equal(int64(1), v)
+
+	v, err = cfg.Int("missing", 3)
+	require.NoError(err)
+	require.Equal(int64(3), v)
+
+	cfg.SetInt("int", 2)
+	v, err = cfg.Int("int", 3)
+	require.NoError(err)
+	require.Equal(int64(2), v)
+
+	_, err = cfg.Int("string", 1)
+	require.Error(err)
+	require.True(ErrInvalidType.Is(err))
+}
+
+func TestFloat(t *testing.T) {
+	require := require.New(t)
+	cfg := config()
+
+	v, err := cfg.Float("float", 3.)
+	require.NoError(err)
+	require.Equal(float64(3.14), v)
+
+	v, err = cfg.Float("missing", 3.)
+	require.NoError(err)
+	require.Equal(float64(3.), v)
+
+	cfg.SetFloat("float", 2.)
+	v, err = cfg.Float("float", 3.)
+	require.NoError(err)
+	require.Equal(float64(2.), v)
+
+	_, err = cfg.Float("int", 3.15)
+	require.Error(err)
+	require.True(ErrInvalidType.Is(err))
+}
+
+func TestBool(t *testing.T) {
+	require := require.New(t)
+	cfg := config()
+
+	v, err := cfg.Bool("bool", false)
+	require.NoError(err)
+	require.Equal(true, v)
+
+	v, err = cfg.Bool("missing", false)
+	require.NoError(err)
+	require.Equal(false, v)
+
+	cfg.SetBool("bool", false)
+	v, err = cfg.Bool("bool", true)
+	require.NoError(err)
+	require.Equal(false, v)
+
+	_, err = cfg.Bool("int", false)
+	require.Error(err)
+	require.True(ErrInvalidType.Is(err))
+}
+
+func TestStringSlice(t *testing.T) {
+	var empty []string
+	require := require.New(t)
+	cfg := config()
+
+	v, err := cfg.StringSlice("slice", empty)
+	require.NoError(err)
+	require.Equal([]string{"a", "b", "c"}, v)
+
+	v, err = cfg.StringSlice("missing", empty)
+	require.NoError(err)
+	require.Equal(empty, v)
+
+	cfg.SetStringSlice("slice", "a", "b")
+	v, err = cfg.StringSlice("slice", empty)
+	require.NoError(err)
+	require.Equal([]string{"a", "b"}, v)
+
+	_, err = cfg.StringSlice("int", empty)
+	require.Error(err)
+	require.True(ErrInvalidType.Is(err))
+}
+
+func config() *Config {
+	parent := New()
+	parent.SetString("string", "foo")
+	parent.SetInt("int", 1)
+	parent.SetFloat("float", 3.14)
+	parent.SetBool("bool", true)
+	parent.SetStringSlice("slice", "a", "b", "c")
+	return FromConfig(parent)
+}

--- a/engine.go
+++ b/engine.go
@@ -1,6 +1,7 @@
 package sqle
 
 import (
+	"gopkg.in/src-d/go-mysql-server.v0/config"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression/function"
@@ -9,6 +10,7 @@ import (
 
 // Engine is a SQL engine.
 type Engine struct {
+	Config   *config.Config
 	Catalog  *sql.Catalog
 	Analyzer *analyzer.Analyzer
 }
@@ -19,7 +21,7 @@ func New() *Engine {
 	c.RegisterFunctions(function.Defaults)
 
 	a := analyzer.New(c)
-	return &Engine{c, a}
+	return &Engine{config.New(), c, a}
 }
 
 // Query executes a query without attaching to any context.

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,7 +1,6 @@
 package sqle_test
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -257,7 +256,7 @@ func TestAmbiguousColumnResolution(t *testing.T) {
 	e.AddDatabase(db)
 
 	q := `SELECT f.a, bar.b, f.b FROM foo f INNER JOIN bar ON f.a = bar.c`
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	_, rows, err := e.Query(ctx, q)
 	require.NoError(err)
@@ -313,9 +312,9 @@ func TestDDL(t *testing.T) {
 func testQuery(t *testing.T, e *sqle.Engine, q string, r [][]interface{}) {
 	t.Run(q, func(t *testing.T) {
 		require := require.New(t)
-		session := sql.NewContext(context.TODO(), sql.NewBaseSession())
+		ctx := sql.NewEmptyContext()
 
-		_, rows, err := e.Query(session, q)
+		_, rows, err := e.Query(ctx, q)
 		require.NoError(err)
 
 		var rs [][]interface{}

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,10 +1,12 @@
 package sqle_test
 
 import (
+	"context"
 	"io"
 	"testing"
 
 	"gopkg.in/src-d/go-mysql-server.v0"
+	"gopkg.in/src-d/go-mysql-server.v0/config"
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/parse"
@@ -210,6 +212,22 @@ func TestQueries(t *testing.T) {
 			{"third row"},
 		},
 	)
+
+	testQuery(t, e,
+		"SET SESSION a='foo', b=true",
+		[][]interface{}{
+			{"a", "foo"},
+			{"b", true},
+		},
+	)
+
+	testQuery(t, e,
+		"SET GLOBAL a='foo', b=true",
+		[][]interface{}{
+			{"a", "foo"},
+			{"b", true},
+		},
+	)
 }
 
 func TestInsertInto(t *testing.T) {
@@ -312,7 +330,14 @@ func TestDDL(t *testing.T) {
 func testQuery(t *testing.T, e *sqle.Engine, q string, r [][]interface{}) {
 	t.Run(q, func(t *testing.T) {
 		require := require.New(t)
-		ctx := sql.NewEmptyContext()
+		ctx := sql.NewContext(
+			context.TODO(),
+			sql.NewBaseSession(
+				config.FromConfig(
+					config.New(),
+				),
+			),
+		)
 
 		_, rows, err := e.Query(ctx, q)
 		require.NoError(err)

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,6 @@
 package sqle_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -12,7 +11,7 @@ import (
 
 func Example() {
 	e := sqle.New()
-	ctx := gitqlsql.NewContext(context.TODO(), gitqlsql.NewBaseSession())
+	ctx := gitqlsql.NewEmptyContext()
 
 	// Create a test memory database and register it to the default engine.
 	e.AddDatabase(createTestDatabase())

--- a/mem/table_test.go
+++ b/mem/table_test.go
@@ -1,7 +1,6 @@
 package mem
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,8 +32,7 @@ func TestTableString(t *testing.T) {
 
 func TestTable_Insert_RowIter(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
+	ctx := sql.NewEmptyContext()
 	s := sql.Schema{
 		{"col1", sql.Text, nil, true, ""},
 	}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -37,7 +37,7 @@ func TestHandlerOutput(t *testing.T) {
 
 	dummyConn := &mysql.Conn{ConnectionID: 1}
 
-	handler := NewHandler(e, NewSessionManager(DefaultSessionBuilder))
+	handler := NewHandler(e, NewSessionManager(e.Config, DefaultSessionBuilder))
 
 	c := 0
 	var lastRowsAffected uint64

--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,7 @@ func NewDefaultServer(
 // NewServer creates a server with the given protocol, address, authentication
 // details given a SQLe engine and a session builder.
 func NewServer(protocol, address string, auth mysql.AuthServer, e *sqle.Engine, sb SessionBuilder) (*Server, error) {
-	handler := NewHandler(e, NewSessionManager(sb))
+	handler := NewHandler(e, NewSessionManager(e.Config, sb))
 	l, err := mysql.NewListener(protocol, address, auth, handler)
 	if err != nil {
 		return nil, err

--- a/sql/expression/between_test.go
+++ b/sql/expression/between_test.go
@@ -1,7 +1,6 @@
 package expression
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,9 +35,8 @@ func TestBetween(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
-			result, err := b.Eval(ctx, tt.row)
+			result, err := b.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {

--- a/sql/expression/common_test.go
+++ b/sql/expression/common_test.go
@@ -1,7 +1,6 @@
 package expression
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,10 +8,8 @@ import (
 )
 
 func eval(t *testing.T, e sql.Expression, row sql.Row) interface{} {
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 	t.Helper()
-	v, err := e.Eval(ctx, row)
+	v, err := e.Eval(sql.NewEmptyContext(), row)
 	require.NoError(t, err)
 	return v
 }

--- a/sql/expression/convert_test.go
+++ b/sql/expression/convert_test.go
@@ -1,7 +1,6 @@
 package expression
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -10,11 +9,8 @@ import (
 )
 
 func TestConvert(t *testing.T) {
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 	tests := []struct {
 		name        string
-		ctx         *sql.Context
 		row         sql.Row
 		expression  sql.Expression
 		castTo      string
@@ -23,7 +19,6 @@ func TestConvert(t *testing.T) {
 	}{
 		{
 			name:        "convert int32 to signed",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral(int32(1), sql.Int32),
 			castTo:      ConvertToSigned,
@@ -32,7 +27,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "convert int32 to unsigned",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral(int32(-5), sql.Int32),
 			castTo:      ConvertToUnsigned,
@@ -41,7 +35,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "convert string to signed",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral("-3", sql.Text),
 			castTo:      ConvertToSigned,
@@ -50,7 +43,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "convert string to unsigned",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral("-3", sql.Int32),
 			castTo:      ConvertToUnsigned,
@@ -59,7 +51,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "convert int to string",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral(-3, sql.Int32),
 			castTo:      ConvertToChar,
@@ -68,7 +59,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "impossible conversion string to unsigned",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral("hello", sql.Text),
 			castTo:      ConvertToUnsigned,
@@ -77,7 +67,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "imposible conversion string to signed",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToSigned,
 			expression:  NewLiteral("A", sql.Text),
@@ -86,7 +75,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "string to datetime",
-			ctx:         ctx,
 			row:         nil,
 			expression:  NewLiteral("2017-12-12", sql.Text),
 			castTo:      ConvertToDatetime,
@@ -95,7 +83,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "impossible conversion string to datetime",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToDatetime,
 			expression:  NewLiteral(1, sql.Int32),
@@ -104,7 +91,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "string to date",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToDate,
 			expression:  NewLiteral("2017-12-12 11:12:13", sql.Int32),
@@ -113,7 +99,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "impossible conversion string to date",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToDate,
 			expression:  NewLiteral(1, sql.Int32),
@@ -122,7 +107,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "float to binary",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToBinary,
 			expression:  NewLiteral(float64(-2.3), sql.Float64),
@@ -131,7 +115,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "string to json",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToJSON,
 			expression:  NewLiteral(`{"a":2}`, sql.Text),
@@ -140,7 +123,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "int to json",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToJSON,
 			expression:  NewLiteral(2, sql.Int32),
@@ -149,7 +131,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "imposible conversion string to json",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToJSON,
 			expression:  NewLiteral("3>2", sql.Text),
@@ -158,7 +139,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "bool to signed",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToSigned,
 			expression:  NewLiteral(true, sql.Boolean),
@@ -167,7 +147,6 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "bool to datetime",
-			ctx:         ctx,
 			row:         nil,
 			castTo:      ConvertToDatetime,
 			expression:  NewLiteral(true, sql.Boolean),
@@ -180,7 +159,7 @@ func TestConvert(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 			convert := NewConvert(test.expression, test.castTo)
-			val, err := convert.Eval(test.ctx, test.row)
+			val, err := convert.Eval(nil, test.row)
 			if test.expectedErr {
 				require.Error(err)
 			} else {

--- a/sql/expression/function/aggregation/avg_test.go
+++ b/sql/expression/function/aggregation/avg_test.go
@@ -1,7 +1,6 @@
 package aggregation
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,88 +17,83 @@ func TestAvg_String(t *testing.T) {
 
 func TestAvg_Eval_INT32(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Int32, "col1", true))
 	buffer := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer))
+	require.Zero(avgNode.Eval(nil, buffer))
 
-	avgNode.Update(ctx, buffer, sql.NewRow(int32(1)))
+	avgNode.Update(nil, buffer, sql.NewRow(int32(1)))
 	require.Equal(float64(1), eval(t, avgNode, buffer))
 
-	avgNode.Update(ctx, buffer, sql.NewRow(int32(2)))
+	avgNode.Update(nil, buffer, sql.NewRow(int32(2)))
 	require.Equal(float64(1.5), eval(t, avgNode, buffer))
 }
 
 func TestAvg_Eval_UINT64(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Uint64, "col1", true))
 	buffer := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer))
+	require.Zero(avgNode.Eval(nil, buffer))
 
-	err := avgNode.Update(ctx, buffer, sql.NewRow(uint64(1)))
+	err := avgNode.Update(nil, buffer, sql.NewRow(uint64(1)))
 	require.NoError(err)
 	require.Equal(float64(1), eval(t, avgNode, buffer))
 
-	err = avgNode.Update(ctx, buffer, sql.NewRow(uint64(2)))
+	err = avgNode.Update(nil, buffer, sql.NewRow(uint64(2)))
 	require.NoError(err)
 	require.Equal(float64(1.5), eval(t, avgNode, buffer))
 }
 
 func TestAvg_Eval_NoNum(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Text, "col1", true))
 	buffer := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer))
+	require.Zero(avgNode.Eval(nil, buffer))
 
-	err := avgNode.Update(ctx, buffer, sql.NewRow("foo"))
+	err := avgNode.Update(nil, buffer, sql.NewRow("foo"))
 	require.NoError(err)
 	require.Equal(float64(0), eval(t, avgNode, buffer))
 }
 
 func TestAvg_Merge(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Float32, "col1", true))
 	require.NotNil(avgNode)
 
 	buffer1 := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer1))
-	err := avgNode.Update(ctx, buffer1, sql.NewRow(float32(1)))
+	require.Zero(avgNode.Eval(nil, buffer1))
+	err := avgNode.Update(nil, buffer1, sql.NewRow(float32(1)))
 	require.NoError(err)
-	err = avgNode.Update(ctx, buffer1, sql.NewRow(float32(4)))
+	err = avgNode.Update(nil, buffer1, sql.NewRow(float32(4)))
 	require.NoError(err)
 	require.Equal(float64(2.5), eval(t, avgNode, buffer1))
 
 	buffer2 := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer2))
-	err = avgNode.Update(ctx, buffer2, sql.NewRow(float32(2)))
+	require.Zero(avgNode.Eval(nil, buffer2))
+	err = avgNode.Update(nil, buffer2, sql.NewRow(float32(2)))
 	require.NoError(err)
-	err = avgNode.Update(ctx, buffer2, sql.NewRow(float32(7)))
+	err = avgNode.Update(nil, buffer2, sql.NewRow(float32(7)))
 	require.NoError(err)
-	err = avgNode.Update(ctx, buffer2, sql.NewRow(float32(12)))
+	err = avgNode.Update(nil, buffer2, sql.NewRow(float32(12)))
 	require.NoError(err)
 	require.Equal(float64(7), eval(t, avgNode, buffer2))
 
-	err = avgNode.Merge(ctx, buffer1, buffer2)
+	err = avgNode.Merge(nil, buffer1, buffer2)
 	require.NoError(err)
 	require.Equal(float64(5.2), eval(t, avgNode, buffer1))
 }
 
 func TestAvg_NULL(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Uint64, "col1", true))
 	buffer := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(ctx, buffer))
+	require.Zero(avgNode.Eval(nil, buffer))
 
-	err := avgNode.Update(ctx, buffer, sql.NewRow(nil))
+	err := avgNode.Update(nil, buffer, sql.NewRow(nil))
 	require.NoError(err)
 	require.Equal(nil, eval(t, avgNode, buffer))
 }

--- a/sql/expression/function/aggregation/common_test.go
+++ b/sql/expression/function/aggregation/common_test.go
@@ -1,7 +1,6 @@
 package aggregation
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,10 +8,8 @@ import (
 )
 
 func eval(t *testing.T, e sql.Expression, row sql.Row) interface{} {
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 	t.Helper()
-	v, err := e.Eval(ctx, row)
+	v, err := e.Eval(sql.NewEmptyContext(), row)
 	require.NoError(t, err)
 	return v
 }

--- a/sql/expression/function/aggregation/count_test.go
+++ b/sql/expression/function/aggregation/count_test.go
@@ -1,7 +1,6 @@
 package aggregation
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,66 +10,62 @@ import (
 
 func TestCount_String(t *testing.T) {
 	require := require.New(t)
-
 	c := NewCount(expression.NewLiteral("foo", sql.Text))
 	require.Equal(`COUNT("foo")`, c.String())
 }
 
 func TestCount_Eval_1(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	c := NewCount(expression.NewLiteral(1, sql.Int32))
 	b := c.NewBuffer()
 	require.Equal(int32(0), eval(t, c, b))
 
-	require.NoError(c.Update(ctx, b, nil))
-	require.NoError(c.Update(ctx, b, sql.NewRow("foo")))
-	require.NoError(c.Update(ctx, b, sql.NewRow(1)))
-	require.NoError(c.Update(ctx, b, sql.NewRow(nil)))
-	require.NoError(c.Update(ctx, b, sql.NewRow(1, 2, 3)))
+	require.NoError(c.Update(nil, b, nil))
+	require.NoError(c.Update(nil, b, sql.NewRow("foo")))
+	require.NoError(c.Update(nil, b, sql.NewRow(1)))
+	require.NoError(c.Update(nil, b, sql.NewRow(nil)))
+	require.NoError(c.Update(nil, b, sql.NewRow(1, 2, 3)))
 	require.Equal(int32(5), eval(t, c, b))
 
 	b2 := c.NewBuffer()
-	require.NoError(c.Update(ctx, b2, nil))
-	require.NoError(c.Update(ctx, b2, sql.NewRow("foo")))
-	require.NoError(c.Merge(ctx, b, b2))
+	require.NoError(c.Update(nil, b2, nil))
+	require.NoError(c.Update(nil, b2, sql.NewRow("foo")))
+	require.NoError(c.Merge(nil, b, b2))
 	require.Equal(int32(7), eval(t, c, b))
 }
 
 func TestCount_Eval_Star(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	c := NewCount(expression.NewStar())
 	b := c.NewBuffer()
 	require.Equal(int32(0), eval(t, c, b))
 
-	c.Update(ctx, b, nil)
-	c.Update(ctx, b, sql.NewRow("foo"))
-	c.Update(ctx, b, sql.NewRow(1))
-	c.Update(ctx, b, sql.NewRow(nil))
-	c.Update(ctx, b, sql.NewRow(1, 2, 3))
+	c.Update(nil, b, nil)
+	c.Update(nil, b, sql.NewRow("foo"))
+	c.Update(nil, b, sql.NewRow(1))
+	c.Update(nil, b, sql.NewRow(nil))
+	c.Update(nil, b, sql.NewRow(1, 2, 3))
 	require.Equal(int32(5), eval(t, c, b))
 
 	b2 := c.NewBuffer()
-	c.Update(ctx, b2, sql.NewRow())
-	c.Update(ctx, b2, sql.NewRow("foo"))
-	c.Merge(ctx, b, b2)
+	c.Update(nil, b2, sql.NewRow())
+	c.Update(nil, b2, sql.NewRow("foo"))
+	c.Merge(nil, b, b2)
 	require.Equal(int32(7), eval(t, c, b))
 }
 
 func TestCount_Eval_String(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	c := NewCount(expression.NewGetField(0, sql.Text, "", true))
 	b := c.NewBuffer()
 	require.Equal(int32(0), eval(t, c, b))
 
-	c.Update(ctx, b, sql.NewRow("foo"))
+	c.Update(nil, b, sql.NewRow("foo"))
 	require.Equal(int32(1), eval(t, c, b))
 
-	c.Update(ctx, b, sql.NewRow(nil))
+	c.Update(nil, b, sql.NewRow(nil))
 	require.Equal(int32(1), eval(t, c, b))
 }

--- a/sql/expression/function/aggregation/max_test.go
+++ b/sql/expression/function/aggregation/max_test.go
@@ -1,7 +1,6 @@
 package aggregation
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -18,39 +17,36 @@ func TestMax_String(t *testing.T) {
 
 func TestMax_Eval_Int32(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMax(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow(int32(7)))
-	m.Update(ctx, b, sql.NewRow(nil))
-	m.Update(ctx, b, sql.NewRow(int32(6)))
+	m.Update(nil, b, sql.NewRow(int32(7)))
+	m.Update(nil, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(int32(6)))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(int32(7), v)
 }
 
 func TestMax_Eval_Text(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMax(expression.NewGetField(0, sql.Text, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow("a"))
-	m.Update(ctx, b, sql.NewRow("A"))
-	m.Update(ctx, b, sql.NewRow("b"))
+	m.Update(nil, b, sql.NewRow("a"))
+	m.Update(nil, b, sql.NewRow("A"))
+	m.Update(nil, b, sql.NewRow("b"))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal("b", v)
 }
 
 func TestMax_Eval_Timestamp(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMax(expression.NewGetField(0, sql.Timestamp, "field", true))
 	b := m.NewBuffer()
@@ -59,38 +55,36 @@ func TestMax_Eval_Timestamp(t *testing.T) {
 	someTime, _ := time.Parse(sql.TimestampLayout, "2007-01-02 15:04:05")
 	otherTime, _ := time.Parse(sql.TimestampLayout, "2006-01-02 15:04:05")
 
-	m.Update(ctx, b, sql.NewRow(someTime))
-	m.Update(ctx, b, sql.NewRow(expected))
-	m.Update(ctx, b, sql.NewRow(otherTime))
+	m.Update(nil, b, sql.NewRow(someTime))
+	m.Update(nil, b, sql.NewRow(expected))
+	m.Update(nil, b, sql.NewRow(otherTime))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(expected, v)
 }
 func TestMax_Eval_NULL(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMax(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow(nil))
-	m.Update(ctx, b, sql.NewRow(nil))
-	m.Update(ctx, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(nil, v)
 }
 
 func TestMax_Eval_Empty(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMax(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(nil, v)
 }

--- a/sql/expression/function/aggregation/min_test.go
+++ b/sql/expression/function/aggregation/min_test.go
@@ -1,7 +1,6 @@
 package aggregation
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,39 +18,36 @@ func TestMin_Name(t *testing.T) {
 
 func TestMin_Eval_Int32(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMin(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow(int32(7)))
-	m.Update(ctx, b, sql.NewRow(int32(2)))
-	m.Update(ctx, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(int32(7)))
+	m.Update(nil, b, sql.NewRow(int32(2)))
+	m.Update(nil, b, sql.NewRow(nil))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(int32(2), v)
 }
 
 func TestMin_Eval_Text(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMin(expression.NewGetField(0, sql.Text, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow("a"))
-	m.Update(ctx, b, sql.NewRow("A"))
-	m.Update(ctx, b, sql.NewRow("b"))
+	m.Update(nil, b, sql.NewRow("a"))
+	m.Update(nil, b, sql.NewRow("A"))
+	m.Update(nil, b, sql.NewRow("b"))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal("A", v)
 }
 
 func TestMin_Eval_Timestamp(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMin(expression.NewGetField(0, sql.Timestamp, "field", true))
 	b := m.NewBuffer()
@@ -60,39 +56,37 @@ func TestMin_Eval_Timestamp(t *testing.T) {
 	someTime, _ := time.Parse(sql.TimestampLayout, "2007-01-02 15:04:05")
 	otherTime, _ := time.Parse(sql.TimestampLayout, "2008-01-02 15:04:05")
 
-	m.Update(ctx, b, sql.NewRow(someTime))
-	m.Update(ctx, b, sql.NewRow(expected))
-	m.Update(ctx, b, sql.NewRow(otherTime))
+	m.Update(nil, b, sql.NewRow(someTime))
+	m.Update(nil, b, sql.NewRow(expected))
+	m.Update(nil, b, sql.NewRow(otherTime))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(expected, v)
 }
 
 func TestMin_Eval_NULL(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMin(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	m.Update(ctx, b, sql.NewRow(nil))
-	m.Update(ctx, b, sql.NewRow(nil))
-	m.Update(ctx, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
+	m.Update(nil, b, sql.NewRow(nil))
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(nil, v)
 }
 
 func TestMin_Eval_Empty(t *testing.T) {
 	assert := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	m := NewMin(expression.NewGetField(0, sql.Int32, "field", true))
 	b := m.NewBuffer()
 
-	v, err := m.Eval(ctx, b)
+	v, err := m.Eval(nil, b)
 	assert.NoError(err)
 	assert.Equal(nil, v)
 }

--- a/sql/expression/function/common_test.go
+++ b/sql/expression/function/common_test.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,10 +8,8 @@ import (
 )
 
 func eval(t *testing.T, e sql.Expression, row sql.Row) interface{} {
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 	t.Helper()
-	v, err := e.Eval(ctx, row)
+	v, err := e.Eval(sql.NewEmptyContext(), row)
 	require.NoError(t, err)
 	return v
 }

--- a/sql/expression/function/substring_test.go
+++ b/sql/expression/function/substring_test.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,9 +39,8 @@ func TestSubstring(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
-			v, err := f.Eval(ctx, tt.row)
+			v, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {

--- a/sql/expression/function/time_test.go
+++ b/sql/expression/function/time_test.go
@@ -1,7 +1,6 @@
 package function
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -17,7 +16,6 @@ const (
 
 func TestTime_Year(t *testing.T) {
 	f := NewYear(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -35,7 +33,7 @@ func TestTime_Year(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -48,7 +46,6 @@ func TestTime_Year(t *testing.T) {
 
 func TestTime_Month(t *testing.T) {
 	f := NewMonth(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -66,7 +63,7 @@ func TestTime_Month(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -79,7 +76,6 @@ func TestTime_Month(t *testing.T) {
 
 func TestTime_Day(t *testing.T) {
 	f := NewDay(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -97,7 +93,7 @@ func TestTime_Day(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -110,7 +106,6 @@ func TestTime_Day(t *testing.T) {
 
 func TestTime_Hour(t *testing.T) {
 	f := NewHour(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -128,7 +123,7 @@ func TestTime_Hour(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -141,7 +136,6 @@ func TestTime_Hour(t *testing.T) {
 
 func TestTime_Minute(t *testing.T) {
 	f := NewMinute(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -159,7 +153,7 @@ func TestTime_Minute(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -172,7 +166,6 @@ func TestTime_Minute(t *testing.T) {
 
 func TestTime_Second(t *testing.T) {
 	f := NewSecond(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 	testCases := []struct {
 		name     string
 		row      sql.Row
@@ -189,7 +182,7 @@ func TestTime_Second(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {
@@ -202,7 +195,6 @@ func TestTime_Second(t *testing.T) {
 
 func TestTime_DayOfYear(t *testing.T) {
 	f := NewDayOfYear(expression.NewGetField(0, sql.Text, "foo", false))
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
 
 	testCases := []struct {
 		name     string
@@ -220,7 +212,7 @@ func TestTime_DayOfYear(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			val, err := f.Eval(ctx, tt.row)
+			val, err := f.Eval(nil, tt.row)
 			if tt.err {
 				require.Error(err)
 			} else {

--- a/sql/expression/logic_test.go
+++ b/sql/expression/logic_test.go
@@ -1,7 +1,6 @@
 package expression
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,12 +27,10 @@ func TestAnd(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 			result, err := NewAnd(
 				NewLiteral(tt.left, sql.Boolean),
 				NewLiteral(tt.right, sql.Boolean),
-			).Eval(ctx, sql.NewRow())
+			).Eval(nil, sql.NewRow())
 			require.NoError(err)
 			require.Equal(tt.expected, result)
 		})
@@ -58,12 +55,10 @@ func TestOr(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
-
 			result, err := NewOr(
 				NewLiteral(tt.left, sql.Boolean),
 				NewLiteral(tt.right, sql.Boolean),
-			).Eval(ctx, sql.NewRow())
+			).Eval(nil, sql.NewRow())
 			require.NoError(err)
 			require.Equal(tt.expected, result)
 		})

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -478,6 +478,20 @@ var fixtures = map[string]sql.Node{
 			plan.NewUnresolvedTable("foo"),
 		),
 	),
+	`SET SESSION a=1, b=true`: plan.NewSet(
+		plan.SessionScope,
+		[]plan.Update{
+			{Name: "a", Value: expression.NewLiteral(int64(1), sql.Int64)},
+			{Name: "b", Value: expression.NewLiteral(true, sql.Boolean)},
+		},
+	),
+	`SET GLOBAL a=1, b=true`: plan.NewSet(
+		plan.GlobalScope,
+		[]plan.Update{
+			{Name: "a", Value: expression.NewLiteral(int64(1), sql.Int64)},
+			{Name: "b", Value: expression.NewLiteral(true, sql.Boolean)},
+		},
+	),
 }
 
 func TestParse(t *testing.T) {
@@ -508,4 +522,8 @@ func TestParseErrors(t *testing.T) {
 			require.Equal(expectedError.Error(), err.Error())
 		})
 	}
+}
+
+func TestTest(t *testing.T) {
+	Parse(nil, "SET A=1")
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1,7 +1,6 @@
 package parse
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -485,7 +484,7 @@ func TestParse(t *testing.T) {
 	for query, expectedPlan := range fixtures {
 		t.Run(query, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+			ctx := sql.NewEmptyContext()
 			p, err := Parse(ctx, query)
 			require.Nil(err, "error for query '%s'", query)
 			require.Exactly(expectedPlan, p,
@@ -503,7 +502,7 @@ func TestParseErrors(t *testing.T) {
 	for query, expectedError := range fixturesErrors {
 		t.Run(query, func(t *testing.T) {
 			require := require.New(t)
-			ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+			ctx := sql.NewEmptyContext()
 			_, err := Parse(ctx, query)
 			require.Error(err)
 			require.Equal(expectedError.Error(), err.Error())

--- a/sql/plan/common_test.go
+++ b/sql/plan/common_test.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -86,7 +85,7 @@ func assertRows(t *testing.T, iter sql.RowIter, expected int64) {
 
 func collectRows(t *testing.T, node sql.Node) []sql.Row {
 	t.Helper()
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	iter, err := node.RowIter(ctx)
 	require.NoError(t, err)

--- a/sql/plan/cross_join_test.go
+++ b/sql/plan/cross_join_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -26,7 +25,7 @@ var rSchema = sql.Schema{
 
 func TestCrossJoin(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	resultSchema := sql.Schema{
 		{Name: "lcol1", Type: sql.Text},
@@ -95,7 +94,7 @@ func TestCrossJoin(t *testing.T) {
 
 func TestCrossJoin_Empty(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	ltable := mem.NewTable("left", lSchema)
 	rtable := mem.NewTable("right", rSchema)

--- a/sql/plan/ddl_test.go
+++ b/sql/plan/ddl_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestCreateTable(t *testing.T) {
 
 	c := NewCreateTable(db, "testTable", s)
 
-	rows, err := c.RowIter(sql.NewContext(context.TODO(), sql.NewBaseSession()))
+	rows, err := c.RowIter(sql.NewEmptyContext())
 
 	require.NoError(err)
 

--- a/sql/plan/describe_test.go
+++ b/sql/plan/describe_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 
 func TestDescribe(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	table := mem.NewTable("test", sql.Schema{
 		{Name: "c1", Type: sql.Text},
@@ -39,7 +38,7 @@ func TestDescribe(t *testing.T) {
 
 func TestDescribe_Empty(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	d := NewDescribe(NewUnresolvedTable("test_table"))
 

--- a/sql/plan/distinct_test.go
+++ b/sql/plan/distinct_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 
 func TestDistinct(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	childSchema := sql.Schema{
 		{Name: "name", Type: sql.Text, Nullable: true},
@@ -53,7 +52,7 @@ func TestDistinct(t *testing.T) {
 
 func TestOrderedDistinct(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	childSchema := sql.Schema{
 		{Name: "name", Type: sql.Text, Nullable: true},
@@ -93,7 +92,7 @@ func TestOrderedDistinct(t *testing.T) {
 
 func BenchmarkDistinct(b *testing.B) {
 	require := require.New(b)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	for i := 0; i < b.N; i++ {
 		p := NewProject([]sql.Expression{
@@ -126,7 +125,7 @@ func BenchmarkDistinct(b *testing.B) {
 
 func BenchmarkOrderedDistinct(b *testing.B) {
 	require := require.New(b)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	for i := 0; i < b.N; i++ {
 		p := NewProject([]sql.Expression{

--- a/sql/plan/filter_test.go
+++ b/sql/plan/filter_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +11,7 @@ import (
 
 func TestFilter(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	childSchema := sql.Schema{
 		{Name: "col1", Type: sql.Text, Nullable: true},

--- a/sql/plan/group_by_test.go
+++ b/sql/plan/group_by_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,7 +44,7 @@ func TestGroupBy_Resolved(t *testing.T) {
 
 func TestGroupBy_RowIter(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	childSchema := sql.Schema{
 		{Name: "col1", Type: sql.Text},
@@ -92,7 +91,7 @@ func TestGroupBy_RowIter(t *testing.T) {
 
 func TestGroupBy_Error(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	childSchema := sql.Schema{
 		{Name: "col1", Type: sql.Text},

--- a/sql/plan/innerjoin_test.go
+++ b/sql/plan/innerjoin_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,7 +36,7 @@ func TestInnerJoin(t *testing.T) {
 
 func TestInnerJoinEmpty(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	ltable := mem.NewTable("left", lSchema)
 	rtable := mem.NewTable("right", rSchema)

--- a/sql/plan/limit_test.go
+++ b/sql/plan/limit_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -100,7 +99,7 @@ func getTestingTable() (*mem.Table, int) {
 }
 
 func getLimitedIterator(limitSize int64) (sql.RowIter, error) {
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 	table, _ := getTestingTable()
 	limitPlan := NewLimit(limitSize, table)
 	return limitPlan.RowIter(ctx)

--- a/sql/plan/offset_test.go
+++ b/sql/plan/offset_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,7 +9,7 @@ import (
 
 func TestOffsetPlan(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	table, _ := getTestingTable()
 	offset := NewOffset(0, table)
@@ -23,7 +22,7 @@ func TestOffsetPlan(t *testing.T) {
 
 func TestOffset(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	table, n := getTestingTable()
 	offset := NewOffset(1, table)

--- a/sql/plan/project_test.go
+++ b/sql/plan/project_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 
 func TestProject(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 	childSchema := sql.Schema{
 		{Name: "col1", Type: sql.Text, Nullable: true},
 		{Name: "col2", Type: sql.Text, Nullable: true},
@@ -62,7 +61,7 @@ func TestProject(t *testing.T) {
 
 func BenchmarkProject(b *testing.B) {
 	require := require.New(b)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	for i := 0; i < b.N; i++ {
 		d := NewProject([]sql.Expression{

--- a/sql/plan/set.go
+++ b/sql/plan/set.go
@@ -1,0 +1,197 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+
+	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-mysql-server.v0/config"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// Scope of the config update.
+type Scope bool
+
+const (
+	// SessionScope means the config update is to the session config.
+	SessionScope = Scope(false)
+	// GlobalScope means the config update is to the global config.
+	GlobalScope = Scope(true)
+)
+
+func (s Scope) String() string {
+	switch s {
+	case SessionScope:
+		return "SESSION"
+	case GlobalScope:
+		return "GLOBAL"
+	}
+	return ""
+}
+
+// Update represents a single update operation to the configuration.
+type Update struct {
+	// Name of the configuration key.
+	Name string
+	// Expression that will be evaluated to get the configuration value.
+	Value sql.Expression
+}
+
+// Set updates configuration values and returns the result of those updates.
+type Set struct {
+	Scope   Scope
+	Updates []Update
+}
+
+// NewSet creates a new Set node.
+func NewSet(scope Scope, updates []Update) *Set {
+	return &Set{scope, updates}
+}
+
+// Resolved implements the Node interface.
+func (s *Set) Resolved() bool {
+	for _, u := range s.Updates {
+		if !u.Value.Resolved() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Children implements the Node interface.
+func (Set) Children() []sql.Node { return nil }
+
+func (s *Set) String() string {
+	var children = make([]string, len(s.Updates))
+	for i, u := range s.Updates {
+		children[i] = fmt.Sprintf("%s = %s", u.Name, u.Value)
+	}
+
+	p := sql.NewTreePrinter()
+	_ = p.WriteNode("SET(%s)", s.Scope)
+	_ = p.WriteChildren(children...)
+	return p.String()
+}
+
+// Schema implements the Node interface.
+func (s *Set) Schema() sql.Schema {
+	return sql.Schema{
+		{Name: "name", Type: sql.Text, Nullable: false},
+		{Name: "value", Type: sql.Text, Nullable: false},
+	}
+}
+
+// ErrUnableToAccessGlobalConfig is returned when global config cannot be
+// accessed.
+var ErrUnableToAccessGlobalConfig = errors.NewKind("unable to access global config, session config parent is empty")
+
+// RowIter implements the Node interface.
+func (s *Set) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	var conf *config.Config
+	if s.Scope == GlobalScope {
+		if ctx.Config().Parent() == nil {
+			return nil, ErrUnableToAccessGlobalConfig.New()
+		}
+
+		conf = ctx.Config().Parent()
+	} else {
+		conf = ctx.Config()
+	}
+
+	pairs := make([]pair, len(s.Updates))
+	for i, u := range s.Updates {
+		val, err := u.Value.Eval(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if sql.IsNumber(u.Value.Type()) {
+			if sql.IsDecimal(u.Value.Type()) {
+				val, err = sql.Float64.Convert(val)
+				if err != nil {
+					return nil, err
+				}
+
+				pairs[i] = pair{u.Name, val}
+				conf.SetFloat(u.Name, val.(float64))
+			} else {
+				val, err = sql.Int64.Convert(val)
+				if err != nil {
+					return nil, err
+				}
+
+				pairs[i] = pair{u.Name, val}
+				conf.SetInt(u.Name, val.(int64))
+			}
+		} else if u.Value.Type() == sql.Boolean {
+			val, err = sql.Boolean.Convert(val)
+			if err != nil {
+				return nil, err
+			}
+
+			pairs[i] = pair{u.Name, val}
+			conf.SetBool(u.Name, val.(bool))
+		} else {
+			val, err = sql.Text.Convert(val)
+			if err != nil {
+				return nil, err
+			}
+
+			pairs[i] = pair{u.Name, val}
+			conf.SetString(u.Name, val.(string))
+		}
+
+		// TODO: support arrays?
+	}
+
+	return &pairIterator{p: pairs}, nil
+}
+
+// TransformUp implements the Node interface.
+func (s *Set) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	return f(NewSet(s.Scope, s.Updates))
+}
+
+// TransformExpressionsUp implements the Node interface.
+func (s *Set) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	var updates = make([]Update, len(s.Updates))
+	for i, u := range s.Updates {
+		expr, err := u.Value.TransformUp(f)
+		if err != nil {
+			return nil, err
+		}
+		updates[i] = Update{
+			Name:  u.Name,
+			Value: expr,
+		}
+	}
+	return NewSet(s.Scope, updates), nil
+}
+
+type pair struct {
+	name  string
+	value interface{}
+}
+
+type pairIterator struct {
+	p   []pair
+	idx int
+}
+
+func (i *pairIterator) Next() (sql.Row, error) {
+	if i.idx >= len(i.p) {
+		return nil, io.EOF
+	}
+
+	i.idx++
+	return sql.NewRow(
+		i.p[i.idx-1].name,
+		i.p[i.idx-1].value,
+	), nil
+}
+
+func (i *pairIterator) Close() error {
+	i.idx = len(i.p)
+	return nil
+}

--- a/sql/plan/set_test.go
+++ b/sql/plan/set_test.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/config"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestSetGlobal(t *testing.T) {
+	require := require.New(t)
+
+	globalConf := config.New()
+	sessionConf := config.FromConfig(globalConf)
+
+	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession(sessionConf))
+
+	node := NewSet(GlobalScope, []Update{
+		{"a", expression.NewLiteral(int64(1), sql.Int64)},
+		{"b", expression.NewLiteral("foo", sql.Text)},
+		{"c", expression.NewLiteral(float64(3.14), sql.Float64)},
+		{"d", expression.NewLiteral(true, sql.Boolean)},
+	})
+
+	iter, err := node.RowIter(ctx)
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+	require.Equal([]sql.Row{
+		sql.NewRow("a", int64(1)),
+		sql.NewRow("b", "foo"),
+		sql.NewRow("c", float64(3.14)),
+		sql.NewRow("d", true),
+	}, rows)
+
+	v, err := globalConf.Int("a", 0)
+	require.NoError(err)
+	require.Equal(int64(1), v)
+
+	vs, err := globalConf.String("b", "")
+	require.NoError(err)
+	require.Equal("foo", vs)
+
+	vf, err := globalConf.Float("c", 0.)
+	require.NoError(err)
+	require.Equal(float64(3.14), vf)
+
+	vb, err := globalConf.Bool("d", false)
+	require.NoError(err)
+	require.True(vb)
+}
+
+func TestSetSession(t *testing.T) {
+	require := require.New(t)
+
+	globalConf := config.New()
+	sessionConf := config.FromConfig(globalConf)
+
+	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession(sessionConf))
+
+	node := NewSet(SessionScope, []Update{
+		{"a", expression.NewLiteral(int64(3), sql.Int64)},
+		{"c", expression.NewLiteral("foo", sql.Text)},
+	})
+
+	iter, err := node.RowIter(ctx)
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+	require.Equal([]sql.Row{
+		sql.NewRow("a", int64(3)),
+		sql.NewRow("c", "foo"),
+	}, rows)
+
+	v, err := globalConf.Int("a", 0)
+	require.NoError(err)
+	require.Equal(int64(0), v)
+
+	v, err = sessionConf.Int("a", 0)
+	require.NoError(err)
+	require.Equal(int64(3), v)
+
+	vs, err := globalConf.String("c", "")
+	require.NoError(err)
+	require.Equal("", vs)
+
+	vs, err = sessionConf.String("c", "")
+	require.NoError(err)
+	require.Equal("foo", vs)
+}
+
+func TestSetNoGlobal(t *testing.T) {
+	require := require.New(t)
+
+	conf := config.New()
+	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession(conf))
+
+	node := NewSet(GlobalScope, []Update{
+		{"a", expression.NewLiteral(int64(1), sql.Int64)},
+		{"b", expression.NewLiteral("foo", sql.Text)},
+	})
+
+	_, err := node.RowIter(ctx)
+	require.Error(err)
+	require.True(ErrUnableToAccessGlobalConfig.Is(err))
+}

--- a/sql/plan/show_tables_test.go
+++ b/sql/plan/show_tables_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 
 func TestShowTables(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	unresolvedShowTables := NewShowTables(&sql.UnresolvedDatabase{})
 

--- a/sql/plan/sort_test.go
+++ b/sql/plan/sort_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"testing"
 
 	"gopkg.in/src-d/go-mysql-server.v0/mem"
@@ -13,7 +12,7 @@ import (
 
 func TestSort(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	data := []sql.Row{
 		sql.NewRow("c", nil),
@@ -55,7 +54,7 @@ func TestSort(t *testing.T) {
 
 func TestSortAscending(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	data := []sql.Row{
 		sql.NewRow("c"),
@@ -95,7 +94,7 @@ func TestSortAscending(t *testing.T) {
 
 func TestSortDescending(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	data := []sql.Row{
 		sql.NewRow("c"),

--- a/sql/plan/tablealias_test.go
+++ b/sql/plan/tablealias_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 
 func TestTableAlias(t *testing.T) {
 	require := require.New(t)
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession())
+	ctx := sql.NewEmptyContext()
 
 	table := mem.NewTable("bar", sql.Schema{
 		{Name: "a", Type: sql.Text, Nullable: true},

--- a/sql/session.go
+++ b/sql/session.go
@@ -1,20 +1,30 @@
 package sql
 
-import "context"
+import (
+	"context"
+
+	"gopkg.in/src-d/go-mysql-server.v0/config"
+)
 
 // Session holds the session data.
 type Session interface {
-	// TODO: add config
+	// Config of the session. It also has access to the global config.
+	Config() *config.Config
 }
 
 // BaseSession is the basic session type.
 type BaseSession struct {
-	// TODO: add config
+	cfg *config.Config
 }
 
 // NewBaseSession creates a new basic session.
-func NewBaseSession() Session {
-	return &BaseSession{}
+func NewBaseSession(config *config.Config) Session {
+	return &BaseSession{cfg: config}
+}
+
+// Config returns the config of the session.
+func (s BaseSession) Config() *config.Config {
+	return s.cfg
 }
 
 // Context of the query execution.
@@ -26,4 +36,9 @@ type Context struct {
 // NewContext creates a new query context.
 func NewContext(ctx context.Context, session Session) *Context {
 	return &Context{ctx, session}
+}
+
+// NewEmptyContext creates an empty context.
+func NewEmptyContext() *Context {
+	return NewContext(context.TODO(), NewBaseSession(config.New()))
 }

--- a/sql/session_test.go
+++ b/sql/session_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/config"
 )
 
 type testNode struct{}
@@ -64,7 +65,7 @@ func (t *testNodeIterator) Close() error {
 func TestSessionIterator(t *testing.T) {
 	require := require.New(t)
 	ctx, cancelFunc := context.WithCancel(context.TODO())
-	session := NewBaseSession()
+	session := NewBaseSession(config.New())
 
 	node := &testNode{}
 	iter, err := node.RowIter(NewContext(ctx, session))


### PR DESCRIPTION
Closes #109 

This only implements the Config API and introduces it into the `Session` and `Engine`, we still need to figure out how to fill that configuration (files, environment variables, `set` commands, ...).

### Beware!

This introduces breaking changes that will make gitquery explode, so don't merge without caution.

### Config API

This API is designed for config to be inheritable, type-safe and thread-safe. For our use case, what we need is the following:
- Be able to work in multiple goroutines (when the engine works in parallel)
- Be able to have an Engine configuration and a Session configuration where the Session configuration can access the configuration values from the Engine and override them without actually changing them. That's why the `Config` has a parent that allows it to access it, while not being able to change it.
- Not panic but be able to store any kind of value. Hence, the `Set*` and `*` methods for getting the different types of values and the error in the getters.

To avoid the "what happens when there is no config? do we throw an error?" all methods require a default value when you're getting the config value.

The only part I don't feel much of this API is the usage from the `Session`. From a session it would be used like this:

```go
val, err := session.Config().String("my_key", "default")
```

One option we could explore to overcome this is making `Config` an interface and embed it on the `Session` interface.

The previous snippet would become:

```go
val, err := session.String("my_key", "default")
```

Which, to be honest, is actually a bit weird.

Another option we could explore is just duplicate methods on session:

```go
val, err := session.StringConfig("my_key", "default")
session.SetStringConfig("my_key", "my_val")
```

### Next steps

- Figure out how to let the user fill this config from the outside