### PR TITLE
sql: implement functional options pattern for context building

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -430,7 +430,7 @@ func TestTracing(t *testing.T) {
 		require.NoError(closer.Close())
 	}()
 
-	ctx := sql.NewContext(context.TODO(), sql.NewBaseSession(), tracer)
+	ctx := sql.NewContext(context.TODO(), sql.WithTracer(tracer))
 
 	_, iter, err := e.Query(ctx, `SELECT DISTINCT i 
 		FROM mytable 

--- a/server/context.go
+++ b/server/context.go
@@ -59,7 +59,7 @@ func (s *SessionManager) NewContext(conn *mysql.Conn) (*sql.Context, DoneFunc, e
 	s.mu.Lock()
 	sess := s.sessions[conn.ConnectionID]
 	s.mu.Unlock()
-	context := sql.NewContext(ctx, sess, s.tracer)
+	context := sql.NewContext(ctx, sql.WithSession(sess), sql.WithTracer(s.tracer))
 	id, err := uuid.NewV4()
 	if err != nil {
 		cancel()

--- a/sql/session_test.go
+++ b/sql/session_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"testing"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,10 +64,9 @@ func (t *testNodeIterator) Close() error {
 func TestSessionIterator(t *testing.T) {
 	require := require.New(t)
 	ctx, cancelFunc := context.WithCancel(context.TODO())
-	session := NewBaseSession()
 
 	node := &testNode{}
-	iter, err := node.RowIter(NewContext(ctx, session, opentracing.NoopTracer{}))
+	iter, err := node.RowIter(NewContext(ctx))
 	require.NoError(err)
 
 	counter := 0


### PR DESCRIPTION
As the number of dependencies inside sql.Context grows, so will the number of arguments of sql.NewContext. To avoid that, since most of them in testing and mocking are the default arguments it's more convenient to set some default values and configure them optionally using the functional options pattern to do so.