### PR TITLE
plan/index: Add tracing to index creation

### DIFF
--- a/sql/index.go
+++ b/sql/index.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"io"
 	"strings"
@@ -116,7 +115,7 @@ type IndexDriver interface {
 	// LoadAll loads all indexes for given db and table
 	LoadAll(db, table string) ([]Index, error)
 	// Save the given index
-	Save(ctx context.Context, index Index, iter IndexKeyValueIter) error
+	Save(ctx *Context, index Index, iter IndexKeyValueIter) error
 	// Delete the given index.
 	Delete(index Index) error
 }

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"crypto/sha1"
 	"fmt"
 	"testing"
@@ -275,8 +274,8 @@ func (d loadDriver) LoadAll(db, table string) ([]Index, error) {
 	}
 	return result, nil
 }
-func (loadDriver) Save(ctx context.Context, index Index, iter IndexKeyValueIter) error { return nil }
-func (loadDriver) Delete(index Index) error                                            { return nil }
+func (loadDriver) Save(ctx *Context, index Index, iter IndexKeyValueIter) error { return nil }
+func (loadDriver) Delete(index Index) error                                     { return nil }
 
 type dummyIdx struct {
 	id       string

--- a/test/mem_tracer.go
+++ b/test/mem_tracer.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// MemTracer implements a simple tracer in memory for testing.
+type MemTracer struct {
+	Spans []string
+}
+
+type memSpan struct {
+	opName string
+}
+
+// StartSpan implements opentracing.Tracer interface.
+func (t *MemTracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
+	t.Spans = append(t.Spans, operationName)
+	return &memSpan{operationName}
+}
+
+// Inject implements opentracing.Tracer interface.
+func (t *MemTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+	panic("not implemented")
+}
+
+// Extract implements opentracing.Tracer interface.
+func (t *MemTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+	panic("not implemented")
+}
+
+func (m memSpan) Context() opentracing.SpanContext                      { return m }
+func (m memSpan) SetBaggageItem(key, val string) opentracing.Span       { return m }
+func (m memSpan) BaggageItem(key string) string                         { return "" }
+func (m memSpan) SetTag(key string, value interface{}) opentracing.Span { return m }
+func (m memSpan) LogFields(fields ...log.Field)                         {}
+func (m memSpan) LogKV(keyVals ...interface{})                          {}
+func (m memSpan) Finish()                                               {}
+func (m memSpan) FinishWithOptions(opts opentracing.FinishOptions)      {}
+func (m memSpan) SetOperationName(operationName string) opentracing.Span {
+	return &memSpan{operationName}
+}
+func (m memSpan) Tracer() opentracing.Tracer                            { return &MemTracer{} }
+func (m memSpan) LogEvent(event string)                                 {}
+func (m memSpan) LogEventWithPayload(event string, payload interface{}) {}
+func (m memSpan) Log(data opentracing.LogData)                          {}
+func (m memSpan) ForeachBaggageItem(handler func(k, v string) bool)     {}


### PR DESCRIPTION
Tracing is mostly done in `CreateIndex` so the logic does not have to be replicated in the drivers.

Logging of rows indexed now shows the duration. It is also logged to the span.

Error is only logged in the `CreateIndex` span (`plan.backgroundIndexCreate`) so it is not duplicated also in the driver's span.