### PR TITLE
sql/analyzer: add rules for ensuring read only queries

### DIFF
--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -1803,3 +1803,22 @@ func (i *releaseIter) Close() error {
 	i.once.Do(i.release)
 	return nil
 }
+
+// EnsureReadOnlyRule is a rule ensuring only read queries can be performed.
+const EnsureReadOnlyRule = "ensure_read_only"
+
+// ErrQueryNotAllowed is returned when the engine is in read-only mode and
+// there is a query with that performs any write/update operation.
+var ErrQueryNotAllowed = errors.NewKind("query of type %q not allowed in read-only mode")
+
+// EnsureReadOnly ensures only read queries can be performed, and returns an
+// error if it's not the case.
+func EnsureReadOnly(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error) {
+	switch node.(type) {
+	case *plan.InsertInto, *plan.DropIndex, *plan.CreateIndex:
+		typ := strings.Split(reflect.TypeOf(node).String(), ".")[1]
+		return nil, ErrQueryNotAllowed.New(typ)
+	default:
+		return node, nil
+	}
+}


### PR DESCRIPTION
Partially solves https://github.com/src-d/gitbase/issues/326, requires some stuff on gitbase

Since the actual job of ensuring read only queries is done on the analyzer, it felt weird to add like a `SetReadOnly` or such to the `Engine`, because the rules have no access to the `Engine`, only the `Analyzer`, that's why I thought about this way of doing it, which felt like the least intrusive way of implementing this feature without going into users and permissions.