### PR TITLE
sql/expression/function: add function split to the default functions to add to the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We are continuously adding more functionality to go-mysql-server. We support a s
 - `SUBSTRING(str,pos)`, ` SUBSTRING(str,pos,len)`: return a substring from the provided string.
 - Date and Timestamp functions: `YEAR(date)`, `MONTH(date)`, `DAY(date)`, `HOUR(date)`, `MINUTE(date)`, `SECOND(date)`, `DAYOFYEAR(date)`.
 - `ARRAY_LENGTH(json)`: If the json representation is an array, this function returns its size.
+- `SPLIT(str,sep)`: receives a string and a delimiter and returns the parts of the string splitted by the delimiter as a JSON array of strings.
 
 ## Example
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -226,6 +226,22 @@ var queries = []struct {
 			{"     └─ Column(s, TEXT, nullable=false)"},
 		},
 	},
+	{
+		`SELECT split(s," ") FROM mytable`,
+		[]sql.Row{
+			sql.NewRow([]interface{}{"first", "row"}),
+			sql.NewRow([]interface{}{"second", "row"}),
+			sql.NewRow([]interface{}{"third", "row"}),
+		},
+	},
+	{
+		`SELECT split(s,"s") FROM mytable`,
+		[]sql.Row{
+			sql.NewRow([]interface{}{"fir", "t row"}),
+			sql.NewRow([]interface{}{"", "econd row"}),
+			sql.NewRow([]interface{}{"third row"}),
+		},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -29,4 +29,5 @@ var Defaults = sql.Functions{
 	"second":       sql.Function1(NewSecond),
 	"dayofyear":    sql.Function1(NewDayOfYear),
 	"array_length": sql.Function1(NewArrayLength),
+	"split":        sql.Function2(NewSplit),
 }


### PR DESCRIPTION
The `split` function was implemented but not added to the default functions to be registered.
