### PR TITLE
sql/analyzer: implement a rule to assign indexes

### DIFF
--- a/mem/table.go
+++ b/mem/table.go
@@ -1,8 +1,12 @@
 package mem
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
+	"io"
 
+	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -88,3 +92,102 @@ func (t Table) String() string {
 	_ = p.WriteChildren(schema...)
 	return p.String()
 }
+
+var _ sql.Indexable = (*Table)(nil)
+
+var errColumnNotFound = errors.NewKind("could not find column %s")
+
+// IndexKeyValueIter implements the Indexable interface.
+func (t *Table) IndexKeyValueIter(ctx *sql.Context, colNames []string) (sql.IndexKeyValueIter, error) {
+	var columns = make([]int, len(colNames))
+	for i, name := range colNames {
+		var found bool
+		for j, col := range t.schema {
+			if col.Name == name {
+				columns[i] = j
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, errColumnNotFound.New(name)
+		}
+	}
+
+	return &keyValueIter{t.data, columns, 0}, nil
+}
+
+// HandledFilters implements the PushdownProjectionAndFiltersTable interface.
+func (t *Table) HandledFilters([]sql.Expression) []sql.Expression {
+	return nil
+}
+
+// WithProjectAndFilters implements the PushdownProjectionAndFiltersTable interface.
+func (t *Table) WithProjectAndFilters(
+	ctx *sql.Context,
+	columns, filters []sql.Expression,
+) (sql.RowIter, error) {
+	return t.RowIter(ctx)
+}
+
+// WithProjectFiltersAndIndex implements the Indexable interface.
+func (t *Table) WithProjectFiltersAndIndex(
+	ctx *sql.Context,
+	columns, filters []sql.Expression,
+	index sql.IndexValueIter,
+) (sql.RowIter, error) {
+	return &indexIter{t.data, index}, nil
+}
+
+type keyValueIter struct {
+	data    []sql.Row
+	columns []int
+	pos     int
+}
+
+func (i *keyValueIter) Next() ([]interface{}, []byte, error) {
+	if i.pos >= len(i.data) {
+		return nil, nil, io.EOF
+	}
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, int64(i.pos)); err != nil {
+		return nil, nil, err
+	}
+
+	var values = make([]interface{}, len(i.columns))
+	for j, col := range i.columns {
+		values[j] = i.data[i.pos][col]
+	}
+
+	i.pos++
+
+	return values, buf.Bytes(), nil
+}
+
+func (i *keyValueIter) Close() error {
+	i.pos = len(i.data)
+	return nil
+}
+
+type indexIter struct {
+	data  []sql.Row
+	index sql.IndexValueIter
+}
+
+func (i *indexIter) Next() (sql.Row, error) {
+	data, err := i.index.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	var pos int64
+	if err := binary.Read(bytes.NewBuffer(data), binary.LittleEndian, &pos); err != nil {
+		return nil, err
+	}
+
+	return i.data[int(pos)], nil
+}
+
+func (i *indexIter) Close() error { return i.index.Close() }

--- a/mem/table_test.go
+++ b/mem/table_test.go
@@ -1,6 +1,9 @@
 package mem
 
 import (
+	"bytes"
+	"encoding/binary"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,4 +59,99 @@ func TestTable_Insert_RowIter(t *testing.T) {
 	require.Len(rows, 2)
 	require.Nil(s.CheckRow(rows[0]))
 	require.Nil(s.CheckRow(rows[1]))
+}
+
+func TestTableIndexKeyValueIter(t *testing.T) {
+	require := require.New(t)
+
+	table := NewTable("foo", sql.Schema{
+		{Name: "foo", Type: sql.Text},
+		{Name: "bar", Type: sql.Int64},
+	})
+
+	require.NoError(table.Insert(sql.NewRow("foo", int64(1))))
+	require.NoError(table.Insert(sql.NewRow("bar", int64(2))))
+	require.NoError(table.Insert(sql.NewRow("baz", int64(3))))
+
+	iter, err := table.IndexKeyValueIter(sql.NewEmptyContext(), []string{"bar"})
+	require.NoError(err)
+
+	type result struct {
+		key    int64
+		values []interface{}
+	}
+
+	var obtained []result
+	for {
+		values, data, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+
+		var r result
+		require.NoError(binary.Read(bytes.NewBuffer(data), binary.LittleEndian, &r.key))
+		r.values = values
+		obtained = append(obtained, r)
+	}
+
+	var expected = []result{
+		{0, []interface{}{int64(1)}},
+		{1, []interface{}{int64(2)}},
+		{2, []interface{}{int64(3)}},
+	}
+
+	require.Equal(expected, obtained)
+}
+
+func TestTableIndex(t *testing.T) {
+	require := require.New(t)
+
+	table := NewTable("foo", sql.Schema{
+		{Name: "foo", Type: sql.Text},
+		{Name: "bar", Type: sql.Int64},
+	})
+
+	require.NoError(table.Insert(sql.NewRow("foo", int64(1))))
+	require.NoError(table.Insert(sql.NewRow("bar", int64(2))))
+	require.NoError(table.Insert(sql.NewRow("baz", int64(3))))
+	require.NoError(table.Insert(sql.NewRow("qux", int64(4))))
+
+	index := &index{keys: []int64{1, 2}}
+
+	it, err := table.WithProjectFiltersAndIndex(sql.NewEmptyContext(), nil, nil, index)
+	require.NoError(err)
+
+	result, err := sql.RowIterToRows(it)
+	require.NoError(err)
+
+	expected := []sql.Row{
+		{"bar", int64(2)},
+		{"baz", int64(3)},
+	}
+
+	require.Equal(expected, result)
+}
+
+type index struct {
+	keys []int64
+	pos  int
+}
+
+func (i *index) Next() ([]byte, error) {
+	if i.pos >= len(i.keys) {
+		return nil, io.EOF
+	}
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, i.keys[i.pos]); err != nil {
+		return nil, err
+	}
+
+	i.pos++
+	return buf.Bytes(), nil
+}
+
+func (i *index) Close() error {
+	i.pos = len(i.keys)
+	return nil
 }

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -29,10 +29,15 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	a := New(catalog)
 	a.CurrentDatabase = "mydb"
 
+	emptyCols := []sql.Expression{}
+
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("mytable")
 	analyzed, err := a.Analyze(sql.NewEmptyContext(), notAnalyzed)
 	require.NoError(err)
-	require.Equal(table, analyzed)
+	require.Equal(
+		plan.NewPushdownProjectionAndFiltersTable(emptyCols, nil, table),
+		analyzed,
+	)
 
 	notAnalyzed = plan.NewUnresolvedTable("nonexistant")
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), notAnalyzed)
@@ -41,7 +46,10 @@ func TestAnalyzer_Analyze(t *testing.T) {
 
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), table)
 	require.NoError(err)
-	require.Equal(table, analyzed)
+	require.Equal(
+		plan.NewPushdownProjectionAndFiltersTable(emptyCols, nil, table),
+		analyzed,
+	)
 
 	notAnalyzed = plan.NewProject(
 		[]sql.Expression{expression.NewUnresolvedColumn("o")},
@@ -57,7 +65,11 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), notAnalyzed)
 	var expected sql.Node = plan.NewProject(
 		[]sql.Expression{expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false)},
-		table,
+		plan.NewPushdownProjectionAndFiltersTable(
+			[]sql.Expression{expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false)},
+			nil,
+			table,
+		),
 	)
 	require.NoError(err)
 	require.Equal(expected, analyzed)
@@ -66,7 +78,9 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		plan.NewUnresolvedTable("mytable"),
 	)
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), notAnalyzed)
-	expected = plan.NewDescribe(table)
+	expected = plan.NewDescribe(
+		plan.NewPushdownProjectionAndFiltersTable(emptyCols, nil, table),
+	)
 	require.NoError(err)
 	require.Equal(expected, analyzed)
 
@@ -76,7 +90,17 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	)
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), notAnalyzed)
 	require.NoError(err)
-	require.Equal(table, analyzed)
+	require.Equal(
+		plan.NewPushdownProjectionAndFiltersTable(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+				expression.NewGetFieldWithTable(1, sql.Text, "mytable", "t", false),
+			},
+			nil,
+			table,
+		),
+		analyzed,
+	)
 
 	notAnalyzed = plan.NewProject(
 		[]sql.Expression{expression.NewStar()},
@@ -87,7 +111,17 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	)
 	analyzed, err = a.Analyze(sql.NewEmptyContext(), notAnalyzed)
 	require.NoError(err)
-	require.Equal(table, analyzed)
+	require.Equal(
+		plan.NewPushdownProjectionAndFiltersTable(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+				expression.NewGetFieldWithTable(1, sql.Text, "mytable", "t", false),
+			},
+			nil,
+			table,
+		),
+		analyzed,
+	)
 
 	notAnalyzed = plan.NewProject(
 		[]sql.Expression{
@@ -106,7 +140,13 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				"foo",
 			),
 		},
-		table,
+		plan.NewPushdownProjectionAndFiltersTable(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+			},
+			nil,
+			table,
+		),
 	)
 	require.NoError(err)
 	require.Equal(expected, analyzed)
@@ -131,7 +171,13 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
 				expression.NewLiteral(int32(1), sql.Int32),
 			),
-			table,
+			plan.NewPushdownProjectionAndFiltersTable(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+				},
+				nil,
+				table,
+			),
 		),
 	)
 	require.NoError(err)
@@ -153,7 +199,22 @@ func TestAnalyzer_Analyze(t *testing.T) {
 			expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
 			expression.NewGetFieldWithTable(2, sql.Int32, "mytable2", "i2", false),
 		},
-		plan.NewCrossJoin(table, table2),
+		plan.NewCrossJoin(
+			plan.NewPushdownProjectionAndFiltersTable(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+				},
+				nil,
+				table,
+			),
+			plan.NewPushdownProjectionAndFiltersTable(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int32, "mytable2", "i2", false),
+				},
+				nil,
+				table2,
+			),
+		),
 	)
 	require.NoError(err)
 	require.Equal(expected, analyzed)
@@ -172,7 +233,13 @@ func TestAnalyzer_Analyze(t *testing.T) {
 			[]sql.Expression{
 				expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
 			},
-			table,
+			plan.NewPushdownProjectionAndFiltersTable(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+				},
+				nil,
+				table,
+			),
 		),
 	)
 	require.Nil(err)

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -24,7 +24,8 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	db.AddTable("mytable", table)
 	db.AddTable("mytable2", table2)
 
-	catalog := &sql.Catalog{Databases: []sql.Database{db}}
+	catalog := sql.NewCatalog()
+	catalog.AddDatabase(db)
 	a := New(catalog)
 	a.CurrentDatabase = "mydb"
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	errors "gopkg.in/src-d/go-errors.v1"
@@ -801,6 +802,11 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 		return n, nil
 	}
 
+	// don't do pushdown on insert queries
+	if _, ok := n.(*plan.InsertInto); ok {
+		return n, nil
+	}
+
 	var fieldsByTable = make(map[string][]string)
 	var exprsByTable = make(map[string][]sql.Expression)
 	type tableField struct {
@@ -928,10 +934,21 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 				len(tableFilters),
 			)
 
+			release := func() {
+				for _, index := range indexable.index.indexes {
+					a.Catalog.ReleaseIndex(index)
+				}
+			}
+
+			lookup := &releaserIndexLookup{
+				lookup:  indexable.index.lookup,
+				release: release,
+			}
+
 			return plan.NewIndexableTable(
 				cols,
 				handled,
-				indexable.lookup,
+				lookup,
 				indexable.Indexable,
 			), nil
 		case sql.PushdownProjectionTable:
@@ -985,10 +1002,26 @@ func fixFieldIndexes(schema sql.Schema, exp sql.Expression) (sql.Expression, err
 
 func assignIndexes(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error) {
 	if !node.Resolved() {
+		a.Log("node is not resolved, skipping assigning indexes")
 		return node, nil
 	}
 
-	var indexes map[string]sql.IndexLookup
+	a.Log("assigning indexes, node of type: %T", node)
+
+	var indexes map[string]*indexLookup
+	// release all unused indexes
+	defer func() {
+		if indexes == nil {
+			return
+		}
+
+		for _, i := range indexes {
+			for _, index := range i.indexes {
+				a.Catalog.ReleaseIndex(index)
+			}
+		}
+	}()
+
 	var err error
 	plan.Inspect(node, func(node sql.Node) bool {
 		filter, ok := node.(*plan.Filter)
@@ -996,7 +1029,7 @@ func assignIndexes(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, erro
 			return true
 		}
 
-		var result map[string]sql.IndexLookup
+		var result map[string]*indexLookup
 		result, err = getIndexes(filter.Expression, a)
 		if err != nil {
 			return false
@@ -1021,12 +1054,21 @@ func assignIndexes(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, erro
 			return node, nil
 		}
 
-		lookup, ok := indexes[table.Name()]
+		// if we assign indexes to already assigned tables there will be
+		// an infinite loop
+		switch table.(type) {
+		case *plan.IndexableTable, *indexable:
+			return node, nil
+		}
+
+		index, ok := indexes[table.Name()]
 		if !ok {
 			return node, nil
 		}
 
-		return &indexable{lookup, table}, nil
+		delete(indexes, table.Name())
+
+		return &indexable{index, table}, nil
 	})
 }
 
@@ -1043,8 +1085,15 @@ func containsColumns(e sql.Expression) bool {
 
 var errInvalidInRightEvaluation = errors.NewKind("expecting evaluation of IN expression right hand side to be a tuple, but it is %T")
 
-func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, error) {
-	var result = make(map[string]sql.IndexLookup)
+// indexLookup contains an sql.IndexLookup and all sql.Index that are involved
+// in it.
+type indexLookup struct {
+	lookup  sql.IndexLookup
+	indexes []sql.Index
+}
+
+func getIndexes(e sql.Expression, a *Analyzer) (map[string]*indexLookup, error) {
+	var result = make(map[string]*indexLookup)
 	switch e := e.(type) {
 	case *expression.Or:
 		leftIndexes, err := getIndexes(e.Left, a)
@@ -1057,11 +1106,12 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 			return nil, err
 		}
 
-		for table, lookup := range leftIndexes {
-			if lookup2, ok := rightIndexes[table]; ok && canMergeIndexes(lookup, lookup2) {
-				lookup = lookup.(sql.SetOperations).Union(lookup2)
+		for table, idx := range leftIndexes {
+			if idx2, ok := rightIndexes[table]; ok && canMergeIndexes(idx.lookup, idx2.lookup) {
+				idx.lookup = idx.lookup.(sql.SetOperations).Union(idx2.lookup)
+				idx.indexes = append(idx.indexes, idx2.indexes...)
 			}
-			result[table] = lookup
+			result[table] = idx
 		}
 
 		// Put in the result map the indexes for tables we don't have indexes yet.
@@ -1079,19 +1129,29 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 		}
 
 		if !isEvaluable(left) && isEvaluable(right) {
-			index := a.Catalog.IndexByExpression(a.CurrentDatabase, left)
-			if index != nil {
+			idx := a.Catalog.IndexByExpression(a.CurrentDatabase, left)
+			if idx != nil {
+				// release the index if it was not used
+				defer func() {
+					if _, ok := result[idx.Table()]; !ok {
+						a.Catalog.ReleaseIndex(idx)
+					}
+				}()
+
 				value, err := right.Eval(sql.NewEmptyContext(), nil)
 				if err != nil {
 					return nil, err
 				}
 
-				lookup, err := index.Get(value)
+				lookup, err := idx.Get(value)
 				if err != nil {
 					return nil, err
 				}
 
-				result[index.Table()] = lookup
+				result[idx.Table()] = &indexLookup{
+					lookup:  lookup,
+					indexes: []sql.Index{idx},
+				}
 			}
 		}
 	case *expression.In:
@@ -1099,8 +1159,15 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 		// the right branch is evaluable and the indexlookup supports set
 		// operations.
 		if !isEvaluable(e.Left()) && isEvaluable(e.Right()) {
-			index := a.Catalog.IndexByExpression(a.CurrentDatabase, e.Left())
-			if index != nil {
+			idx := a.Catalog.IndexByExpression(a.CurrentDatabase, e.Left())
+			if idx != nil {
+				// release the index if it was not used
+				defer func() {
+					if _, ok := result[idx.Table()]; !ok {
+						a.Catalog.ReleaseIndex(idx)
+					}
+				}()
+
 				value, err := e.Right().Eval(sql.NewEmptyContext(), nil)
 				if err != nil {
 					return nil, err
@@ -1111,13 +1178,13 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 					return nil, errInvalidInRightEvaluation.New(value)
 				}
 
-				lookup, err := index.Get(values[0])
+				lookup, err := idx.Get(values[0])
 				if err != nil {
 					return nil, err
 				}
 
 				for _, v := range values[1:] {
-					lookup2, err := index.Get(v)
+					lookup2, err := idx.Get(v)
 					if err != nil {
 						return nil, err
 					}
@@ -1130,7 +1197,10 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 					lookup = lookup.(sql.SetOperations).Union(lookup2)
 				}
 
-				result[index.Table()] = lookup
+				result[idx.Table()] = &indexLookup{
+					indexes: []sql.Index{idx},
+					lookup:  lookup,
+				}
 			}
 		}
 	case *expression.And:
@@ -1150,14 +1220,15 @@ func getIndexes(e sql.Expression, a *Analyzer) (map[string]sql.IndexLookup, erro
 	return result, nil
 }
 
-func indexesIntersection(left, right map[string]sql.IndexLookup) map[string]sql.IndexLookup {
-	var result = make(map[string]sql.IndexLookup)
+func indexesIntersection(left, right map[string]*indexLookup) map[string]*indexLookup {
+	var result = make(map[string]*indexLookup)
 
-	for table, lookup := range left {
-		if lookup2, ok := right[table]; ok && canMergeIndexes(lookup, lookup2) {
-			lookup = lookup.(sql.SetOperations).Intersection(lookup2)
+	for table, idx := range left {
+		if idx2, ok := right[table]; ok && canMergeIndexes(idx.lookup, idx2.lookup) {
+			idx.lookup = idx.lookup.(sql.SetOperations).Intersection(idx2.lookup)
+			idx.indexes = append(idx.indexes, idx2.indexes...)
 		}
-		result[table] = lookup
+		result[table] = idx
 	}
 
 	// Put in the result map the indexes for tables we don't have indexes yet.
@@ -1198,7 +1269,7 @@ func canMergeIndexes(a, b sql.IndexLookup) bool {
 // It's meant to be used by the pushdown rule to finally wrap the Indexable
 // table with all it requires.
 type indexable struct {
-	lookup sql.IndexLookup
+	index *indexLookup
 	sql.Indexable
 }
 
@@ -1215,4 +1286,61 @@ func (i *indexable) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
 }
 func (i *indexable) TransformExpressionsUp(fn sql.TransformExprFunc) (sql.Node, error) {
 	return i, nil
+}
+
+// releaserIndexLookup is a wrapper around index lookup that is in charge of
+// passing down a release function to release the index once the values of the
+// lookup are consumed.
+type releaserIndexLookup struct {
+	lookup  sql.IndexLookup
+	release func()
+	used    bool
+}
+
+var errLookupUsed = errors.NewKind("unable to reuse this sql.IndexLookup, index already released")
+
+func (l *releaserIndexLookup) Values() (sql.IndexValueIter, error) {
+	if l.used {
+		return nil, errLookupUsed.New()
+	}
+
+	l.used = true
+	iter, err := l.lookup.Values()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+
+	return &releaserValueIter{iter, l.release}, nil
+}
+
+// releaserValueIter is a sql.IndexValueIter capable of releasing the index
+// when the iterator has been either drained or closed.
+type releaserValueIter struct {
+	iter    sql.IndexValueIter
+	release func()
+}
+
+func (i *releaserValueIter) Next() ([]byte, error) {
+	v, err := i.iter.Next()
+	if err != nil {
+		if err == io.EOF {
+			i.Release()
+		}
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func (i *releaserValueIter) Release() {
+	if i.release != nil {
+		i.release()
+		i.release = nil
+	}
+}
+
+func (i *releaserValueIter) Close() error {
+	i.Release()
+	return i.iter.Close()
 }

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -1,7 +1,10 @@
 package analyzer
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -765,7 +768,7 @@ func TestPushdownProjection(t *testing.T) {
 
 func TestPushdownProjectionAndFilters(t *testing.T) {
 	require := require.New(t)
-	a := New(nil)
+	a := New(sql.NewCatalog())
 
 	table := &pushdownProjectionAndFiltersTable{mem.NewTable("mytable", sql.Schema{
 		{Name: "i", Type: sql.Int32, Source: "mytable"},
@@ -847,6 +850,100 @@ func TestPushdownProjectionAndFilters(t *testing.T) {
 	require.Equal(expected, result)
 }
 
+func TestPushdownIndexable(t *testing.T) {
+	require := require.New(t)
+	a := New(sql.NewCatalog())
+
+	var index, index2 dummyIndexLookup
+
+	table := &indexable{
+		index,
+		&indexableTable{&pushdownProjectionAndFiltersTable{mem.NewTable("mytable", sql.Schema{
+			{Name: "i", Type: sql.Int32, Source: "mytable"},
+			{Name: "f", Type: sql.Float64, Source: "mytable"},
+			{Name: "t", Type: sql.Text, Source: "mytable"},
+		})}},
+	}
+
+	table2 := &indexable{
+		index2,
+		&indexableTable{&pushdownProjectionAndFiltersTable{mem.NewTable("mytable2", sql.Schema{
+			{Name: "i2", Type: sql.Int32, Source: "mytable2"},
+			{Name: "f2", Type: sql.Float64, Source: "mytable2"},
+			{Name: "t2", Type: sql.Text, Source: "mytable2"},
+		})}},
+	}
+
+	node := plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedQualifiedColumn("mytable", "i"),
+		},
+		plan.NewFilter(
+			expression.NewAnd(
+				expression.NewAnd(
+					expression.NewEquals(
+						expression.NewUnresolvedQualifiedColumn("mytable", "f"),
+						expression.NewLiteral(3.14, sql.Float64),
+					),
+					expression.NewGreaterThan(
+						expression.NewUnresolvedQualifiedColumn("mytable", "f"),
+						expression.NewLiteral(3., sql.Float64),
+					),
+				),
+				expression.NewIsNull(
+					expression.NewUnresolvedQualifiedColumn("mytable2", "i2"),
+				),
+			),
+			plan.NewCrossJoin(table, table2),
+		),
+	)
+
+	expected := plan.NewProject(
+		[]sql.Expression{
+			expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+		},
+		plan.NewFilter(
+			expression.NewAnd(
+				expression.NewGreaterThan(
+					expression.NewGetFieldWithTable(1, sql.Float64, "mytable", "f", false),
+					expression.NewLiteral(3., sql.Float64),
+				),
+				expression.NewIsNull(
+					expression.NewGetFieldWithTable(3, sql.Int32, "mytable2", "i2", false),
+				),
+			),
+			plan.NewCrossJoin(
+				plan.NewIndexableTable(
+					[]sql.Expression{
+						expression.NewGetFieldWithTable(0, sql.Int32, "mytable", "i", false),
+						expression.NewGetFieldWithTable(1, sql.Float64, "mytable", "f", false),
+					},
+					[]sql.Expression{
+						expression.NewEquals(
+							expression.NewGetFieldWithTable(1, sql.Float64, "mytable", "f", false),
+							expression.NewLiteral(3.14, sql.Float64),
+						),
+					},
+					index,
+					table.Indexable,
+				),
+				plan.NewIndexableTable(
+					[]sql.Expression{
+						expression.NewGetFieldWithTable(0, sql.Int32, "mytable2", "i2", false),
+					},
+					nil,
+					index2,
+					table2.Indexable,
+				),
+			),
+		),
+	)
+
+	result, err := a.Analyze(sql.NewEmptyContext(), node)
+	require.NoError(err)
+	require.Equal(expected, result)
+}
+
 type pushdownProjectionTable struct {
 	sql.Table
 }
@@ -891,6 +988,395 @@ func (t *pushdownProjectionAndFiltersTable) TransformUp(f sql.TransformNodeFunc)
 
 func (t *pushdownProjectionAndFiltersTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return t, nil
+}
+
+type dummyIndexLookup struct{}
+
+func (dummyIndexLookup) Values() sql.IndexValueIter {
+	return nil
+}
+
+type indexableTable struct {
+	sql.PushdownProjectionAndFiltersTable
+}
+
+func (i *indexableTable) IndexKeyValueIter(_ *sql.Context, colNames []string) (sql.IndexKeyValueIter, error) {
+	panic("not implemented")
+}
+
+func (i *indexableTable) WithProjectFiltersAndIndex(
+	ctx *sql.Context,
+	columns, filters []sql.Expression,
+	index sql.IndexValueIter,
+) (sql.RowIter, error) {
+	panic("not implemented")
+}
+
+func (i *indexableTable) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
+	return fn(i)
+}
+
+func (i *indexableTable) TransformExpressionsUp(fn sql.TransformExprFunc) (sql.Node, error) {
+	return i, nil
+}
+
+func TestAssignIndexes(t *testing.T) {
+	require := require.New(t)
+
+	catalog := sql.NewCatalog()
+	done, err := catalog.AddIndex(&dummyIndex{
+		"t2",
+		expression.NewGetFieldWithTable(0, sql.Int64, "t2", "bar", false),
+	})
+	require.NoError(err)
+	close(done)
+
+	done, err = catalog.AddIndex(&dummyIndex{
+		"t1",
+		expression.NewGetFieldWithTable(0, sql.Int64, "t1", "foo", false),
+	})
+	require.NoError(err)
+	close(done)
+
+	time.Sleep(50 * time.Millisecond)
+	a := New(catalog)
+
+	t1 := &indexableTable{
+		&pushdownProjectionAndFiltersTable{
+			mem.NewTable("t1", sql.Schema{
+				{Name: "foo", Type: sql.Int64, Source: "t1"},
+			}),
+		},
+	}
+
+	t2 := &indexableTable{
+		&pushdownProjectionAndFiltersTable{
+			mem.NewTable("t2", sql.Schema{
+				{Name: "bar", Type: sql.Int64, Source: "t2"},
+				{Name: "baz", Type: sql.Int64, Source: "t2"},
+			}),
+		},
+	}
+
+	node := plan.NewProject(
+		[]sql.Expression{},
+		plan.NewFilter(
+			expression.NewOr(
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t2", "bar", false),
+					expression.NewLiteral(int64(1), sql.Int64),
+				),
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t1", "foo", false),
+					expression.NewLiteral(int64(2), sql.Int64),
+				),
+			),
+			plan.NewInnerJoin(
+				t1,
+				t2,
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t1", "foo", false),
+					expression.NewGetFieldWithTable(0, sql.Int64, "t2", "baz", false),
+				),
+			),
+		),
+	)
+
+	expected := plan.NewProject(
+		[]sql.Expression{},
+		plan.NewFilter(
+			expression.NewOr(
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t2", "bar", false),
+					expression.NewLiteral(int64(1), sql.Int64),
+				),
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t1", "foo", false),
+					expression.NewLiteral(int64(2), sql.Int64),
+				),
+			),
+			plan.NewInnerJoin(
+				&indexable{&mergeableIndexLookup{id: "2"}, t1},
+				&indexable{&mergeableIndexLookup{id: "1"}, t2},
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "t1", "foo", false),
+					expression.NewGetFieldWithTable(0, sql.Int64, "t2", "baz", false),
+				),
+			),
+		),
+	)
+
+	result, err := assignIndexes(sql.NewEmptyContext(), a, node)
+	require.NoError(err)
+
+	require.Equal(expected, result)
+}
+
+func TestGetIndexes(t *testing.T) {
+	testCases := []struct {
+		expr     sql.Expression
+		expected map[string]sql.IndexLookup
+		ok       bool
+	}{
+		{
+			expression.NewEquals(
+				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+				expression.NewGetFieldWithTable(1, sql.Int64, "foo", "baz", false),
+			),
+			map[string]sql.IndexLookup{},
+			true,
+		},
+		{
+			expression.NewEquals(
+				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+				expression.NewLiteral(int64(1), sql.Int64),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1"},
+			},
+			true,
+		},
+		{
+			expression.NewOr(
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+					expression.NewLiteral(int64(1), sql.Int64),
+				),
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+					expression.NewLiteral(int64(2), sql.Int64),
+				),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1", unions: []string{"2"}},
+			},
+			true,
+		},
+		{
+			expression.NewAnd(
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+					expression.NewLiteral(int64(1), sql.Int64),
+				),
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+					expression.NewLiteral(int64(2), sql.Int64),
+				),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1", intersections: []string{"2"}},
+			},
+			true,
+		},
+		{
+			expression.NewAnd(
+				expression.NewOr(
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(1), sql.Int64),
+					),
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(2), sql.Int64),
+					),
+				),
+				expression.NewOr(
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(3), sql.Int64),
+					),
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(4), sql.Int64),
+					),
+				),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1", unions: []string{"2", "4"}, intersections: []string{"3"}},
+			},
+			true,
+		},
+		{
+			expression.NewOr(
+				expression.NewOr(
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(1, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(1), sql.Int64),
+					),
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(2), sql.Int64),
+					),
+				),
+				expression.NewOr(
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(3), sql.Int64),
+					),
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+						expression.NewLiteral(int64(4), sql.Int64),
+					),
+				),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1", unions: []string{"2", "3", "4"}},
+			},
+			true,
+		},
+		{
+			expression.NewIn(
+				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+				expression.NewTuple(
+					expression.NewLiteral(int64(1), sql.Int64),
+					expression.NewLiteral(int64(2), sql.Int64),
+					expression.NewLiteral(int64(3), sql.Int64),
+					expression.NewLiteral(int64(4), sql.Int64),
+				),
+			),
+			map[string]sql.IndexLookup{
+				"t1": &mergeableIndexLookup{id: "1", unions: []string{"2", "3", "4"}},
+			},
+			true,
+		},
+	}
+
+	catalog := sql.NewCatalog()
+
+	done, err := catalog.AddIndex(&dummyIndex{
+		"t1",
+		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
+	})
+	require.NoError(t, err)
+	close(done)
+
+	time.Sleep(50 * time.Millisecond)
+	a := New(catalog)
+
+	for _, tt := range testCases {
+		t.Run(tt.expr.String(), func(t *testing.T) {
+			require := require.New(t)
+
+			result, err := getIndexes(tt.expr, a)
+			if tt.ok {
+				require.NoError(err)
+				require.Equal(tt.expected, result)
+			} else {
+				require.Error(err)
+			}
+		})
+	}
+}
+
+type dummyIndex struct {
+	table string
+	expr  sql.Expression
+}
+
+var _ sql.Index = (*dummyIndex)(nil)
+
+func (dummyIndex) Database() string { return "" }
+func (i dummyIndex) ExpressionHashes() []sql.ExpressionHash {
+	h := sha1.New()
+	h.Write([]byte(i.expr.String()))
+	return []sql.ExpressionHash{h.Sum(nil)}
+}
+func (i dummyIndex) Get(key ...interface{}) (sql.IndexLookup, error) {
+	if len(key) != 1 {
+		return &mergeableIndexLookup{id: fmt.Sprint(key)}, nil
+	}
+	return &mergeableIndexLookup{id: fmt.Sprint(key[0])}, nil
+}
+func (i dummyIndex) Has(key ...interface{}) (bool, error) {
+	panic("not implemented")
+}
+func (i dummyIndex) ID() string    { return i.expr.String() }
+func (i dummyIndex) Table() string { return i.table }
+
+func TestIndexesIntersection(t *testing.T) {
+	require := require.New(t)
+
+	left := map[string]sql.IndexLookup{
+		"a": &mergeableIndexLookup{id: "a"},
+		"b": &mergeableIndexLookup{id: "b"},
+		"c": new(dummyIndexLookup),
+	}
+
+	right := map[string]sql.IndexLookup{
+		"b": &mergeableIndexLookup{id: "b2"},
+		"c": &mergeableIndexLookup{id: "c"},
+		"d": &mergeableIndexLookup{id: "d"},
+	}
+
+	require.Equal(
+		map[string]sql.IndexLookup{
+			"a": &mergeableIndexLookup{id: "a"},
+			"b": &mergeableIndexLookup{
+				id:            "b",
+				intersections: []string{"b2"},
+			},
+			"c": new(dummyIndexLookup),
+			"d": &mergeableIndexLookup{id: "d"},
+		},
+		indexesIntersection(left, right),
+	)
+}
+
+func TestCanMergeIndexes(t *testing.T) {
+	require := require.New(t)
+
+	require.False(canMergeIndexes(new(mergeableIndexLookup), new(dummyIndexLookup)))
+	require.True(canMergeIndexes(new(mergeableIndexLookup), new(mergeableIndexLookup)))
+}
+
+type mergeableIndexLookup struct {
+	id            string
+	unions        []string
+	intersections []string
+}
+
+var _ sql.Mergeable = (*mergeableIndexLookup)(nil)
+var _ sql.SetOperations = (*mergeableIndexLookup)(nil)
+
+func (i *mergeableIndexLookup) IsMergeable(lookup sql.IndexLookup) bool {
+	_, ok := lookup.(*mergeableIndexLookup)
+	return ok
+}
+
+func (i *mergeableIndexLookup) Values() sql.IndexValueIter {
+	panic("not implemented")
+}
+
+func (i *mergeableIndexLookup) Difference(indexes ...sql.IndexLookup) sql.IndexLookup {
+	panic("not implemented")
+}
+
+func (i *mergeableIndexLookup) Intersection(indexes ...sql.IndexLookup) sql.IndexLookup {
+	var intersections, unions []string
+	for _, idx := range indexes {
+		intersections = append(intersections, idx.(*mergeableIndexLookup).id)
+		intersections = append(intersections, idx.(*mergeableIndexLookup).intersections...)
+		unions = append(unions, idx.(*mergeableIndexLookup).unions...)
+	}
+	return &mergeableIndexLookup{
+		i.id,
+		append(i.unions, unions...),
+		append(i.intersections, intersections...),
+	}
+}
+
+func (i *mergeableIndexLookup) Union(indexes ...sql.IndexLookup) sql.IndexLookup {
+	var intersections, unions []string
+	for _, idx := range indexes {
+		unions = append(unions, idx.(*mergeableIndexLookup).id)
+		unions = append(unions, idx.(*mergeableIndexLookup).unions...)
+		intersections = append(intersections, idx.(*mergeableIndexLookup).intersections...)
+	}
+	return &mergeableIndexLookup{
+		i.id,
+		append(i.unions, unions...),
+		append(i.intersections, intersections...),
+	}
 }
 
 func getRule(name string) Rule {

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -861,7 +861,7 @@ func TestPushdownIndexable(t *testing.T) {
 	var idx, idx2 dummyIndexLookup
 
 	table := &indexable{
-		&index{idx, nil},
+		&indexLookup{idx, nil},
 		&indexableTable{&pushdownProjectionAndFiltersTable{mem.NewTable("mytable", sql.Schema{
 			{Name: "i", Type: sql.Int32, Source: "mytable"},
 			{Name: "f", Type: sql.Float64, Source: "mytable"},
@@ -870,7 +870,7 @@ func TestPushdownIndexable(t *testing.T) {
 	}
 
 	table2 := &indexable{
-		&index{idx2, nil},
+		&indexLookup{idx2, nil},
 		&indexableTable{&pushdownProjectionAndFiltersTable{mem.NewTable("mytable2", sql.Schema{
 			{Name: "i2", Type: sql.Int32, Source: "mytable2"},
 			{Name: "f2", Type: sql.Float64, Source: "mytable2"},
@@ -1116,11 +1116,11 @@ func TestAssignIndexes(t *testing.T) {
 				),
 			),
 			plan.NewInnerJoin(
-				&indexable{&index{
+				&indexable{&indexLookup{
 					&mergeableIndexLookup{id: "2"},
 					[]sql.Index{idx2},
 				}, t1},
-				&indexable{&index{
+				&indexable{&indexLookup{
 					&mergeableIndexLookup{id: "1"},
 					[]sql.Index{idx1},
 				}, t2},
@@ -1141,7 +1141,7 @@ func TestAssignIndexes(t *testing.T) {
 func TestGetIndexes(t *testing.T) {
 	testCases := []struct {
 		expr     sql.Expression
-		expected map[string]*index
+		expected map[string]*indexLookup
 		ok       bool
 	}{
 		{
@@ -1149,7 +1149,7 @@ func TestGetIndexes(t *testing.T) {
 				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
 				expression.NewGetFieldWithTable(1, sql.Int64, "foo", "baz", false),
 			),
-			map[string]*index{},
+			map[string]*indexLookup{},
 			true,
 		},
 		{
@@ -1157,8 +1157,8 @@ func TestGetIndexes(t *testing.T) {
 				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "bar", false),
 				expression.NewLiteral(int64(1), sql.Int64),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1"},
 					[]sql.Index{
 						&dummyIndex{
@@ -1181,8 +1181,8 @@ func TestGetIndexes(t *testing.T) {
 					expression.NewLiteral(int64(2), sql.Int64),
 				),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1", unions: []string{"2"}},
 					[]sql.Index{
 						&dummyIndex{
@@ -1209,8 +1209,8 @@ func TestGetIndexes(t *testing.T) {
 					expression.NewLiteral(int64(2), sql.Int64),
 				),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1", intersections: []string{"2"}},
 					[]sql.Index{
 						&dummyIndex{
@@ -1249,8 +1249,8 @@ func TestGetIndexes(t *testing.T) {
 					),
 				),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1", unions: []string{"2", "4"}, intersections: []string{"3"}},
 					[]sql.Index{
 						&dummyIndex{
@@ -1297,8 +1297,8 @@ func TestGetIndexes(t *testing.T) {
 					),
 				),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1", unions: []string{"2", "3", "4"}},
 					[]sql.Index{
 						&dummyIndex{
@@ -1332,8 +1332,8 @@ func TestGetIndexes(t *testing.T) {
 					expression.NewLiteral(int64(4), sql.Int64),
 				),
 			),
-			map[string]*index{
-				"t1": &index{
+			map[string]*indexLookup{
+				"t1": &indexLookup{
 					&mergeableIndexLookup{id: "1", unions: []string{"2", "3", "4"}},
 					[]sql.Index{&dummyIndex{
 						table: "t1",
@@ -1402,30 +1402,30 @@ func TestIndexesIntersection(t *testing.T) {
 
 	idx1, idx2 := &dummyIndex{table: "bar"}, &dummyIndex{table: "foo"}
 
-	left := map[string]*index{
-		"a": &index{&mergeableIndexLookup{id: "a"}, nil},
-		"b": &index{&mergeableIndexLookup{id: "b"}, []sql.Index{idx1}},
-		"c": &index{new(dummyIndexLookup), nil},
+	left := map[string]*indexLookup{
+		"a": &indexLookup{&mergeableIndexLookup{id: "a"}, nil},
+		"b": &indexLookup{&mergeableIndexLookup{id: "b"}, []sql.Index{idx1}},
+		"c": &indexLookup{new(dummyIndexLookup), nil},
 	}
 
-	right := map[string]*index{
-		"b": &index{&mergeableIndexLookup{id: "b2"}, []sql.Index{idx2}},
-		"c": &index{&mergeableIndexLookup{id: "c"}, nil},
-		"d": &index{&mergeableIndexLookup{id: "d"}, nil},
+	right := map[string]*indexLookup{
+		"b": &indexLookup{&mergeableIndexLookup{id: "b2"}, []sql.Index{idx2}},
+		"c": &indexLookup{&mergeableIndexLookup{id: "c"}, nil},
+		"d": &indexLookup{&mergeableIndexLookup{id: "d"}, nil},
 	}
 
 	require.Equal(
-		map[string]*index{
-			"a": &index{&mergeableIndexLookup{id: "a"}, nil},
-			"b": &index{
+		map[string]*indexLookup{
+			"a": &indexLookup{&mergeableIndexLookup{id: "a"}, nil},
+			"b": &indexLookup{
 				&mergeableIndexLookup{
 					id:            "b",
 					intersections: []string{"b2"},
 				},
 				[]sql.Index{idx1, idx2},
 			},
-			"c": &index{new(dummyIndexLookup), nil},
-			"d": &index{&mergeableIndexLookup{id: "d"}, nil},
+			"c": &indexLookup{new(dummyIndexLookup), nil},
+			"d": &indexLookup{&mergeableIndexLookup{id: "d"}, nil},
 		},
 		indexesIntersection(left, right),
 	)

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -37,6 +37,11 @@ func (d Databases) Database(name string) (Database, error) {
 	return nil, ErrDatabaseNotFound.New(name)
 }
 
+// AddDatabase adds a new database.
+func (d *Databases) AddDatabase(db Database) {
+	*d = append(*d, db)
+}
+
 // Table returns the Table with the given name if it exists.
 func (d Databases) Table(dbName string, tableName string) (Table, error) {
 	db, err := d.Database(dbName)

--- a/sql/core.go
+++ b/sql/core.go
@@ -151,6 +151,7 @@ type Table interface {
 // Indexable represents a table that supports being indexed and receiving
 // indexes to be able to speed up its execution.
 type Indexable interface {
+	PushdownProjectionAndFiltersTable
 	// IndexKeyValueIter returns an iterator with the values of each row in
 	// the table for the given column names.
 	IndexKeyValueIter(ctx *Context, colNames []string) (IndexKeyValueIter, error)
@@ -158,7 +159,11 @@ type Indexable interface {
 	// method of the table. Returns a new iterator given the columns,
 	// filters and the index so the table can improve its speed instead of
 	// making a full scan.
-	WithProjectFiltersAndIndex(ctx *Context, columns, filters []Expression, index IndexValueIter) (RowIter, error)
+	WithProjectFiltersAndIndex(
+		ctx *Context,
+		columns, filters []Expression,
+		index IndexValueIter,
+	) (RowIter, error)
 }
 
 // PushdownProjectionTable is a table that can produce a specific RowIter

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -84,3 +84,10 @@ func (p *GetField) String() string {
 	}
 	return fmt.Sprintf("%s.%s", p.table, p.name)
 }
+
+// WithIndex returns this same GetField with a new index.
+func (p *GetField) WithIndex(n int) sql.Expression {
+	p2 := *p
+	p2.fieldIndex = n
+	return &p2
+}

--- a/sql/index.go
+++ b/sql/index.go
@@ -78,7 +78,7 @@ type DescendIndex interface {
 // implemented to grant more capabilities to the index lookup.
 type IndexLookup interface {
 	// Values returns the values in the subset of the index.
-	Values() IndexValueIter
+	Values() (IndexValueIter, error)
 }
 
 // SetOperations is a specialization of IndexLookup that enables set operations
@@ -170,7 +170,7 @@ func (r *IndexRegistry) retainIndex(db, id string) {
 	r.rcmut.Lock()
 	defer r.rcmut.Unlock()
 	key := indexKey{db, id}
-	r.refCounts[key] = r.refCounts[key] + 1
+	r.refCounts[key]++
 }
 
 // CanUseIndex returns whether the given index is ready to use or not.
@@ -190,8 +190,7 @@ func (r *IndexRegistry) ReleaseIndex(idx Index) {
 	r.rcmut.Lock()
 	defer r.rcmut.Unlock()
 	key := indexKey{idx.Database(), idx.ID()}
-	r.refCounts[key] = r.refCounts[key] - 1
-
+	r.refCounts[key]--
 	if r.refCounts[key] > 0 {
 		return
 	}

--- a/sql/index/pilosa/driver.go
+++ b/sql/index/pilosa/driver.go
@@ -69,6 +69,7 @@ func (d *Driver) Create(db, table, id string, expr []sql.ExpressionHash, config 
 		table:       table,
 		id:          id,
 		expressions: expr,
+		mapping:     newMapping(path),
 	}, nil
 }
 
@@ -122,11 +123,6 @@ func (d *Driver) Save(ctx context.Context, i sql.Index, iter sql.IndexKeyValueIt
 		return errInvalidIndexType.New(i)
 	}
 
-	path, err := mkdir(d.root, idx.Database(), idx.Table(), idx.ID())
-	if err != nil {
-		return err
-	}
-
 	// Retrieve the pilosa schema
 	schema, err := d.client.Schema()
 	if err != nil {
@@ -152,7 +148,6 @@ func (d *Driver) Save(ctx context.Context, i sql.Index, iter sql.IndexKeyValueIt
 		return err
 	}
 
-	idx.mapping = newMapping(path)
 	idx.mapping.open()
 	defer idx.mapping.close()
 

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -64,6 +64,20 @@ func TestLoadAll(t *testing.T) {
 	}
 }
 
+func assertEqualIndexes(t *testing.T, a, b sql.Index) {
+	t.Helper()
+	require.Equal(t, withoutMapping(a), withoutMapping(b))
+}
+
+func withoutMapping(a sql.Index) sql.Index {
+	if i, ok := a.(*pilosaIndex); ok {
+		b := *i
+		b.mapping = nil
+		return &b
+	}
+	return a
+}
+
 func TestSaveAndLoad(t *testing.T) {
 	if !dockerIsRunning {
 		t.Skipf("Skip TestSaveAndLoad: %s", dockerCmdOutput)
@@ -93,14 +107,16 @@ func TestSaveAndLoad(t *testing.T) {
 	indexes, err := d.LoadAll(db, table)
 	require.Nil(err)
 	require.Equal(1, len(indexes))
-	require.Truef(reflect.DeepEqual(sqlIdx, indexes[0]), "Not equal indexes")
+	assertEqualIndexes(t, sqlIdx, indexes[0])
 
 	for _, r := range it.records {
 		lookup, err := sqlIdx.Get(r.values...)
-		require.Nil(err)
+		require.NoError(err)
 
 		found, foundLoc := false, []string{}
-		lit := lookup.Values()
+		lit, err := lookup.Values()
+		require.NoError(err)
+
 		for i := 0; ; i++ {
 			loc, err := lit.Next()
 			t.Logf("[%d] values: %v location: %x loc: %x err: %v\n", i, r.values, r.location, loc, err)
@@ -150,26 +166,11 @@ func TestSaveAndGetAll(t *testing.T) {
 	indexes, err := d.LoadAll(db, table)
 	require.Nil(err)
 	require.Equal(1, len(indexes))
-	require.Truef(reflect.DeepEqual(sqlIdx, indexes[0]), "Not equal indexes")
+	assertEqualIndexes(t, sqlIdx, indexes[0])
 
-	lookup, err := sqlIdx.Get()
-	require.Nil(err)
-
-	lit := lookup.Values()
-	for i := 0; ; i++ {
-		loc, err := lit.Next()
-		if err == io.EOF {
-			break
-		}
-		require.Nil(err)
-
-		t.Logf("[%d] values: %v location: %x loc: %x err: %v\n", i, it.records[i].values, it.records[i].location, loc, err)
-		require.Truef(reflect.DeepEqual(it.records[i].location, loc),
-			"Expected: %v\nGot: %v\n", it.records[i].location, loc)
-	}
-
-	err = lit.Close()
-	require.Nil(err)
+	_, err = sqlIdx.Get()
+	require.Error(err)
+	require.True(errInvalidKeys.Is(err))
 }
 
 func TestPilosaHiccup(t *testing.T) {
@@ -217,7 +218,7 @@ func TestPilosaHiccup(t *testing.T) {
 	indexes, err := d.LoadAll(db, table)
 	require.Nil(err)
 	require.Equal(1, len(indexes))
-	require.Truef(reflect.DeepEqual(sqlIdx, indexes[0]), "Not equal indexes")
+	assertEqualIndexes(t, sqlIdx, indexes[0])
 
 	for i, r := range it.records {
 		var lookup sql.IndexLookup
@@ -229,9 +230,11 @@ func TestPilosaHiccup(t *testing.T) {
 			}
 			return err
 		})
-		require.Nil(err)
+		require.NoError(err)
 
-		lit := lookup.Values()
+		lit, err := lookup.Values()
+		require.NoError(err)
+
 		loc, err := lit.Next()
 		t.Logf("[%d] values: %v location: %x loc: %x err: %v\n", i, r.values, r.location, loc, err)
 		if err == io.EOF {

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -57,9 +57,9 @@ func TestLoadAll(t *testing.T) {
 
 	for _, idx := range indexes {
 		if idx.ID() == "id1" {
-			require.Truef(reflect.DeepEqual(idx1, idx), "Expected: %v\nGot: %v\n", idx1, idx)
+			assertEqualIndexes(t, idx1, idx)
 		} else {
-			require.Truef(reflect.DeepEqual(idx2, idx), "Expected: %v\nGot: %v\n", idx2, idx)
+			assertEqualIndexes(t, idx2, idx)
 		}
 	}
 }

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -1,17 +1,19 @@
 package pilosa
 
 import (
-	"errors"
 	"io"
+
+	"gopkg.in/src-d/go-errors.v1"
 
 	pilosa "github.com/pilosa/go-pilosa"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
-// Index is an pilosa implementation of sql.Index interface
-type sqlIndex struct {
-	path   string
-	client *pilosa.Client
+// pilosaIndex is an pilosa implementation of sql.Index interface
+type pilosaIndex struct {
+	path    string
+	client  *pilosa.Client
+	mapping *mapping
 
 	db          string
 	table       string
@@ -19,88 +21,32 @@ type sqlIndex struct {
 	expressions []sql.ExpressionHash
 }
 
+var (
+	errInvalidKeys = errors.NewKind("expecting %d keys for index %q, got %d")
+	errPilosaQuery = errors.NewKind("error executing pilosa query: %s")
+)
+
 // Get returns an IndexLookup for the given key in the index.
 // If key parameter is not present then the returned iterator
 // will go through all the locations on the index.
-func (idx *sqlIndex) Get(key ...interface{}) (sql.IndexLookup, error) {
-	name := indexName(idx.Database(), idx.Table(), idx.ID())
-	mapping, err := openMapping(idx.path)
-	if err != nil {
-		return nil, err
+func (idx *pilosaIndex) Get(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(keys) != len(idx.expressions) {
+		return nil, errInvalidKeys.New(len(idx.expressions), idx.ID(), len(keys))
 	}
 
-	n := len(key)
-	if n == 0 {
-		// return all locations from mapping
-		total, err := mapping.getLocationN(name)
-		if err != nil {
-			return nil, err
-		}
-
-		return &sqlIndexLookupIter{
-			total:     uint64(total),
-			mapping:   mapping,
-			indexName: name,
-		}, nil
-	}
-
-	// min(len(key), len(idx.expressions))
-	if n > len(idx.expressions) {
-		n = len(idx.expressions)
-	}
-
-	schema, err := idx.client.Schema()
-	if err != nil {
-		return nil, err
-	}
-	index, err := schema.Index(name)
-	if err != nil {
-		return nil, err
-	}
-
-	// Compute Intersection of bitmaps
-	var bitmaps []*pilosa.PQLBitmapQuery
-	for i := 0; i < n; i++ {
-		frm, err := index.Frame(frameName(idx.expressions[i]))
-		if err != nil {
-			return nil, err
-		}
-
-		rowID, err := mapping.getRowID(frm.Name(), key[i])
-		if err != nil {
-			return nil, err
-		}
-
-		bitmaps = append(bitmaps, frm.Bitmap(rowID))
-	}
-
-	resp, err := idx.client.Query(index.Intersect(bitmaps...))
-	if err != nil {
-		return nil, err
-	}
-	if !resp.Success {
-		return nil, errors.New(resp.ErrorMessage)
-	}
-	if resp.Result() == nil {
-		return &sqlIndexLookupIter{mapping: mapping, indexName: name}, nil
-	}
-
-	bits := resp.Result().Bitmap().Bits
-	return &sqlIndexLookupIter{
-		total:     uint64(len(bits)),
-		bits:      bits,
-		mapping:   mapping,
-		indexName: name,
+	return &indexLookup{
+		indexName:   indexName(idx.Database(), idx.Table(), idx.ID()),
+		mapping:     idx.mapping,
+		keys:        keys,
+		client:      idx.client,
+		expressions: idx.expressions,
 	}, nil
 }
 
 // Has checks if the given key is present in the index mapping
-func (idx *sqlIndex) Has(key ...interface{}) (bool, error) {
-	m, err := openMapping(idx.path)
-	if err != nil {
-		return false, err
-	}
-	defer m.close()
+func (idx *pilosaIndex) Has(key ...interface{}) (bool, error) {
+	idx.mapping.open()
+	defer idx.mapping.close()
 
 	n := len(key)
 	if n > len(idx.expressions) {
@@ -113,7 +59,7 @@ func (idx *sqlIndex) Has(key ...interface{}) (bool, error) {
 		expr := idx.expressions[i]
 		name := frameName(expr)
 
-		val, err := m.get(name, key[i])
+		val, err := idx.mapping.get(name, key[i])
 		if err != nil || val == nil {
 			return false, err
 		}
@@ -123,29 +69,87 @@ func (idx *sqlIndex) Has(key ...interface{}) (bool, error) {
 }
 
 // Database returns the database name this index belongs to.
-func (idx *sqlIndex) Database() string {
+func (idx *pilosaIndex) Database() string {
 	return idx.db
 }
 
 // Table returns the table name this index belongs to.
-func (idx *sqlIndex) Table() string {
+func (idx *pilosaIndex) Table() string {
 	return idx.table
 }
 
 // ID returns the identifier of the index.
-func (idx *sqlIndex) ID() string {
+func (idx *pilosaIndex) ID() string {
 	return idx.id
 }
 
 // Expressions returns the indexed expressions. If the result is more than
 // one expression, it means the index has multiple columns indexed. If it's
 // just one, it means it may be an expression or a column.
-func (idx *sqlIndex) ExpressionHashes() []sql.ExpressionHash {
+func (idx *pilosaIndex) ExpressionHashes() []sql.ExpressionHash {
 	return idx.expressions
 }
 
-// lookup implements sql.IndexLookup and sql.IndexValueIter interface
-type sqlIndexLookupIter struct {
+type indexLookup struct {
+	keys        []interface{}
+	indexName   string
+	mapping     *mapping
+	client      *pilosa.Client
+	expressions []sql.ExpressionHash
+}
+
+func (l *indexLookup) Values() (sql.IndexValueIter, error) {
+	l.mapping.open()
+
+	schema, err := l.client.Schema()
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := schema.Index(l.indexName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute Intersection of bitmaps
+	var bitmaps []*pilosa.PQLBitmapQuery
+	for i := 0; i < len(l.keys); i++ {
+		frm, err := index.Frame(frameName(l.expressions[i]))
+		if err != nil {
+			return nil, err
+		}
+
+		rowID, err := l.mapping.getRowID(frm.Name(), l.keys[i])
+		if err != nil {
+			return nil, err
+		}
+
+		bitmaps = append(bitmaps, frm.Bitmap(rowID))
+	}
+
+	resp, err := l.client.Query(index.Intersect(bitmaps...))
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Success {
+		return nil, errPilosaQuery.New(resp.ErrorMessage)
+	}
+
+	if resp.Result() == nil {
+		return &indexValueIter{mapping: l.mapping, indexName: l.indexName}, nil
+	}
+
+	bits := resp.Result().Bitmap().Bits
+	return &indexValueIter{
+		total:     uint64(len(bits)),
+		bits:      bits,
+		mapping:   l.mapping,
+		indexName: l.indexName,
+	}, nil
+}
+
+type indexValueIter struct {
 	offset    uint64
 	total     uint64
 	bits      []uint64
@@ -153,12 +157,11 @@ type sqlIndexLookupIter struct {
 	indexName string
 }
 
-func (it *sqlIndexLookupIter) Values() sql.IndexValueIter {
-	return it
-}
-
-func (it *sqlIndexLookupIter) Next() ([]byte, error) {
+func (it *indexValueIter) Next() ([]byte, error) {
 	if it.offset >= it.total {
+		if err := it.Close(); err != nil {
+			return nil, err
+		}
 		return nil, io.EOF
 	}
 
@@ -170,12 +173,8 @@ func (it *sqlIndexLookupIter) Next() ([]byte, error) {
 	}
 
 	it.offset++
+
 	return it.mapping.getLocation(it.indexName, colID)
 }
 
-func (it *sqlIndexLookupIter) Close() error {
-	it.offset, it.total = uint64(0), uint64(0)
-	it.bits = nil
-
-	return it.mapping.close()
-}
+func (it *indexValueIter) Close() error { return it.mapping.close() }

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 
 	pilosa "github.com/pilosa/go-pilosa"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -160,7 +161,8 @@ type indexValueIter struct {
 func (it *indexValueIter) Next() ([]byte, error) {
 	if it.offset >= it.total {
 		if err := it.Close(); err != nil {
-			return nil, err
+			logrus.WithField("err", err.Error()).
+				Error("unable to close the pilosa index value iterator")
 		}
 		return nil, io.EOF
 	}

--- a/sql/index/pilosa/mapping_test.go
+++ b/sql/index/pilosa/mapping_test.go
@@ -15,8 +15,8 @@ func TestRowID(t *testing.T) {
 	require.Nil(err)
 	defer os.RemoveAll(path)
 
-	m, err := openMapping(path)
-	require.Nil(err)
+	m := newMapping(path)
+	m.open()
 	defer m.close()
 
 	cases := []int{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}
@@ -36,8 +36,8 @@ func TestLocation(t *testing.T) {
 	require.Nil(err)
 	defer os.RemoveAll(path)
 
-	m, err := openMapping(path)
-	require.Nil(err)
+	m := newMapping(path)
+	m.open()
 	defer m.close()
 
 	cases := map[uint64]string{
@@ -67,8 +67,8 @@ func TestGet(t *testing.T) {
 	require.Nil(err)
 	defer os.RemoveAll(path)
 
-	m, err := openMapping(path)
-	require.Nil(err)
+	m := newMapping(path)
+	m.open()
 	defer m.close()
 
 	cases := []int{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -134,12 +134,12 @@ type dummyExpr struct {
 
 var _ Expression = (*dummyExpr)(nil)
 
-func (dummyExpr) Children() []Expression                               { return nil }
-func (dummyExpr) Eval(*Context, Row) (interface{}, error)              { panic("not implemented") }
-func (dummyExpr) TransformUp(fn TransformExprFunc) (Expression, error) { panic("not implemented") }
-func (d dummyExpr) String() string {
-	return fmt.Sprintf("dummyExpr{foo: %d, bar: %s}", d.foo, d.bar)
+func (dummyExpr) Children() []Expression                  { return nil }
+func (dummyExpr) Eval(*Context, Row) (interface{}, error) { panic("not implemented") }
+func (e dummyExpr) TransformUp(fn TransformExprFunc) (Expression, error) {
+	return fn(e)
 }
+func (e dummyExpr) String() string { return fmt.Sprintf("dummyExpr{%d, %q}", e.foo, e.bar) }
 func (dummyExpr) IsNullable() bool { return false }
 func (dummyExpr) Resolved() bool   { return false }
 func (dummyExpr) Type() Type       { panic("not implemented") }

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -99,8 +99,18 @@ type indexableTable struct {
 	sql.Table
 }
 
-func (indexableTable) IndexKeyValueIter(ctx *sql.Context, colNames []string) (sql.IndexKeyValueIter, error) {
+var _ sql.Indexable = (*indexableTable)(nil)
+
+func (indexableTable) HandledFilters([]sql.Expression) []sql.Expression {
+	panic("not implemented")
+}
+
+func (indexableTable) IndexKeyValueIter(_ *sql.Context, colNames []string) (sql.IndexKeyValueIter, error) {
 	return nil, nil
+}
+
+func (indexableTable) WithProjectAndFilters(ctx *sql.Context, columns, filters []sql.Expression) (sql.RowIter, error) {
+	panic("not implemented")
 }
 
 func (indexableTable) WithProjectFiltersAndIndex(

--- a/sql/plan/pushdown.go
+++ b/sql/plan/pushdown.go
@@ -171,10 +171,6 @@ func (t *PushdownProjectionAndFiltersTable) Expressions() []sql.Expression {
 // TransformExpressions implements the Expressioner interface.
 func (t *PushdownProjectionAndFiltersTable) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
 	cols, err := transformExpressionsUp(f, t.Columns)
-	if err != nil {
-		return nil, err
-	}
-
 	filters, err := transformExpressionsUp(f, t.Filters)
 	if err != nil {
 		return nil, err
@@ -185,4 +181,95 @@ func (t *PushdownProjectionAndFiltersTable) TransformExpressions(f sql.Transform
 		filters,
 		t.PushdownProjectionAndFiltersTable,
 	), nil
+}
+
+// IndexableTable is a node wrapping a table implementing the sql.Inedxable
+// interface so it returns a RowIter with custom logic given the set of used
+// columns that need to be projected, the filtes that apply to that table and
+// the indexes to use.
+// IndexableTable nodes don't propagate transformations to the underlying
+// table.
+type IndexableTable struct {
+	sql.Indexable
+	Columns []sql.Expression
+	Filters []sql.Expression
+	Index   sql.IndexLookup
+}
+
+// NewPushdownProjectionAndFiltersTable creates a new
+// PushdownProjectionAndFiltersTable node.
+func NewIndexableTable(
+	columns []sql.Expression,
+	filters []sql.Expression,
+	index sql.IndexLookup,
+	table sql.Indexable,
+) *IndexableTable {
+	return &IndexableTable{table, columns, filters, index}
+}
+
+// TransformUp implements the Node interface.
+func (t *IndexableTable) TransformUp(
+	f sql.TransformNodeFunc,
+) (sql.Node, error) {
+	return f(t)
+}
+
+// TransformExpressionsUp implements the Node interface.
+func (t *IndexableTable) TransformExpressionsUp(
+	f sql.TransformExprFunc,
+) (sql.Node, error) {
+	filters, err := transformExpressionsUp(f, t.Filters)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewIndexableTable(t.Columns, filters, t.Index, t.Indexable), nil
+}
+
+// RowIter implements the Node interface.
+func (t *IndexableTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.IndexableTable", opentracing.Tags{
+		"columns": len(t.Columns),
+		"filters": len(t.Filters),
+		"table":   t.Name(),
+	})
+
+	iter, err := t.WithProjectFiltersAndIndex(ctx, t.Columns, t.Filters, t.Index.Values())
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+
+	return sql.NewSpanIter(span, iter), nil
+}
+
+func (t IndexableTable) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("IndexableTable")
+
+	var columns = make([]string, len(t.Columns))
+	for i, col := range t.Columns {
+		columns[i] = col.String()
+	}
+
+	var filters = make([]string, len(t.Filters))
+	for i, f := range t.Filters {
+		filters[i] = f.String()
+	}
+
+	_ = pr.WriteChildren(
+		fmt.Sprintf("Columns(%s)", strings.Join(columns, ", ")),
+		fmt.Sprintf("Filters(%s)", strings.Join(filters, ", ")),
+		t.Indexable.String(),
+	)
+
+	return pr.String()
+}
+
+// Expressions implements the Expressioner interface.
+func (t IndexableTable) Expressions() []sql.Expression {
+	var exprs []sql.Expression
+	exprs = append(exprs, t.Columns...)
+	exprs = append(exprs, t.Filters...)
+	return exprs
 }

--- a/sql/plan/pushdown.go
+++ b/sql/plan/pushdown.go
@@ -234,7 +234,12 @@ func (t *IndexableTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		"table":   t.Name(),
 	})
 
-	iter, err := t.WithProjectFiltersAndIndex(ctx, t.Columns, t.Filters, t.Index.Values())
+	values, err := t.Index.Values()
+	if err != nil {
+		return nil, err
+	}
+
+	iter, err := t.WithProjectFiltersAndIndex(ctx, t.Columns, t.Filters, values)
 	if err != nil {
 		span.Finish()
 		return nil, err
@@ -273,3 +278,6 @@ func (t IndexableTable) Expressions() []sql.Expression {
 	exprs = append(exprs, t.Filters...)
 	return exprs
 }
+
+// Children implements the Node interface.
+func (t IndexableTable) Children() []sql.Node { return nil }

--- a/sql/plan/pushdown_test.go
+++ b/sql/plan/pushdown_test.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"bytes"
+	"encoding/gob"
 	"io"
 	"testing"
 
@@ -168,4 +170,85 @@ Loop:
 
 		return row, nil
 	}
+}
+
+func TestPushdownIndexableTable(t *testing.T) {
+	require := require.New(t)
+
+	index := &indexLookup{[]interface{}{1, 2, 3}}
+	filters := []sql.Expression{
+		expression.NewLiteral(1, sql.Int64),
+		expression.NewLiteral(2, sql.Int64),
+	}
+	columns := []sql.Expression{
+		expression.NewLiteral(3, sql.Int64),
+		expression.NewLiteral(4, sql.Int64),
+	}
+
+	table := &pushdownIndexableTable{nil, t, columns, filters, index, false}
+
+	pushdownIndexableTable := NewIndexableTable(columns, filters, index, table)
+
+	_, err := pushdownIndexableTable.RowIter(sql.NewEmptyContext())
+	require.NoError(err)
+	require.True(table.called)
+}
+
+type pushdownIndexableTable struct {
+	sql.PushdownProjectionAndFiltersTable
+	t                *testing.T
+	columns, filters []sql.Expression
+	index            sql.IndexLookup
+	called           bool
+}
+
+func (t *pushdownIndexableTable) WithProjectFiltersAndIndex(
+	ctx *sql.Context,
+	columns, filters []sql.Expression,
+	index sql.IndexValueIter,
+) (sql.RowIter, error) {
+	t.called = true
+	require := require.New(t.t)
+	require.Equal(t.columns, columns)
+	require.Equal(t.filters, filters)
+	require.Equal(t.index.Values(), index)
+	return sql.RowsToRowIter(), nil
+}
+
+func (t *pushdownIndexableTable) IndexKeyValueIter(_ *sql.Context, colNames []string) (sql.IndexKeyValueIter, error) {
+	panic("not implemented")
+}
+
+func (t *pushdownIndexableTable) Name() string { return "name" }
+
+type indexLookup struct {
+	values []interface{}
+}
+
+func (l indexLookup) Values() sql.IndexValueIter {
+	return &indexValueIter{l.values, 0}
+}
+
+type indexValueIter struct {
+	values []interface{}
+	pos    int
+}
+
+func (i *indexValueIter) Next() ([]byte, error) {
+	if i.pos >= len(i.values) {
+		return nil, io.EOF
+	}
+
+	i.pos++
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(i.values[i.pos-1]); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (i *indexValueIter) Close() error {
+	i.pos = len(i.values)
+	return nil
 }

--- a/sql/plan/pushdown_test.go
+++ b/sql/plan/pushdown_test.go
@@ -211,7 +211,9 @@ func (t *pushdownIndexableTable) WithProjectFiltersAndIndex(
 	require := require.New(t.t)
 	require.Equal(t.columns, columns)
 	require.Equal(t.filters, filters)
-	require.Equal(t.index.Values(), index)
+	values, err := t.index.Values()
+	require.NoError(err)
+	require.Equal(values, index)
 	return sql.RowsToRowIter(), nil
 }
 
@@ -225,8 +227,8 @@ type indexLookup struct {
 	values []interface{}
 }
 
-func (l indexLookup) Values() sql.IndexValueIter {
-	return &indexValueIter{l.values, 0}
+func (l indexLookup) Values() (sql.IndexValueIter, error) {
+	return &indexValueIter{l.values, 0}, nil
 }
 
 type indexValueIter struct {


### PR DESCRIPTION
Closes #176

This commit introduces the `assign_indexes` rule, which finds expressions that are indexed and pushes them down to their respective tables. This rule works in combination with the `pushdown` rule. It simply finds indexes and combines them to wrap their table node with a placeholder node that has the indexes.
Then, is in the pushdown when the table node is wrapped with the final pushed down version with the projection, filters and indexes. These two rules work together because a `sql.Indexable` table also requires the filters and the projection to be pushed down. Since this logic is already implemented in the `pushdown` rule, this avoids repeating this complicated logic by simply delegating that work to the `pushdown` rule and only finding the indexes and combining them in `assign_indexes`.

How does finding indexes work?

- Every expression is checked against the index registry to check if it's indexed.
- When expressions inside OR or AND nodes are encountered, they are combined, if such combination is possible.
  - In OR expressions, filters for the same table are combined using `Union`.
  - In AND expression, filters for the same table are combined using `Intersection`.
  - If no combination is possible, the first-most index is kept and the others are discarded.
- All indexes are grouped by its table, generating a map between table name and a `sql.IndexLookup`.

**NOTE:** multiple column indexes are not handled yet. They will be handled in a subsequent PR as a second iteration.
