### PR TITLE
 sql/analyzer: propagate context throughout the analyzer 

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -32,7 +32,7 @@ func (e *Engine) Query(
 		return nil, nil, err
 	}
 
-	analyzed, err := e.Analyzer.Analyze(parsed)
+	analyzed, err := e.Analyzer.Analyze(ctx, parsed)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -100,7 +100,7 @@ func TestResolveSubqueries(t *testing.T) {
 		),
 	)
 
-	result, err := resolveSubqueries(a, node)
+	result, err := resolveSubqueries(sql.NewEmptyContext(), a, node)
 	require.NoError(err)
 
 	require.Equal(expected, result)
@@ -125,16 +125,16 @@ func TestResolveTables(t *testing.T) {
 
 	a.CurrentDatabase = "mydb"
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("mytable")
-	analyzed, err := f.Apply(a, notAnalyzed)
+	analyzed, err := f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.NoError(err)
 	require.Equal(table, analyzed)
 
 	notAnalyzed = plan.NewUnresolvedTable("nonexistant")
-	analyzed, err = f.Apply(a, notAnalyzed)
+	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.Error(err)
 	require.Nil(analyzed)
 
-	analyzed, err = f.Apply(a, table)
+	analyzed, err = f.Apply(sql.NewEmptyContext(), a, table)
 	require.NoError(err)
 	require.Equal(table, analyzed)
 }
@@ -161,7 +161,7 @@ func TestResolveTablesNested(t *testing.T) {
 		[]sql.Expression{expression.NewGetField(0, sql.Int32, "i", true)},
 		plan.NewUnresolvedTable("mytable"),
 	)
-	analyzed, err := f.Apply(a, notAnalyzed)
+	analyzed, err := f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.NoError(err)
 	expected := plan.NewProject(
 		[]sql.Expression{expression.NewGetField(0, sql.Int32, "i", true)},
@@ -264,7 +264,7 @@ func TestResolveStar(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := f.Apply(nil, tt.node)
+			result, err := f.Apply(sql.NewEmptyContext(), nil, tt.node)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
@@ -292,7 +292,7 @@ func TestQualifyColumns(t *testing.T) {
 		table,
 	)
 
-	result, err := f.Apply(nil, node)
+	result, err := f.Apply(sql.NewEmptyContext(), nil, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 
@@ -303,7 +303,7 @@ func TestQualifyColumns(t *testing.T) {
 		table,
 	)
 
-	result, err = f.Apply(nil, node)
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 
@@ -321,7 +321,7 @@ func TestQualifyColumns(t *testing.T) {
 		plan.NewTableAlias("a", table),
 	)
 
-	result, err = f.Apply(nil, node)
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 
@@ -332,7 +332,7 @@ func TestQualifyColumns(t *testing.T) {
 		plan.NewTableAlias("a", table),
 	)
 
-	result, err = f.Apply(nil, node)
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.Error(err)
 	require.True(ErrColumnNotFound.Is(err))
 
@@ -343,7 +343,7 @@ func TestQualifyColumns(t *testing.T) {
 		plan.NewTableAlias("a", table),
 	)
 
-	result, err = f.Apply(nil, node)
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.Error(err)
 	require.True(sql.ErrTableNotFound.Is(err))
 
@@ -354,7 +354,7 @@ func TestQualifyColumns(t *testing.T) {
 		plan.NewTableAlias("a", table),
 	)
 
-	_, err = f.Apply(nil, node)
+	_, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.Error(err)
 	require.True(ErrColumnNotFound.Is(err))
 
@@ -365,7 +365,7 @@ func TestQualifyColumns(t *testing.T) {
 		plan.NewCrossJoin(table, table2),
 	)
 
-	_, err = f.Apply(nil, node)
+	_, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.Error(err)
 	require.True(ErrAmbiguousColumnName.Is(err))
 
@@ -401,7 +401,7 @@ func TestQualifyColumns(t *testing.T) {
 		),
 	)
 
-	result, err = f.Apply(nil, node)
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 }
@@ -413,10 +413,10 @@ func TestOptimizeDistinct(t *testing.T) {
 
 	rule := getRule("optimize_distinct")
 
-	analyzedNotSorted, err := rule.Apply(nil, notSorted)
+	analyzedNotSorted, err := rule.Apply(sql.NewEmptyContext(), nil, notSorted)
 	require.NoError(err)
 
-	analyzedSorted, err := rule.Apply(nil, sorted)
+	analyzedSorted, err := rule.Apply(sql.NewEmptyContext(), nil, sorted)
 	require.NoError(err)
 
 	require.Equal(notSorted, analyzedNotSorted)
@@ -478,7 +478,7 @@ func TestPushdownProjection(t *testing.T) {
 		),
 	)
 
-	result, err := f.Apply(nil, node)
+	result, err := f.Apply(sql.NewEmptyContext(), nil, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 }
@@ -562,7 +562,7 @@ func TestPushdownProjectionAndFilters(t *testing.T) {
 		),
 	)
 
-	result, err := a.Analyze(node)
+	result, err := a.Analyze(sql.NewEmptyContext(), node)
 	require.NoError(err)
 	require.Equal(expected, result)
 }

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -41,7 +41,7 @@ var DefaultValidationRules = []ValidationRule{
 	{validateProjectTuplesRule, validateProjectTuples},
 }
 
-func validateIsResolved(n sql.Node) error {
+func validateIsResolved(ctx *sql.Context, n sql.Node) error {
 	if !n.Resolved() {
 		return ErrValidationResolved.New(n)
 	}
@@ -49,7 +49,7 @@ func validateIsResolved(n sql.Node) error {
 	return nil
 }
 
-func validateOrderBy(n sql.Node) error {
+func validateOrderBy(ctx *sql.Context, n sql.Node) error {
 	switch n := n.(type) {
 	case *plan.Sort:
 		for _, field := range n.SortFields {
@@ -63,7 +63,7 @@ func validateOrderBy(n sql.Node) error {
 	return nil
 }
 
-func validateGroupBy(n sql.Node) error {
+func validateGroupBy(ctx *sql.Context, n sql.Node) error {
 	switch n := n.(type) {
 	case *plan.GroupBy:
 		// Allow the parser use the GroupBy node to eval the aggregation functions
@@ -105,7 +105,7 @@ func isValidAgg(validAggs []string, expr sql.Expression) bool {
 	}
 }
 
-func validateSchemaSource(n sql.Node) error {
+func validateSchemaSource(ctx *sql.Context, n sql.Node) error {
 	switch n := n.(type) {
 	case *plan.TableAlias:
 		// table aliases should not be validated
@@ -128,7 +128,7 @@ func validateSchema(t sql.Table) error {
 	return nil
 }
 
-func validateProjectTuples(n sql.Node) error {
+func validateProjectTuples(ctx *sql.Context, n sql.Node) error {
 	switch n := n.(type) {
 	case *plan.Project:
 		for i, e := range n.Projections {

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -17,10 +17,10 @@ func TestValidateResolved(t *testing.T) {
 
 	vr := getValidationRule(validateResolvedRule)
 
-	err := vr.Apply(dummyNode{true})
+	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
 	require.NoError(err)
 
-	err = vr.Apply(dummyNode{false})
+	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
 	require.Error(err)
 }
 
@@ -29,12 +29,12 @@ func TestValidateOrderBy(t *testing.T) {
 
 	vr := getValidationRule(validateOrderByRule)
 
-	err := vr.Apply(dummyNode{true})
+	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(dummyNode{false})
+	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
 	require.NoError(err)
 
-	err = vr.Apply(plan.NewSort(
+	err = vr.Apply(sql.NewEmptyContext(), plan.NewSort(
 		[]plan.SortField{{Column: aggregation.NewCount(nil), Order: plan.Descending}},
 		nil,
 	))
@@ -46,9 +46,9 @@ func TestValidateGroupBy(t *testing.T) {
 
 	vr := getValidationRule(validateGroupByRule)
 
-	err := vr.Apply(dummyNode{true})
+	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(dummyNode{false})
+	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
 	require.NoError(err)
 
 	childSchema := sql.Schema{
@@ -75,7 +75,7 @@ func TestValidateGroupBy(t *testing.T) {
 		child,
 	)
 
-	err = vr.Apply(p)
+	err = vr.Apply(sql.NewEmptyContext(), p)
 	require.NoError(err)
 }
 
@@ -84,9 +84,9 @@ func TestValidateGroupByErr(t *testing.T) {
 
 	vr := getValidationRule(validateGroupByRule)
 
-	err := vr.Apply(dummyNode{true})
+	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(dummyNode{false})
+	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
 	require.NoError(err)
 
 	childSchema := sql.Schema{
@@ -112,7 +112,7 @@ func TestValidateGroupByErr(t *testing.T) {
 		child,
 	)
 
-	err = vr.Apply(p)
+	err = vr.Apply(sql.NewEmptyContext(), p)
 	require.Error(err)
 }
 
@@ -170,7 +170,7 @@ func TestValidateSchemaSource(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			err := rule.Apply(tt.node)
+			err := rule.Apply(sql.NewEmptyContext(), tt.node)
 			if tt.ok {
 				require.NoError(err)
 			} else {
@@ -245,7 +245,7 @@ func TestValidateProjectTuples(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			err := rule.Apply(tt.node)
+			err := rule.Apply(sql.NewEmptyContext(), tt.node)
 			if tt.ok {
 				require.NoError(err)
 			} else {


### PR DESCRIPTION
Depends on #138
Related to #137 

This propagates the context throughout the analyzer, which we didn't do before and it will be needed in the next step for #137, which is actually tracing all nodes and components.