### PR TITLE
 sql/(plan,expression,parse,analyzer): trace node execution 

### DIFF
--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -68,6 +68,9 @@ func (a *Analyzer) Log(msg string, args ...interface{}) {
 
 // Analyze the node and all its children.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("analyze")
+	defer span.Finish()
+
 	prev := n
 
 	a.Log("starting analysis of node of type: %T", n)
@@ -103,6 +106,9 @@ func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
 }
 
 func (a *Analyzer) analyzeOnce(ctx *sql.Context, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("analyze_once")
+	defer span.Finish()
+
 	result := n
 	for _, rule := range a.Rules {
 		var err error
@@ -115,6 +121,9 @@ func (a *Analyzer) analyzeOnce(ctx *sql.Context, n sql.Node) (sql.Node, error) {
 }
 
 func (a *Analyzer) validate(ctx *sql.Context, n sql.Node) (validationErrors []error) {
+	span, ctx := ctx.Span("validate")
+	defer span.Finish()
+
 	validationErrors = append(validationErrors, a.validateOnce(ctx, n)...)
 
 	for _, node := range n.Children() {
@@ -125,6 +134,9 @@ func (a *Analyzer) validate(ctx *sql.Context, n sql.Node) (validationErrors []er
 }
 
 func (a *Analyzer) validateOnce(ctx *sql.Context, n sql.Node) (validationErrors []error) {
+	span, ctx := ctx.Span("validate_once")
+	defer span.Finish()
+
 	for _, rule := range a.ValidationRules {
 		err := rule.Apply(ctx, n)
 		if err != nil {

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -37,6 +37,9 @@ var (
 )
 
 func resolveSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_subqueries")
+	defer span.Finish()
+
 	a.Log("resolving subqueries")
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
@@ -54,6 +57,9 @@ func resolveSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, err
 }
 
 func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("qualify_columns")
+	defer span.Finish()
+
 	a.Log("qualify columns")
 	tables := make(map[string]sql.Node)
 	tableAliases := make(map[string]string)
@@ -134,6 +140,9 @@ func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error)
 }
 
 func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_database")
+	defer span.Finish()
+
 	a.Log("resolve database, node of type: %T", n)
 
 	// TODO Database should implement node,
@@ -159,6 +168,9 @@ func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error
 }
 
 func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_tables")
+	defer span.Finish()
+
 	a.Log("resolve table, node of type: %T", n)
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
@@ -183,6 +195,9 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 }
 
 func resolveStar(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_star")
+	defer span.Finish()
+
 	a.Log("resolving star, node of type: %T", n)
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
@@ -229,6 +244,9 @@ type columnInfo struct {
 }
 
 func resolveColumns(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_columns")
+	defer span.Finish()
+
 	a.Log("resolve columns, node of type: %T", n)
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
@@ -299,6 +317,9 @@ func resolveColumns(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error)
 }
 
 func resolveFunctions(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("resolve_functions")
+	defer span.Finish()
+
 	a.Log("resolve functions, node of type %T", n)
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
@@ -336,6 +357,9 @@ func resolveFunctions(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, erro
 }
 
 func optimizeDistinct(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("optimize_distinct")
+	defer span.Finish()
+
 	a.Log("optimize distinct, node of type: %T", node)
 	if node, ok := node.(*plan.Distinct); ok {
 		var isSorted bool
@@ -369,6 +393,9 @@ func dedupStrings(in []string) []string {
 }
 
 func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("pushdown")
+	defer span.Finish()
+
 	a.Log("pushdown, node of type: %T", n)
 	if !n.Resolved() {
 		return n, nil
@@ -383,6 +410,8 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	var tableFields = make(map[tableField]struct{})
 
 	a.Log("finding used columns in node")
+
+	colSpan, _ := ctx.Span("find_pushdown_columns")
 
 	// First step is to find all col exprs and group them by the table they mention.
 	// Even if they appear multiple times, only the first one will be used.
@@ -399,7 +428,11 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 		return true
 	})
 
+	colSpan.Finish()
+
 	a.Log("finding filters in node")
+
+	filterSpan, _ := ctx.Span("find_pushdown_filters")
 
 	// then find all filters, also by table. Note that filters that mention
 	// more than one table will not be passed to neither.
@@ -414,6 +447,8 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 		}
 		return true
 	})
+
+	filterSpan.Finish()
 
 	a.Log("transforming nodes with pushdown of filters and projections")
 

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -42,6 +42,9 @@ var DefaultValidationRules = []ValidationRule{
 }
 
 func validateIsResolved(ctx *sql.Context, n sql.Node) error {
+	span, ctx := ctx.Span("validate_is_resolved")
+	defer span.Finish()
+
 	if !n.Resolved() {
 		return ErrValidationResolved.New(n)
 	}
@@ -50,6 +53,9 @@ func validateIsResolved(ctx *sql.Context, n sql.Node) error {
 }
 
 func validateOrderBy(ctx *sql.Context, n sql.Node) error {
+	span, ctx := ctx.Span("validate_order_by")
+	defer span.Finish()
+
 	switch n := n.(type) {
 	case *plan.Sort:
 		for _, field := range n.SortFields {
@@ -64,6 +70,9 @@ func validateOrderBy(ctx *sql.Context, n sql.Node) error {
 }
 
 func validateGroupBy(ctx *sql.Context, n sql.Node) error {
+	span, ctx := ctx.Span("validate_order_by")
+	defer span.Finish()
+
 	switch n := n.(type) {
 	case *plan.GroupBy:
 		// Allow the parser use the GroupBy node to eval the aggregation functions
@@ -106,6 +115,9 @@ func isValidAgg(validAggs []string, expr sql.Expression) bool {
 }
 
 func validateSchemaSource(ctx *sql.Context, n sql.Node) error {
+	span, ctx := ctx.Span("validate_schema_source")
+	defer span.Finish()
+
 	switch n := n.(type) {
 	case *plan.TableAlias:
 		// table aliases should not be validated
@@ -129,6 +141,9 @@ func validateSchema(t sql.Table) error {
 }
 
 func validateProjectTuples(ctx *sql.Context, n sql.Node) error {
+	span, ctx := ctx.Span("validate_project_tuples")
+	defer span.Finish()
+
 	switch n := n.(type) {
 	case *plan.Project:
 		for i, e := range n.Projections {

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -42,6 +42,9 @@ func (b *Between) Resolved() bool {
 
 // Eval implements the Expression interface.
 func (b *Between) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Between")
+	defer span.Finish()
+
 	typ := b.Val.Type()
 	val, err := b.Val.Eval(ctx, row)
 	if err != nil {

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -23,6 +23,9 @@ func (e Not) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (e Not) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Not")
+	defer span.Finish()
+
 	v, err := e.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -144,6 +144,9 @@ func NewEquals(left sql.Expression, right sql.Expression) *Equals {
 
 // Eval implements the Expression interface.
 func (e *Equals) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Equals")
+	defer span.Finish()
+
 	result, err := e.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -187,6 +190,9 @@ func NewRegexp(left sql.Expression, right sql.Expression) *Regexp {
 
 // Eval implements the Expression interface.
 func (re *Regexp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Regexp")
+	defer span.Finish()
+
 	if sql.IsText(re.Left().Type()) && sql.IsText(re.Right().Type()) {
 		return re.compareRegexp(ctx, row)
 	}
@@ -262,6 +268,9 @@ func NewGreaterThan(left sql.Expression, right sql.Expression) *GreaterThan {
 
 // Eval implements the Expression interface.
 func (gt *GreaterThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.GreaterThan")
+	defer span.Finish()
+
 	result, err := gt.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -305,6 +314,9 @@ func NewLessThan(left sql.Expression, right sql.Expression) *LessThan {
 
 // Eval implements the expression interface.
 func (lt *LessThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.LessThan")
+	defer span.Finish()
+
 	result, err := lt.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -349,6 +361,9 @@ func NewGreaterThanOrEqual(left sql.Expression, right sql.Expression) *GreaterTh
 
 // Eval implements the Expression interface.
 func (gte *GreaterThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.GreaterThanOrEqual")
+	defer span.Finish()
+
 	result, err := gte.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -393,6 +408,9 @@ func NewLessThanOrEqual(left sql.Expression, right sql.Expression) *LessThanOrEq
 
 // Eval implements the Expression interface.
 func (lte *LessThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.LessThanOrEqual")
+	defer span.Finish()
+
 	result, err := lte.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -445,6 +463,9 @@ func NewIn(left sql.Expression, right sql.Expression) *In {
 
 // Eval implements the Expression interface.
 func (in *In) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.In")
+	defer span.Finish()
+
 	typ := in.Left().Type()
 	leftElems := sql.NumColumns(typ)
 	left, err := in.Left().Eval(ctx, row)
@@ -533,6 +554,9 @@ func NewNotIn(left sql.Expression, right sql.Expression) *NotIn {
 
 // Eval implements the Expression interface.
 func (in *NotIn) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.NotIn")
+	defer span.Finish()
+
 	typ := in.Left().Type()
 	leftElems := sql.NumColumns(typ)
 	left, err := in.Left().Eval(ctx, row)

--- a/sql/expression/comparison_test.go
+++ b/sql/expression/comparison_test.go
@@ -269,7 +269,7 @@ func TestIn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			result, err := NewIn(tt.left, tt.right).Eval(nil, tt.row)
+			result, err := NewIn(tt.left, tt.right).Eval(sql.NewEmptyContext(), tt.row)
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
@@ -351,7 +351,7 @@ func TestNotIn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			result, err := NewNotIn(tt.left, tt.right).Eval(nil, tt.row)
+			result, err := NewNotIn(tt.left, tt.right).Eval(sql.NewEmptyContext(), tt.row)
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/spf13/cast"
 	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -90,6 +91,9 @@ func (c *Convert) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 
 // Eval implements the Expression interface.
 func (c *Convert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Convert", opentracing.Tag{Key: "type", Value: c.castToType})
+	defer span.Finish()
+
 	val, err := c.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/function/aggregation/avg.go
+++ b/sql/expression/function/aggregation/avg.go
@@ -75,6 +75,9 @@ func (a *Avg) NewBuffer() sql.Row {
 
 // Update implements AggregationExpression interface. (AggregationExpression)
 func (a *Avg) Update(ctx *sql.Context, buffer, row sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Avg_Update")
+	defer span.Finish()
+
 	v, err := a.Child.Eval(ctx, row)
 	if err != nil {
 		return err
@@ -109,6 +112,9 @@ func (a *Avg) Update(ctx *sql.Context, buffer, row sql.Row) error {
 
 // Merge implements AggregationExpression interface. (AggregationExpression)
 func (a *Avg) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
+	span, _ := ctx.Span("aggregation.Avg_Merge")
+	defer span.Finish()
+
 	bufferAvg := buffer[0].(float64)
 	bufferRows := buffer[1].(float64)
 

--- a/sql/expression/function/aggregation/avg_test.go
+++ b/sql/expression/function/aggregation/avg_test.go
@@ -92,12 +92,13 @@ func TestAvg_Merge(t *testing.T) {
 
 func TestAvg_NULL(t *testing.T) {
 	require := require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	avgNode := NewAvg(expression.NewGetField(0, sql.Uint64, "col1", true))
 	buffer := avgNode.NewBuffer()
-	require.Zero(avgNode.Eval(nil, buffer))
+	require.Zero(avgNode.Eval(ctx, buffer))
 
-	err := avgNode.Update(nil, buffer, sql.NewRow(nil))
+	err := avgNode.Update(ctx, buffer, sql.NewRow(nil))
 	require.NoError(err)
 	require.Equal(nil, eval(t, avgNode, buffer))
 }

--- a/sql/expression/function/aggregation/count.go
+++ b/sql/expression/function/aggregation/count.go
@@ -56,6 +56,9 @@ func (c *Count) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 
 // Update implements the Aggregation interface.
 func (c *Count) Update(ctx *sql.Context, buffer, row sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Count_Update")
+	defer span.Finish()
+
 	var inc bool
 	if _, ok := c.Child.(*expression.Star); ok {
 		inc = true
@@ -79,6 +82,9 @@ func (c *Count) Update(ctx *sql.Context, buffer, row sql.Row) error {
 
 // Merge implements the Aggregation interface.
 func (c *Count) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
+	span, _ := ctx.Span("aggregation.Count_Merge")
+	defer span.Finish()
+
 	buffer[0] = buffer[0].(int32) + partial[0].(int32)
 	return nil
 }

--- a/sql/expression/function/aggregation/max.go
+++ b/sql/expression/function/aggregation/max.go
@@ -54,6 +54,9 @@ func (m *Max) NewBuffer() sql.Row {
 
 // Update implements the Aggregation interface.
 func (m *Max) Update(ctx *sql.Context, buffer, row sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Max_Update")
+	defer span.Finish()
+
 	v, err := m.Child.Eval(ctx, row)
 	if err != nil {
 		return err
@@ -80,6 +83,8 @@ func (m *Max) Update(ctx *sql.Context, buffer, row sql.Row) error {
 
 // Merge implements the Aggregation interface.
 func (m *Max) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Max_Merge")
+	defer span.Finish()
 	return m.Update(ctx, buffer, partial)
 }
 

--- a/sql/expression/function/aggregation/min.go
+++ b/sql/expression/function/aggregation/min.go
@@ -54,6 +54,8 @@ func (m *Min) NewBuffer() sql.Row {
 
 // Update implements the Aggregation interface.
 func (m *Min) Update(ctx *sql.Context, buffer, row sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Min_Update")
+	defer span.Finish()
 	v, err := m.Child.Eval(ctx, row)
 	if err != nil {
 		return err
@@ -80,6 +82,8 @@ func (m *Min) Update(ctx *sql.Context, buffer, row sql.Row) error {
 
 // Merge implements the Aggregation interface.
 func (m *Min) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
+	span, ctx := ctx.Span("aggregation.Min_Merge")
+	defer span.Finish()
 	return m.Update(ctx, buffer, partial)
 }
 

--- a/sql/expression/function/arraylength.go
+++ b/sql/expression/function/arraylength.go
@@ -38,6 +38,9 @@ func (f ArrayLength) TransformUp(fn sql.TransformExprFunc) (sql.Expression, erro
 
 // Eval implements the Expression interface.
 func (f ArrayLength) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.ArrayLength")
+	defer span.Finish()
+
 	if !sql.IsArray(f.Child.Type()) {
 		return nil, sql.ErrInvalidType.New(f.Child.Type().Type().String())
 	}

--- a/sql/expression/function/arraylength_test.go
+++ b/sql/expression/function/arraylength_test.go
@@ -27,7 +27,7 @@ func TestArrayLength(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			result, err := f.Eval(nil, tt.row)
+			result, err := f.Eval(sql.NewEmptyContext(), tt.row)
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
@@ -40,7 +40,7 @@ func TestArrayLength(t *testing.T) {
 
 	f = NewArrayLength(expression.NewGetField(0, sql.Tuple(sql.Int64, sql.Int64), "", false))
 	require := require.New(t)
-	_, err := f.Eval(nil, []interface{}{int64(1), int64(2)})
+	_, err := f.Eval(sql.NewEmptyContext(), []interface{}{int64(1), int64(2)})
 	require.Error(err)
 	require.True(sql.ErrInvalidType.Is(err))
 }

--- a/sql/expression/function/substring.go
+++ b/sql/expression/function/substring.go
@@ -50,6 +50,9 @@ func (s *Substring) Eval(
 	ctx *sql.Context,
 	row sql.Row,
 ) (interface{}, error) {
+	span, ctx := ctx.Span("function.Substring")
+	defer span.Finish()
+
 	str, err := s.str.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -51,6 +51,8 @@ func (y *Year) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (y *Year) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Year")
+	defer span.Finish()
 	return getDatePart(ctx, y.UnaryExpression, row, (time.Time).Year)
 }
 
@@ -81,6 +83,9 @@ func (m *Month) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (m *Month) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Month")
+	defer span.Finish()
+
 	monthFunc := func(t time.Time) int {
 		return int(t.Month())
 	}
@@ -115,6 +120,8 @@ func (d *Day) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (d *Day) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Day")
+	defer span.Finish()
 	return getDatePart(ctx, d.UnaryExpression, row, (time.Time).Day)
 }
 
@@ -145,6 +152,8 @@ func (h *Hour) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (h *Hour) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Hour")
+	defer span.Finish()
 	return getDatePart(ctx, h.UnaryExpression, row, (time.Time).Hour)
 }
 
@@ -175,6 +184,8 @@ func (m *Minute) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (m *Minute) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Minute")
+	defer span.Finish()
 	return getDatePart(ctx, m.UnaryExpression, row, (time.Time).Minute)
 }
 
@@ -205,6 +216,8 @@ func (s *Second) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (s *Second) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.Second")
+	defer span.Finish()
 	return getDatePart(ctx, s.UnaryExpression, row, (time.Time).Second)
 }
 
@@ -235,6 +248,8 @@ func (d *DayOfYear) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (d *DayOfYear) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("function.DayOfYear")
+	defer span.Finish()
 	return getDatePart(ctx, d.UnaryExpression, row, (time.Time).YearDay)
 }
 

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -3,6 +3,7 @@ package expression
 import (
 	"fmt"
 
+	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -57,8 +58,14 @@ func (p GetField) Type() sql.Type {
 	return p.fieldType
 }
 
+// ErrIndexOutOfBounds is returned when the field index is out of the bounds.
+var ErrIndexOutOfBounds = errors.NewKind("unable to find field with index %d in row of %d columns")
+
 // Eval implements the Expression interface.
 func (p GetField) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	if p.fieldIndex < 0 || p.fieldIndex >= len(row) {
+		return nil, ErrIndexOutOfBounds.New(p.fieldIndex, len(row))
+	}
 	return row[p.fieldIndex], nil
 }
 

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -24,6 +24,9 @@ func (e *IsNull) IsNullable() bool {
 
 // Eval implements the Expression interface.
 func (e *IsNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.IsNull")
+	defer span.Finish()
+
 	v, err := e.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -43,6 +43,9 @@ func (And) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (a *And) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.And")
+	defer span.Finish()
+
 	lval, err := a.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -104,6 +107,9 @@ func (Or) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Or")
+	defer span.Finish()
+
 	lval, err := o.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -18,6 +19,9 @@ func NewTuple(exprs ...sql.Expression) Tuple {
 
 // Eval implements the Expression interface.
 func (t Tuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	span, ctx := ctx.Span("expression.Tuple", opentracing.Tag{Key: "elems", Value: len(t)})
+	defer span.Finish()
+
 	if len(t) == 1 {
 		return t[0].Eval(ctx, row)
 	}

--- a/sql/expression/tuple_test.go
+++ b/sql/expression/tuple_test.go
@@ -16,11 +16,13 @@ func TestTuple(t *testing.T) {
 		NewLiteral("foo", sql.Text),
 	)
 
+	ctx := sql.NewEmptyContext()
+
 	require.False(tup.IsNullable())
 	require.True(tup.Resolved())
 	require.Equal(sql.Tuple(sql.Int64, sql.Float64, sql.Text), tup.Type())
 
-	result, err := tup.Eval(nil, nil)
+	result, err := tup.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal([]interface{}{int64(1), float64(3.14), "foo"}, result)
 
@@ -32,7 +34,7 @@ func TestTuple(t *testing.T) {
 	require.True(tup.Resolved())
 	require.Equal(sql.Text, tup.Type())
 
-	result, err = tup.Eval(nil, sql.NewRow("foo"))
+	result, err = tup.Eval(ctx, sql.NewRow("foo"))
 	require.NoError(err)
 	require.Equal("foo", result)
 
@@ -45,7 +47,7 @@ func TestTuple(t *testing.T) {
 	require.True(tup.Resolved())
 	require.Equal(sql.Tuple(sql.Text, sql.Text), tup.Type())
 
-	result, err = tup.Eval(nil, sql.NewRow("foo"))
+	result, err = tup.Eval(ctx, sql.NewRow("foo"))
 	require.NoError(err)
 	require.Equal([]interface{}{"foo", "bar"}, result)
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
@@ -29,6 +30,9 @@ var (
 
 // Parse parses the given SQL sentence and returns the corresponding node.
 func Parse(ctx *sql.Context, s string) (sql.Node, error) {
+	span, ctx := ctx.Span("parse_query", opentracing.Tag{Key: "query", Value: s})
+	defer span.Finish()
+
 	if strings.HasSuffix(s, ";") {
 		s = s[:len(s)-1]
 	}

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -26,11 +26,15 @@ func (d *Distinct) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (d *Distinct) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Distinct")
+
 	it, err := d.Child.RowIter(ctx)
 	if err != nil {
+		span.Finish()
 		return nil, err
 	}
-	return newDistinctIter(it), nil
+
+	return sql.NewSpanIter(span, newDistinctIter(it)), nil
 }
 
 // TransformUp implements the Transformable interface.
@@ -120,11 +124,15 @@ func (d *OrderedDistinct) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (d *OrderedDistinct) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.OrderedDistinct")
+
 	it, err := d.Child.RowIter(ctx)
 	if err != nil {
+		span.Finish()
 		return nil, err
 	}
-	return newOrderedDistinctIter(it, d.Child.Schema()), nil
+
+	return sql.NewSpanIter(span, newOrderedDistinctIter(it, d.Child.Schema())), nil
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -23,11 +23,15 @@ func (p *Filter) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (p *Filter) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Filter")
+
 	i, err := p.Child.RowIter(ctx)
 	if err != nil {
+		span.Finish()
 		return nil, err
 	}
-	return NewFilterIter(ctx, p.Expression, i), nil
+
+	return sql.NewSpanIter(span, NewFilterIter(ctx, p.Expression, i)), nil
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/plan/innerjoin_test.go
+++ b/sql/plan/innerjoin_test.go
@@ -49,9 +49,5 @@ func TestInnerJoinEmpty(t *testing.T) {
 	iter, err := j.RowIter(ctx)
 	require.NoError(err)
 
-	filter, ok := iter.(*FilterIter)
-	require.True(ok)
-	require.Equal(ctx, filter.ctx)
-
 	assertRows(t, iter, 0)
 }

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -84,11 +84,13 @@ func (s *Sort) expressionsResolved() bool {
 
 // RowIter implements the Node interface.
 func (s *Sort) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Sort")
 	i, err := s.UnaryNode.Child.RowIter(ctx)
 	if err != nil {
+		span.Finish()
 		return nil, err
 	}
-	return newSortIter(s, i), nil
+	return sql.NewSpanIter(span, newSortIter(s, i)), nil
 }
 
 // TransformUp implements the Transformable interface.

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -34,8 +34,15 @@ func (n *SubqueryAlias) Schema() sql.Schema {
 }
 
 // RowIter implements the Node interface.
-func (n *SubqueryAlias) RowIter(sess *sql.Context) (sql.RowIter, error) {
-	return n.Child.RowIter(sess)
+func (n *SubqueryAlias) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.SubqueryAlias")
+	iter, err := n.Child.RowIter(ctx)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+
+	return sql.NewSpanIter(span, iter), nil
 }
 
 // TransformUp implements the Node interface.


### PR DESCRIPTION
Fixes #137

Depends on #139 and #138 

This commit adds tracing of spans of execution in all nodes and expressions.

Since expressions and functions evaluation is immediate, spans are finished inside the `Eval` function with a defer.
In the case of plan nodes it's a bit more complex, as they just return an iterator that will be lazily evaluated. Measuring the span as just the time it takes to return the iterator would be wrong, so what it does is wrap all iterators with a `spanIter`, which iterates over an internal iterator and finishes the span when it's needed (there is an error, io.EOF is returned or `Close` is called) pushing some metrics like the number of processed rows or the error without needing the user to provide them.