### PR TITLE
Replace expressions by hashes in IndexDriver

### DIFF
--- a/sql/core.go
+++ b/sql/core.go
@@ -1,7 +1,9 @@
 package sql
 
 import (
+	"crypto/sha1"
 	"fmt"
+	"hash"
 
 	"gopkg.in/src-d/go-errors.v1"
 )
@@ -75,6 +77,14 @@ type Expression interface {
 	TransformUp(TransformExprFunc) (Expression, error)
 	// Children returns the children expressions of this expression.
 	Children() []Expression
+}
+
+// NewExpressionHash returns a new Hash for given Expression instance.
+// Hash (sha1) checksum will be calculated based on ex.String().
+func NewExpressionHash(ex Expression) hash.Hash {
+	h := sha1.New()
+	h.Write([]byte(ex.String()))
+	return h
 }
 
 // Aggregation implements an aggregation expression, where an

--- a/sql/index.go
+++ b/sql/index.go
@@ -111,9 +111,9 @@ type IndexDriver interface {
 	// Create a new index. If exprs is more than one expression, it means the
 	// index has multiple columns indexed. If it's just one, it means it may
 	// be an expression or a column.
-	Create(table, db, id string, expressionHashes []hash.Hash, config map[string]string) (Index, error)
+	Create(db, table, id string, expressionHashes []hash.Hash, config map[string]string) (Index, error)
 	// Load the index at the given path.
-	Load(table, db string) ([]Index, error)
+	Load(db, table string) ([]Index, error)
 	// Save the given index at the given path.
 	Save(ctx context.Context, index Index, iter IndexKeyValueIter) error
 	// Delete the index with the given path.

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -1,6 +1,9 @@
 package sql
 
 import (
+	"crypto/sha1"
+	"fmt"
+	"hash"
 	"testing"
 	"time"
 
@@ -114,7 +117,11 @@ type dummyIdx struct {
 
 var _ Index = (*dummyIdx)(nil)
 
-func (i dummyIdx) Expressions() []Expression            { return []Expression{i.expr} }
+func (i dummyIdx) ExpressionHashes() []hash.Hash {
+	h := sha1.New()
+	h.Write([]byte(i.expr.String()))
+	return []hash.Hash{h}
+}
 func (i dummyIdx) ID() string                           { return i.id }
 func (i dummyIdx) Get(interface{}) (IndexLookup, error) { panic("not implemented") }
 func (i dummyIdx) Has(interface{}) (bool, error)        { panic("not implemented") }
@@ -131,7 +138,9 @@ var _ Expression = (*dummyExpr)(nil)
 func (dummyExpr) Children() []Expression                               { return nil }
 func (dummyExpr) Eval(*Context, Row) (interface{}, error)              { panic("not implemented") }
 func (dummyExpr) TransformUp(fn TransformExprFunc) (Expression, error) { panic("not implemented") }
-func (dummyExpr) String() string                                       { return "dummyExpr" }
-func (dummyExpr) IsNullable() bool                                     { return false }
-func (dummyExpr) Resolved() bool                                       { return false }
-func (dummyExpr) Type() Type                                           { panic("not implemented") }
+func (d dummyExpr) String() string {
+	return fmt.Sprintf("dummyExpr{foo: %d, bar: %s}", d.foo, d.bar)
+}
+func (dummyExpr) IsNullable() bool { return false }
+func (dummyExpr) Resolved() bool   { return false }
+func (dummyExpr) Type() Type       { panic("not implemented") }

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"hash"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -90,9 +91,8 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}
 
 	index, err := driver.Create(
-		c.Catalog.IndexRegistry.Root,
-		nameable.Name(),
 		c.CurrentDatabase,
+		nameable.Name(),
 		c.Name,
 		exprs,
 		c.Config,
@@ -112,7 +112,7 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}
 
 	go func() {
-		err := driver.Save(ctx, c.Catalog.IndexRegistry.Root, index, iter)
+		err := driver.Save(ctx, index, iter)
 		close(done)
 		if err != nil {
 			logrus.WithField("err", err).Error("unable to save the index")
@@ -187,14 +187,13 @@ func (c *CreateIndex) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
 // to match a row with only the returned columns in that same order.
 func getColumnsAndPrepareExpressions(
 	exprs []sql.Expression,
-) ([]string, []sql.Expression, error) {
+) ([]string, []hash.Hash, error) {
 	var columns []string
 	var seen = make(map[string]int)
-	var expressions = make([]sql.Expression, len(exprs))
+	var expressions = make([]hash.Hash, len(exprs))
 
 	for i, e := range exprs {
-		var err error
-		expressions[i], err = e.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		ex, err := e.TransformUp(func(e sql.Expression) (sql.Expression, error) {
 			gf, ok := e.(*expression.GetField)
 			if !ok {
 				return e, nil
@@ -221,6 +220,8 @@ func getColumnsAndPrepareExpressions(
 		if err != nil {
 			return nil, nil, err
 		}
+
+		expressions[i] = sql.NewExpressionHash(ex)
 	}
 
 	return columns, expressions, nil

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"hash"
 	"testing"
 	"time"
 
@@ -46,17 +47,17 @@ func TestCreateIndex(t *testing.T) {
 	require.Equal([]string{"idx"}, driver.saved)
 	idx := catalog.IndexRegistry.Index("foo", "idx")
 	require.NotNil(idx)
-	require.Equal(&mockIndex{"idx", "foo", "foo", []sql.Expression{
-		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
-		expression.NewGetFieldWithTable(1, sql.Int64, "foo", "a", true),
+	require.Equal(&mockIndex{"foo", "foo", "idx", []hash.Hash{
+		sql.NewExpressionHash(expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true)),
+		sql.NewExpressionHash(expression.NewGetFieldWithTable(1, sql.Int64, "foo", "a", true)),
 	}}, idx)
 }
 
 type mockIndex struct {
-	id    string
-	table string
 	db    string
-	exprs []sql.Expression
+	table string
+	id    string
+	exprs []hash.Hash
 }
 
 var _ sql.Index = (*mockIndex)(nil)
@@ -64,7 +65,7 @@ var _ sql.Index = (*mockIndex)(nil)
 func (i *mockIndex) ID() string                    { return i.id }
 func (i *mockIndex) Table() string                 { return i.table }
 func (i *mockIndex) Database() string              { return i.db }
-func (i *mockIndex) Expressions() []sql.Expression { return i.exprs }
+func (i *mockIndex) ExpressionHashes() []hash.Hash { return i.exprs }
 func (i *mockIndex) Get(key interface{}) (sql.IndexLookup, error) {
 	panic("unimplemented")
 }
@@ -80,17 +81,17 @@ type mockDriver struct {
 var _ sql.IndexDriver = (*mockDriver)(nil)
 
 func (*mockDriver) ID() string { return "mock" }
-func (*mockDriver) Create(path, db, table, id string, exprs []sql.Expression, config map[string]string) (sql.Index, error) {
-	return &mockIndex{id, table, db, exprs}, nil
+func (*mockDriver) Create(db, table, id string, exprs []hash.Hash, config map[string]string) (sql.Index, error) {
+	return &mockIndex{db, table, id, exprs}, nil
 }
-func (*mockDriver) Load(path string) (sql.Index, error) {
+func (*mockDriver) Load(db, table string) ([]sql.Index, error) {
 	panic("not implemented")
 }
-func (d *mockDriver) Save(ctx context.Context, path string, index sql.Index, iter sql.IndexKeyValueIter) error {
+func (d *mockDriver) Save(ctx context.Context, index sql.Index, iter sql.IndexKeyValueIter) error {
 	d.saved = append(d.saved, index.ID())
 	return nil
 }
-func (d *mockDriver) Delete(path string, index sql.Index) error {
+func (d *mockDriver) Delete(index sql.Index) error {
 	d.deleted = append(d.deleted, index.ID())
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
It's hard to deal with `[]sql.Expression` in `IndexDriver` (due to interfaces deserialization issues in go). After meeting with @ajnavarro and @erizocosmico we decided to introduce some kind of `ID` which let us compare two expressions. In `IndexDriver` we do not need _full Expressions_, IDs are good enough. 
This PR introduce a new function `NewExpressionHash(Expression) hash.Hash` and `IndexDriver.ExpressionHashes() []hash.Hash`. A default implementation returns a _sha1_ (but we can replace it by any hash algorithm) based on `Expression.String()`. It would be also easy to map it, because all DBs use _key-value pairs_ as  `[]byte`.

It closes: https://github.com/src-d/go-mysql-server/issues/194