### PR TITLE
sql/analyzer: rule to resolve sort based on dependencies

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -251,6 +251,30 @@ var queries = []struct {
 			{int64(3), "third row", "first", int64(3)},
 		},
 	},
+	{
+		`SELECT i as foo FROM mytable ORDER BY i DESC`,
+		[]sql.Row{
+			{int64(3)},
+			{int64(2)},
+			{int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY i ORDER BY i DESC`,
+		[]sql.Row{
+			{int32(1), int64(3)},
+			{int32(1), int64(2)},
+			{int32(1), int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY i ORDER BY foo, i DESC`,
+		[]sql.Row{
+			{int32(1), int64(3)},
+			{int32(1), int64(2)},
+			{int32(1), int64(1)},
+		},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -15,6 +15,234 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
 
+func TestResolveOrderBy(t *testing.T) {
+	rule := getRule("resolve_orderby")
+	a := NewDefault(nil)
+	ctx := sql.NewEmptyContext()
+
+	table := mem.NewTable("foo", sql.Schema{
+		{Name: "a", Type: sql.Int64, Source: "foo"},
+		{Name: "b", Type: sql.Int64, Source: "foo"},
+	})
+
+	t.Run("with project", func(t *testing.T) {
+		require := require.New(t)
+		node := plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("x")},
+			},
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				table,
+			),
+		)
+
+		result, err := rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(node, result)
+
+		node = plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("a")},
+			},
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				table,
+			),
+		)
+
+		expected := plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+					"x",
+				),
+			},
+			plan.NewSort(
+				[]plan.SortField{
+					{Column: expression.NewUnresolvedColumn("a")},
+				},
+				table,
+			),
+		)
+
+		result, err = rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(expected, result)
+
+		node = plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("a")},
+				{Column: expression.NewUnresolvedColumn("x")},
+			},
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				table,
+			),
+		)
+
+		expected = plan.NewProject(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int64, "", "x", false),
+			},
+			plan.NewSort(
+				[]plan.SortField{
+					{Column: expression.NewUnresolvedColumn("a")},
+					{Column: expression.NewUnresolvedColumn("x")},
+				},
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewAlias(
+							expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+							"x",
+						),
+						expression.NewUnresolvedColumn("a"),
+					},
+					table,
+				),
+			),
+		)
+
+		result, err = rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(expected, result)
+	})
+
+	t.Run("with group by", func(t *testing.T) {
+		require := require.New(t)
+		node := plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("x")},
+			},
+			plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+				},
+				table,
+			),
+		)
+
+		result, err := rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(node, result)
+
+		node = plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("a")},
+			},
+			plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+				},
+				table,
+			),
+		)
+
+		var expected sql.Node = plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias(
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+					"x",
+				),
+			},
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+			},
+			plan.NewSort(
+				[]plan.SortField{
+					{Column: expression.NewUnresolvedColumn("a")},
+				},
+				table,
+			),
+		)
+
+		result, err = rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(expected, result)
+
+		node = plan.NewSort(
+			[]plan.SortField{
+				{Column: expression.NewUnresolvedColumn("a")},
+				{Column: expression.NewUnresolvedColumn("x")},
+			},
+			plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias(
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+						"x",
+					),
+				},
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+				},
+				table,
+			),
+		)
+
+		expected = plan.NewProject(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int64, "", "x", false),
+			},
+			plan.NewSort(
+				[]plan.SortField{
+					{Column: expression.NewUnresolvedColumn("a")},
+					{Column: expression.NewUnresolvedColumn("x")},
+				},
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewAlias(
+							expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+							"x",
+						),
+						expression.NewUnresolvedColumn("a"),
+					},
+					[]sql.Expression{
+						expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
+					},
+					table,
+				),
+			),
+		)
+
+		result, err = rule.Apply(ctx, a, node)
+		require.NoError(err)
+
+		require.Equal(expected, result)
+	})
+}
+
 func TestResolveSubqueries(t *testing.T) {
 	require := require.New(t)
 

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -53,10 +53,16 @@ func (p *GroupBy) Schema() sql.Schema {
 			name = e.String()
 		}
 
+		var table string
+		if t, ok := e.(sql.Tableable); ok {
+			table = t.Table()
+		}
+
 		s[i] = &sql.Column{
 			Name:     name,
 			Type:     e.Type(),
 			Nullable: e.IsNullable(),
+			Source:   table,
 		}
 	}
 


### PR DESCRIPTION
Fixes #248 

There are 3 cases:

- The child node has all needed columns, do nothing in that case.
- The child node has missing columns and it requires no column that was defined in the child, so move the order by below the child node.
- The child has missing columns and it requires some columns defined in the child, so make a new node from the child type below the orderby with the missing dependencies and a projection on top of it with the projected columns of the previous child.

This works both with groupby and project.