### PR TITLE
analyzer: execute rules in batches.

### DIFF
--- a/benchmark/tpc_h_test.go
+++ b/benchmark/tpc_h_test.go
@@ -30,7 +30,7 @@ func BenchmarkTpch(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 	b.ResetTimer()
 

--- a/engine.go
+++ b/engine.go
@@ -14,12 +14,17 @@ type Engine struct {
 	Analyzer *analyzer.Analyzer
 }
 
-// New creates a new Engine.
-func New() *Engine {
+// New creates a new Engine
+func New(c *sql.Catalog, a *analyzer.Analyzer) *Engine {
+	return &Engine{c, a}
+}
+
+// NewDefault creates a new default Engine.
+func NewDefault() *Engine {
 	c := sql.NewCatalog()
 	c.RegisterFunctions(function.Defaults)
 
-	a := analyzer.New(c)
+	a := analyzer.NewDefault(c)
 	return &Engine{c, a}
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -292,7 +292,7 @@ func TestAmbiguousColumnResolution(t *testing.T) {
 	db.AddTable(table.Name(), table)
 	db.AddTable(table2.Name(), table2)
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 
 	q := `SELECT f.a, bar.b, f.b FROM foo f INNER JOIN bar ON f.a = bar.c`
@@ -374,7 +374,7 @@ func TestNaturalJoin(t *testing.T) {
 	db.AddTable(t1.Name(), t1)
 	db.AddTable(t2.Name(), t2)
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 
 	_, iter, err := e.Query(sql.NewEmptyContext(), `SELECT * FROM t1 NATURAL JOIN t2`)
@@ -418,7 +418,7 @@ func TestNaturalJoinEqual(t *testing.T) {
 	db.AddTable(t1.Name(), t1)
 	db.AddTable(t2.Name(), t2)
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 
 	_, iter, err := e.Query(sql.NewEmptyContext(), `SELECT * FROM t1 NATURAL JOIN t2`)
@@ -458,7 +458,7 @@ func TestNaturalJoinDisjoint(t *testing.T) {
 	db.AddTable(t1.Name(), t1)
 	db.AddTable(t2.Name(), t2)
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 
 	_, iter, err := e.Query(sql.NewEmptyContext(), `SELECT * FROM t1 NATURAL JOIN t2`)
@@ -538,7 +538,7 @@ func newEngine(t *testing.T) *sqle.Engine {
 	db.AddTable(table2.Name(), table2)
 	db.AddTable(table3.Name(), table3)
 
-	e := sqle.New()
+	e := sqle.NewDefault()
 	e.AddDatabase(db)
 
 	return e

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Example() {
-	e := sqle.New()
+	e := sqle.NewDefault()
 	ctx := sql.NewEmptyContext()
 
 	// Create a test memory database and register it to the default engine.

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func setupMemDB(require *require.Assertions) *sqle.Engine {
-	e := sqle.New()
+	e := sqle.NewDefault()
 	db := mem.NewDatabase("test")
 	e.AddDatabase(db)
 

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -2,76 +2,116 @@ package analyzer // import "gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 
 import (
 	"os"
-	"reflect"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
+
+const debugAnalyzerKey = "DEBUG_ANALYZER"
 
 const maxAnalysisIterations = 1000
 
 // ErrMaxAnalysisIters is thrown when the analysis iterations are exceeded
 var ErrMaxAnalysisIters = errors.NewKind("exceeded max analysis iterations (%d)")
 
+// Builder provides an easy way to generate Analyzer with custom rules and options.
+type Builder struct {
+	postAnalyzeRules    []Rule
+	preValidationRules  []Rule
+	postValidationRules []Rule
+	catalog             *sql.Catalog
+	debug               bool
+}
+
+// NewBuilder creates a new Builder from a specific catalog.
+// This builder allow us add custom Rules and modify some internal properties.
+func NewBuilder(c *sql.Catalog) *Builder {
+	return &Builder{catalog: c}
+}
+
+// WithDebug activates debug on the Analyzer
+func (ab *Builder) WithDebug() *Builder {
+	ab.debug = true
+
+	return ab
+}
+
+// AddPostAnalyzeRule adds a new rule to the analyzer after standard analyzer rules.
+func (ab *Builder) AddPostAnalyzeRule(name string, fn RuleFunc) *Builder {
+	ab.postAnalyzeRules = append(ab.postAnalyzeRules, Rule{name, fn})
+
+	return ab
+}
+
+// AddPreValidationRule adds a new rule to the analyzer before standard validation rules.
+func (ab *Builder) AddPreValidationRule(name string, fn RuleFunc) *Builder {
+	ab.preValidationRules = append(ab.preValidationRules, Rule{name, fn})
+
+	return ab
+}
+
+// AddPostValidationRule adds a new rule to the analyzer after standard validation rules.
+func (ab *Builder) AddPostValidationRule(name string, fn RuleFunc) *Builder {
+	ab.postValidationRules = append(ab.postValidationRules, Rule{name, fn})
+
+	return ab
+}
+
+// Build creates a new Analyzer using all previous data setted to the Builder
+func (ab *Builder) Build() *Analyzer {
+	_, debug := os.LookupEnv(debugAnalyzerKey)
+	var batches = []*Batch{
+		&Batch{
+			Desc:       "analyzer rules",
+			Iterations: maxAnalysisIterations,
+			Rules:      DefaultRules,
+		},
+		&Batch{
+			Desc:       "post-analyzer rules",
+			Iterations: maxAnalysisIterations,
+			Rules:      ab.postAnalyzeRules,
+		},
+		&Batch{
+			Desc:       "pre-validation rules",
+			Iterations: 1,
+			Rules:      ab.preValidationRules,
+		},
+		&Batch{
+			Desc:       "validation rules",
+			Iterations: 1,
+			Rules:      DefaultValidationRules,
+		},
+		&Batch{
+			Desc:       "post-validation rules",
+			Iterations: 1,
+			Rules:      ab.postValidationRules,
+		},
+	}
+
+	return &Analyzer{
+		Debug:   debug || ab.debug,
+		Batches: batches,
+		Catalog: ab.catalog,
+	}
+}
+
 // Analyzer analyzes nodes of the execution plan and applies rules and validations
 // to them.
 type Analyzer struct {
 	Debug bool
-	// Rules to apply.
-	Rules []Rule
-	// ValidationRules to apply.
-	ValidationRules []ValidationRule
+	// Batches of Rules to apply.
+	Batches []*Batch
 	// Catalog of databases and registered functions.
 	Catalog *sql.Catalog
 	// CurrentDatabase in use.
 	CurrentDatabase string
 }
 
-// RuleFunc is the function to be applied in a rule.
-type RuleFunc func(*sql.Context, *Analyzer, sql.Node) (sql.Node, error)
-
-// ValidationRuleFunc is the function to be used in a validation rule.
-type ValidationRuleFunc func(*sql.Context, sql.Node) error
-
-// Rule to transform nodes.
-type Rule struct {
-	// Name of the rule.
-	Name string
-	// Apply transforms a node.
-	Apply RuleFunc
-}
-
-// ValidationRule validates the given nodes.
-type ValidationRule struct {
-	// Name of the rule.
-	Name string
-	// Apply validates the given node.
-	Apply ValidationRuleFunc
-}
-
-const debugAnalyzerKey = "DEBUG_ANALYZER"
-
-// New returns a new Analyzer given a catalog.
-func New(catalog *sql.Catalog) *Analyzer {
-	_, debug := os.LookupEnv(debugAnalyzerKey)
-	return &Analyzer{
-		Debug:           debug,
-		Rules:           DefaultRules,
-		ValidationRules: DefaultValidationRules,
-		Catalog:         catalog,
-	}
-}
-
-// AddRule adds a new rule to the analyzer.
-func (a *Analyzer) AddRule(name string, fn RuleFunc) {
-	a.Rules = append(a.Rules, Rule{name, fn})
-}
-
-// AddValidationRule adds a new validation rule to the analyzer.
-func (a *Analyzer) AddValidationRule(name string, fn ValidationRuleFunc) {
-	a.ValidationRules = append(a.ValidationRules, ValidationRule{name, fn})
+// NewDefault creates a default Analyzer instance with all default Rules and configuration.
+// To add custom rules, the easiest way is use the Builder.
+func NewDefault(c *sql.Catalog) *Analyzer {
+	return NewBuilder(c).Build()
 }
 
 // Log prints an INFO message to stdout with the given message and args
@@ -88,97 +128,29 @@ func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
 	span.LogKV("plan", n.String())
 
 	prev := n
+	var err error
 	a.Log("starting analysis of node of type: %T", n)
-	cur, err := a.analyzeOnce(ctx, n)
+	for _, batch := range a.Batches {
+		prev, err = batch.Eval(ctx, a, prev)
+		if ErrMaxAnalysisIters.Is(err) {
+			a.Log(err.Error())
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	defer func() {
-		if cur != nil {
-			span.SetTag("IsResolved", cur.Resolved())
+		if prev != nil {
+			span.SetTag("IsResolved", prev.Resolved())
 		}
 		span.Finish()
 	}()
 
-	if err != nil {
-		return nil, err
-	}
-
-	for i := 0; !nodesEqual(prev, cur); {
-		a.Log("previous node does not match new node, analyzing again, iteration: %d", i)
-		prev = cur
-		cur, err = a.analyzeOnce(ctx, cur)
-		if err != nil {
-			return nil, err
-		}
-
-		i++
-		if i >= maxAnalysisIterations {
-			return cur, ErrMaxAnalysisIters.New(maxAnalysisIterations)
-		}
-	}
-
-	if errs := a.validate(ctx, cur); len(errs) != 0 {
-		for _, e := range errs {
-			err = multierror.Append(err, e)
-		}
-	}
-
-	return cur, err
-}
-
-func (a *Analyzer) analyzeOnce(ctx *sql.Context, n sql.Node) (sql.Node, error) {
-	span, ctx := ctx.Span("analyze_once")
-	span.LogKV("plan", n.String())
-	defer span.Finish()
-
-	result := n
-	for _, rule := range a.Rules {
-		var err error
-		result, err = rule.Apply(ctx, a, result)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
-}
-
-func (a *Analyzer) validate(ctx *sql.Context, n sql.Node) (validationErrors []error) {
-	span, ctx := ctx.Span("validate")
-	defer span.Finish()
-
-	validationErrors = append(validationErrors, a.validateOnce(ctx, n)...)
-
-	for _, node := range n.Children() {
-		validationErrors = append(validationErrors, a.validate(ctx, node)...)
-	}
-
-	return validationErrors
-}
-
-func (a *Analyzer) validateOnce(ctx *sql.Context, n sql.Node) (validationErrors []error) {
-	span, ctx := ctx.Span("validate_once")
-	defer span.Finish()
-
-	for _, rule := range a.ValidationRules {
-		err := rule.Apply(ctx, n)
-		if err != nil {
-			validationErrors = append(validationErrors, err)
-		}
-	}
-
-	return validationErrors
+	return prev, err
 }
 
 type equaler interface {
 	Equal(sql.Node) bool
-}
-
-func nodesEqual(a, b sql.Node) bool {
-	if e, ok := a.(equaler); ok {
-		return e.Equal(b)
-	}
-
-	if e, ok := b.(equaler); ok {
-		return e.Equal(a)
-	}
-
-	return reflect.DeepEqual(a, b)
 }

--- a/sql/analyzer/batch.go
+++ b/sql/analyzer/batch.go
@@ -1,0 +1,78 @@
+package analyzer
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// RuleFunc is the function to be applied in a rule.
+type RuleFunc func(*sql.Context, *Analyzer, sql.Node) (sql.Node, error)
+
+// Rule to transform nodes.
+type Rule struct {
+	// Name of the rule.
+	Name string
+	// Apply transforms a node.
+	Apply RuleFunc
+}
+
+// Batch executes a set of rules a specific number of times.
+// When this number of times is reached, the actual node
+// and ErrMaxAnalysisIters is returned.
+type Batch struct {
+	Desc       string
+	Iterations int
+	Rules      []Rule
+}
+
+// Eval executes the actual rules the specified number of times on the Batch.
+// If max number of iterations is reached, this method will return the actual
+// processed Node and ErrMaxAnalysisIters error.
+func (b *Batch) Eval(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	prev := n
+	cur, err := b.evalOnce(ctx, a, n)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; !nodesEqual(prev, cur); {
+		prev = cur
+		cur, err = b.evalOnce(ctx, a, cur)
+		if err != nil {
+			return nil, err
+		}
+
+		i++
+		if i >= b.Iterations {
+			return cur, ErrMaxAnalysisIters.New(b.Iterations)
+		}
+	}
+
+	return cur, nil
+}
+
+func (b *Batch) evalOnce(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	result := n
+	for _, rule := range b.Rules {
+		var err error
+		result, err = rule.Apply(ctx, a, result)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func nodesEqual(a, b sql.Node) bool {
+	if e, ok := a.(equaler); ok {
+		return e.Equal(b)
+	}
+
+	if e, ok := b.(equaler); ok {
+		return e.Equal(a)
+	}
+
+	return reflect.DeepEqual(a, b)
+}

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -17,10 +17,10 @@ func TestValidateResolved(t *testing.T) {
 
 	vr := getValidationRule(validateResolvedRule)
 
-	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
+	_, err := vr.Apply(sql.NewEmptyContext(), nil, dummyNode{true})
 	require.NoError(err)
 
-	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, dummyNode{false})
 	require.Error(err)
 }
 
@@ -29,12 +29,12 @@ func TestValidateOrderBy(t *testing.T) {
 
 	vr := getValidationRule(validateOrderByRule)
 
-	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
+	_, err := vr.Apply(sql.NewEmptyContext(), nil, dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, dummyNode{false})
 	require.NoError(err)
 
-	err = vr.Apply(sql.NewEmptyContext(), plan.NewSort(
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, plan.NewSort(
 		[]plan.SortField{{Column: aggregation.NewCount(nil), Order: plan.Descending}},
 		nil,
 	))
@@ -46,9 +46,9 @@ func TestValidateGroupBy(t *testing.T) {
 
 	vr := getValidationRule(validateGroupByRule)
 
-	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
+	_, err := vr.Apply(sql.NewEmptyContext(), nil, dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, dummyNode{false})
 	require.NoError(err)
 
 	childSchema := sql.Schema{
@@ -75,7 +75,7 @@ func TestValidateGroupBy(t *testing.T) {
 		child,
 	)
 
-	err = vr.Apply(sql.NewEmptyContext(), p)
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, p)
 	require.NoError(err)
 }
 
@@ -84,9 +84,9 @@ func TestValidateGroupByErr(t *testing.T) {
 
 	vr := getValidationRule(validateGroupByRule)
 
-	err := vr.Apply(sql.NewEmptyContext(), dummyNode{true})
+	_, err := vr.Apply(sql.NewEmptyContext(), nil, dummyNode{true})
 	require.NoError(err)
-	err = vr.Apply(sql.NewEmptyContext(), dummyNode{false})
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, dummyNode{false})
 	require.NoError(err)
 
 	childSchema := sql.Schema{
@@ -112,7 +112,7 @@ func TestValidateGroupByErr(t *testing.T) {
 		child,
 	)
 
-	err = vr.Apply(sql.NewEmptyContext(), p)
+	_, err = vr.Apply(sql.NewEmptyContext(), nil, p)
 	require.Error(err)
 }
 
@@ -170,7 +170,7 @@ func TestValidateSchemaSource(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			err := rule.Apply(sql.NewEmptyContext(), tt.node)
+			_, err := rule.Apply(sql.NewEmptyContext(), nil, tt.node)
 			if tt.ok {
 				require.NoError(err)
 			} else {
@@ -245,7 +245,7 @@ func TestValidateProjectTuples(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			err := rule.Apply(sql.NewEmptyContext(), tt.node)
+			_, err := rule.Apply(sql.NewEmptyContext(), nil, tt.node)
 			if tt.ok {
 				require.NoError(err)
 			} else {
@@ -312,7 +312,7 @@ func TestValidateIndexCreation(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			err := rule.Apply(sql.NewEmptyContext(), tt.node)
+			_, err := rule.Apply(sql.NewEmptyContext(), nil, tt.node)
 			if tt.ok {
 				require.NoError(err)
 			} else {
@@ -337,7 +337,7 @@ func (dummyNode) TransformExpressionsUp(
 	return nil, nil
 }
 
-func getValidationRule(name string) ValidationRule {
+func getValidationRule(name string) Rule {
 	for _, rule := range DefaultValidationRules {
 		if rule.Name == name {
 			return rule


### PR DESCRIPTION
- Move all the iteration logic from `Analyzer` to `Batch`. Now `Analyzer` has a set of Batch objects instead of a set of Rules.
- To be able to add custom rules, created an `analyzer.Builder` object. With it, you can build a custom `Analyzer` and add custom rules on specific Batches. This Batches can change depending on our necessities in the future.
- Validation rules do not exist anymore. Now they are standard rules into a Batch that iterates only once.

Closes: #141 

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>