### PR TITLE
index/pilosa: batch boltdb and pilosa writes

### DIFF
--- a/sql/index/pilosa/driver.go
+++ b/sql/index/pilosa/driver.go
@@ -22,6 +22,8 @@ const (
 	IndexNamePrefix = "idx"
 	// FrameNamePrefix the pilosa's frames prefix
 	FrameNamePrefix = "frm"
+	// BatchSize is the number of objects to save when creating indexes.
+	BatchSize = 10000
 )
 
 // Driver implements sql.IndexDriver interface.
@@ -140,12 +142,50 @@ var (
 	errDeletePilosaIndex = errors.NewKind("error deleting pilosa index %s: %s")
 )
 
+type bitBatch struct {
+	size uint64
+	bits []pilosa.Bit
+	pos  uint64
+}
+
+func newBitBatch(size uint64) *bitBatch {
+	b := &bitBatch{size: size}
+	b.Clean()
+
+	return b
+}
+
+func (b *bitBatch) Clean() {
+	b.bits = make([]pilosa.Bit, 0, b.size)
+	b.pos = 0
+}
+
+func (b *bitBatch) Add(row, col uint64) {
+	b.bits = append(b.bits, pilosa.Bit{
+		RowID:    row,
+		ColumnID: col,
+	})
+}
+
+func (b *bitBatch) NextRecord() (pilosa.Record, error) {
+	if b.pos >= uint64(len(b.bits)) {
+		return nil, io.EOF
+	}
+
+	b.pos++
+	return b.bits[b.pos-1], nil
+}
+
+func (b *bitBatch) Send(frame *pilosa.Frame, client *pilosa.Client) error {
+	return client.ImportFrame(frame, b)
+}
+
 // Save the given index (mapping and bitmap)
 func (d *Driver) Save(
 	ctx *sql.Context,
 	i sql.Index,
 	iter sql.IndexKeyValueIter,
-) error {
+) (err error) {
 	span, ctx := ctx.Span("pilosa.Save")
 	span.LogKV("name", i.ID())
 
@@ -197,10 +237,46 @@ func (d *Driver) Save(
 		return err
 	}
 
-	idx.mapping.open()
-	defer idx.mapping.close()
+	// Open mapping in create mode. After finishing the transaction is rolled
+	// back unless all goes well and rollback value is changed.
+	rollback := true
+	idx.mapping.openCreate(true)
+	defer func() {
+		if rollback {
+			idx.mapping.rollback()
+		} else {
+			e := idx.mapping.commit(false)
+			if e != nil && err == nil {
+				err = e
+			}
+		}
+
+		idx.mapping.close()
+	}()
+
+	bitBatch := make([]*bitBatch, len(frames))
+	for i := range bitBatch {
+		bitBatch[i] = newBitBatch(BatchSize)
+	}
 
 	for colID := uint64(0); err == nil; colID++ {
+		// commit each batch of objects (pilosa and boltdb)
+		if colID%BatchSize == 0 && colID != 0 {
+			for i, frm := range frames {
+				err = bitBatch[i].Send(frm, d.client)
+				if err != nil {
+					return err
+				}
+
+				bitBatch[i].Clean()
+			}
+
+			err = idx.mapping.commit(true)
+			if err != nil {
+				return err
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -225,13 +301,7 @@ func (d *Driver) Save(
 					return err
 				}
 
-				resp, err := d.client.Query(frm.SetBit(rowID, colID))
-				if err != nil {
-					return err
-				}
-				if !resp.Success {
-					return errPilosaQuery.New(resp.ErrorMessage)
-				}
+				bitBatch[i].Add(rowID, colID)
 			}
 			err = idx.mapping.putLocation(pilosaIndex.Name(), colID, location)
 		}
@@ -239,6 +309,15 @@ func (d *Driver) Save(
 
 	if err != nil && err != io.EOF {
 		return err
+	}
+
+	rollback = false
+
+	for i, frm := range frames {
+		err = bitBatch[i].Send(frm, d.client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return index.RemoveProcessingFile(path)

--- a/sql/index/pilosa/mapping.go
+++ b/sql/index/pilosa/mapping.go
@@ -196,7 +196,10 @@ func (m *mapping) getRowID(frameName string, value interface{}) (uint64, error) 
 				return nil
 			}
 
+			// the first NextSequence is 1 so the first id will be 1
+			// this can only fail if the transaction is closed
 			id, _ = b.NextSequence()
+
 			val = make([]byte, 8)
 			binary.LittleEndian.PutUint64(val, id)
 			err = b.Put(key, val)

--- a/sql/index/pilosa/mapping.go
+++ b/sql/index/pilosa/mapping.go
@@ -26,6 +26,11 @@ type mapping struct {
 	mut sync.RWMutex
 	db  *bolt.DB
 
+	// in create mode there's only one transaction closed explicitly by
+	// commit function
+	create bool
+	tx     *bolt.Tx
+
 	clientMut sync.Mutex
 	clients   int
 }
@@ -35,9 +40,15 @@ func newMapping(dir string) *mapping {
 }
 
 func (m *mapping) open() {
+	m.openCreate(false)
+}
+
+// openCreate opens and sets creation mode in the database.
+func (m *mapping) openCreate(create bool) {
 	m.clientMut.Lock()
 	defer m.clientMut.Unlock()
 	m.clients++
+	m.create = create
 }
 
 func (m *mapping) close() error {
@@ -93,6 +104,75 @@ func (m *mapping) rowID(frameName string, value interface{}) (uint64, error) {
 	return binary.LittleEndian.Uint64(val), err
 }
 
+// commit saves current transaction, if cont is true a new transaction will be
+// created again in the next query. Only for create mode.
+func (m *mapping) commit(cont bool) error {
+	m.clientMut.Lock()
+	defer m.clientMut.Unlock()
+
+	var err error
+	if m.create && m.tx != nil {
+		err = m.tx.Commit()
+	}
+
+	m.create = cont
+	m.tx = nil
+
+	return err
+}
+
+func (m *mapping) rollback() error {
+	m.clientMut.Lock()
+	defer m.clientMut.Unlock()
+
+	var err error
+	if m.create && m.tx != nil {
+		err = m.tx.Rollback()
+	}
+
+	m.create = false
+	m.tx = nil
+
+	return err
+}
+
+func (m *mapping) transaction(writable bool, f func(*bolt.Tx) error) error {
+	var tx *bolt.Tx
+	var err error
+	if m.create {
+		m.clientMut.Lock()
+		if m.tx == nil {
+			m.tx, err = m.db.Begin(true)
+			if err != nil {
+				m.clientMut.Unlock()
+				return err
+			}
+		}
+
+		m.clientMut.Unlock()
+
+		tx = m.tx
+	} else {
+		tx, err = m.db.Begin(writable)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = f(tx)
+
+	if m.create {
+		return err
+	}
+
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}
+
 func (m *mapping) getRowID(frameName string, value interface{}) (uint64, error) {
 	var id uint64
 	err := m.query(func() error {
@@ -103,7 +183,7 @@ func (m *mapping) getRowID(frameName string, value interface{}) (uint64, error) 
 			return err
 		}
 
-		err = m.db.Update(func(tx *bolt.Tx) error {
+		err = m.transaction(true, func(tx *bolt.Tx) error {
 			b, err := tx.CreateBucketIfNotExists([]byte(frameName))
 			if err != nil {
 				return err
@@ -116,7 +196,7 @@ func (m *mapping) getRowID(frameName string, value interface{}) (uint64, error) 
 				return nil
 			}
 
-			id = uint64(b.Stats().KeyN)
+			id, _ = b.NextSequence()
 			val = make([]byte, 8)
 			binary.LittleEndian.PutUint64(val, id)
 			err = b.Put(key, val)
@@ -131,7 +211,7 @@ func (m *mapping) getRowID(frameName string, value interface{}) (uint64, error) 
 
 func (m *mapping) putLocation(indexName string, colID uint64, location []byte) error {
 	return m.query(func() error {
-		return m.db.Update(func(tx *bolt.Tx) error {
+		return m.transaction(true, func(tx *bolt.Tx) error {
 			b, err := tx.CreateBucketIfNotExists([]byte(indexName))
 			if err != nil {
 				return err
@@ -192,7 +272,7 @@ func (m *mapping) getLocation(indexName string, colID uint64) ([]byte, error) {
 	var location []byte
 
 	err := m.query(func() error {
-		err := m.db.View(func(tx *bolt.Tx) error {
+		err := m.transaction(true, func(tx *bolt.Tx) error {
 			b := tx.Bucket([]byte(indexName))
 			if b == nil {
 				return fmt.Errorf("bucket %s not found", indexName)
@@ -214,7 +294,7 @@ func (m *mapping) getLocation(indexName string, colID uint64) ([]byte, error) {
 func (m *mapping) getLocationN(indexName string) (int, error) {
 	var n int
 	err := m.query(func() error {
-		err := m.db.View(func(tx *bolt.Tx) error {
+		err := m.transaction(false, func(tx *bolt.Tx) error {
 			b := tx.Bucket([]byte(indexName))
 			if b == nil {
 				return fmt.Errorf("Bucket %s not found", indexName)
@@ -240,7 +320,7 @@ func (m *mapping) get(name string, key interface{}) ([]byte, error) {
 			return err
 		}
 
-		err = m.db.View(func(tx *bolt.Tx) error {
+		err = m.transaction(true, func(tx *bolt.Tx) error {
 			b := tx.Bucket([]byte(name))
 			if b != nil {
 				value = b.Get(buf.Bytes())

--- a/sql/index/pilosa/mapping_test.go
+++ b/sql/index/pilosa/mapping_test.go
@@ -20,7 +20,7 @@ func TestRowID(t *testing.T) {
 	defer m.close()
 
 	cases := []int{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}
-	expected := []uint64{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}
+	expected := []uint64{1, 2, 3, 4, 5, 6, 6, 1, 4, 3, 2, 6}
 
 	for i, c := range cases {
 		rowID, err := m.getRowID("frame name", c)
@@ -72,7 +72,7 @@ func TestGet(t *testing.T) {
 	defer m.close()
 
 	cases := []int{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}
-	expected := []uint64{0, 1, 2, 3, 4, 5, 5, 0, 3, 2, 1, 5}
+	expected := []uint64{1, 2, 3, 4, 5, 6, 6, 1, 4, 3, 2, 6}
 
 	for i, c := range cases {
 		m.getRowID("frame name", c)


### PR DESCRIPTION
Writes are now only done once every 10000 rows. This improves index creation times.

pilosa uses import methods instead of queries to set bits. This occupies less memory and is faster than making batched queries.

boltdb mapping now has an extra mode of working (create mode). When this is active there's only one transaction per batch instead of one transaction per operation.

```
create index commit_hash on commits using pilosa (commit_hash);
```

| num repos | before | now |
|--------------|--|-----|
| 9 | 42 s | 5 s |
| 100 | 8 minutes | 21 s |