### PR TITLE
sql/analyzer: replace column indexes with GetFields in SortFields

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -212,6 +212,26 @@ func TestQueries(t *testing.T) {
 	)
 }
 
+func TestOrderByColumns(t *testing.T) {
+	require := require.New(t)
+	e := newEngine(t)
+
+	_, iter, err := e.Query(sql.NewEmptyContext(), "SELECT s, i FROM mytable ORDER BY 2 DESC")
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+
+	require.Equal(
+		[]sql.Row{
+			{"third row", int64(3)},
+			{"second row", int64(2)},
+			{"first row", int64(1)},
+		},
+		rows,
+	)
+}
+
 func TestInsertInto(t *testing.T) {
 	e := newEngine(t)
 	testQuery(t, e,

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -478,6 +478,27 @@ var fixtures = map[string]sql.Node{
 			plan.NewUnresolvedTable("foo"),
 		),
 	),
+	`SELECT a, b FROM t ORDER BY 2, 1`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedColumn("a"),
+			expression.NewUnresolvedColumn("b"),
+		},
+		plan.NewSort(
+			[]plan.SortField{
+				{
+					Column:       expression.NewLiteral(int64(2), sql.Int64),
+					Order:        plan.Ascending,
+					NullOrdering: plan.NullsFirst,
+				},
+				{
+					Column:       expression.NewLiteral(int64(1), sql.Int64),
+					Order:        plan.Ascending,
+					NullOrdering: plan.NullsFirst,
+				},
+			},
+			plan.NewUnresolvedTable("t"),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
Fixes #144

Even if literals were being parsed correctly as the Column in the SortFields, we were not acting accordingly on the Sort node, because it acted as a literal and not a GetField expression.
This commit adds a rule to replace the Literal expression inside the SortField Column field into an UnresolvedColumn that will get resolved as any other column in the tree. By doing this with a rule, we avoid handling this special case inside the Sort node.