### PR TITLE
all: add vanity import specs

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1,4 +1,4 @@
-package sqle
+package sqle // import "gopkg.in/src-d/go-mysql-server.v0"
 
 import (
 	opentracing "github.com/opentracing/opentracing-go"

--- a/mem/database.go
+++ b/mem/database.go
@@ -1,4 +1,4 @@
-package mem
+package mem // import "gopkg.in/src-d/go-mysql-server.v0/mem"
 
 import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-package server
+package server // import "gopkg.in/src-d/go-mysql-server.v0/server"
 
 import (
 	opentracing "github.com/opentracing/opentracing-go"

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -1,4 +1,4 @@
-package analyzer
+package analyzer // import "gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 
 import (
 	"os"

--- a/sql/core.go
+++ b/sql/core.go
@@ -1,4 +1,4 @@
-package sql
+package sql // import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
 import (
 	"crypto/sha1"

--- a/sql/expression/doc.go
+++ b/sql/expression/doc.go
@@ -1,0 +1,1 @@
+package expression // import "gopkg.in/src-d/go-mysql-server.v0/sql/expression"

--- a/sql/expression/function/aggregation/avg.go
+++ b/sql/expression/function/aggregation/avg.go
@@ -1,4 +1,4 @@
-package aggregation
+package aggregation // import "gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation"
 
 import (
 	"fmt"

--- a/sql/expression/function/arraylength.go
+++ b/sql/expression/function/arraylength.go
@@ -1,4 +1,4 @@
-package function
+package function // import "gopkg.in/src-d/go-mysql-server.v0/sql/expression/function"
 
 import (
 	"fmt"

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1,4 +1,4 @@
-package parse
+package parse // import "gopkg.in/src-d/go-mysql-server.v0/sql/parse"
 
 import (
 	"fmt"

--- a/sql/plan/common.go
+++ b/sql/plan/common.go
@@ -1,4 +1,4 @@
-package plan
+package plan // import "gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 
 import "gopkg.in/src-d/go-mysql-server.v0/sql"
 


### PR DESCRIPTION
This CL adds vanity imports to all packages to prevent importing any
given package from the wrong import path.