### PR TITLE
sql/plan: return a new instance of sql.Row in cross join iterator's next method

### DIFF
--- a/sql/plan/cross_join.go
+++ b/sql/plan/cross_join.go
@@ -147,7 +147,11 @@ func (i *crossJoinIterator) Next() (sql.Row, error) {
 			return nil, err
 		}
 
-		return append(i.leftRow, rightRow...), nil
+		var row sql.Row
+		row = append(row, i.leftRow...)
+		row = append(row, rightRow...)
+
+		return row, nil
 	}
 }
 


### PR DESCRIPTION
Trying to update the `go-mysql-server` dependency in [gitbase](https://github.com/src-d/gitbase) I stumbled upon some test failing because of the `sql.RowIterToRows` function returning weird results.

The thing is that the `Next` method in the cross join iterator reuses the same memory addresses of the returning rows to allocate new rows in the next callings.

So when you keep that rows in a slice, like `sql.RowIterToRows` function does, you will end up with rows supposed not to be there in the slice if after the cross join iterator the rows are filtered by a filter iterator.

It seems that assigning the elements from the both side of the cross join to a new `sql.Row` fix the problem.
