### PR TITLE
sql/analyzer: resolve DUAL table

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -213,6 +213,13 @@ func TestQueries(t *testing.T) {
 			{"third row"},
 		},
 	)
+
+	testQuery(t, e,
+		"SELECT 1 + 2",
+		[][]interface{}{
+			{int64(3)},
+		},
+	)
 }
 
 func TestOrderByColumns(t *testing.T) {

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -137,6 +137,11 @@ func TestResolveTables(t *testing.T) {
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, table)
 	require.NoError(err)
 	require.Equal(table, analyzed)
+
+	notAnalyzed = plan.NewUnresolvedTable("dual")
+	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
+	require.NoError(err)
+	require.Equal(dualTable, analyzed)
 }
 
 func TestResolveTablesNested(t *testing.T) {


### PR DESCRIPTION
Fixes #153

DUAL is a special table that is used when no other table is. For example, `SELECT 1+2` becomes `SELECT 1+2 FROM DUAL`. Because it is a special table, it does not show up in `SHOW TABLES` or anything like that. For that reason, having the analyzer to resolve that table without needing that it is on the catalog means we don't have to add special checks for this case in the logic that finds tables in the catalog.