### PR TITLE
Improvement/better tracing

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -827,9 +827,6 @@ func TestTracing(t *testing.T) {
 		"plan.Project",
 		"plan.Filter",
 		"plan.PushdownProjectionAndFiltersTable",
-		"expression.Equals",
-		"expression.Equals",
-		"expression.Equals",
 	}
 
 	var spanOperations []string

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -3,6 +3,7 @@ package analyzer // import "gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
 import (
 	"os"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -142,8 +143,9 @@ func (a *Analyzer) Log(msg string, args ...interface{}) {
 
 // Analyze the node and all its children.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
-	span, ctx := ctx.Span("analyze")
-	span.LogKV("plan", n.String())
+	span, ctx := ctx.Span("analyze", opentracing.Tags{
+		"plan": n.String(),
+	})
 
 	prev := n
 	var err error

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -130,9 +130,6 @@ func (a *Arithmetic) TransformUp(f sql.TransformExprFunc) (sql.Expression, error
 
 // Eval implements the Expression interface.
 func (a *Arithmetic) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.(" + a.op + ")")
-	defer span.Finish()
-
 	lval, rval, err := a.evalLeftRight(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -42,9 +42,6 @@ func (b *Between) Resolved() bool {
 
 // Eval implements the Expression interface.
 func (b *Between) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Between")
-	defer span.Finish()
-
 	typ := b.Val.Type()
 	val, err := b.Val.Eval(ctx, row)
 	if err != nil {

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -23,9 +23,6 @@ func (e *Not) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (e *Not) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Not")
-	defer span.Finish()
-
 	v, err := e.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -144,9 +144,6 @@ func NewEquals(left sql.Expression, right sql.Expression) *Equals {
 
 // Eval implements the Expression interface.
 func (e *Equals) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Equals")
-	defer span.Finish()
-
 	result, err := e.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -190,9 +187,6 @@ func NewRegexp(left sql.Expression, right sql.Expression) *Regexp {
 
 // Eval implements the Expression interface.
 func (re *Regexp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Regexp")
-	defer span.Finish()
-
 	if sql.IsText(re.Left().Type()) && sql.IsText(re.Right().Type()) {
 		return re.compareRegexp(ctx, row)
 	}
@@ -268,9 +262,6 @@ func NewGreaterThan(left sql.Expression, right sql.Expression) *GreaterThan {
 
 // Eval implements the Expression interface.
 func (gt *GreaterThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.GreaterThan")
-	defer span.Finish()
-
 	result, err := gt.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -314,9 +305,6 @@ func NewLessThan(left sql.Expression, right sql.Expression) *LessThan {
 
 // Eval implements the expression interface.
 func (lt *LessThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.LessThan")
-	defer span.Finish()
-
 	result, err := lt.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -361,9 +349,6 @@ func NewGreaterThanOrEqual(left sql.Expression, right sql.Expression) *GreaterTh
 
 // Eval implements the Expression interface.
 func (gte *GreaterThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.GreaterThanOrEqual")
-	defer span.Finish()
-
 	result, err := gte.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -408,9 +393,6 @@ func NewLessThanOrEqual(left sql.Expression, right sql.Expression) *LessThanOrEq
 
 // Eval implements the Expression interface.
 func (lte *LessThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.LessThanOrEqual")
-	defer span.Finish()
-
 	result, err := lte.Compare(ctx, row)
 	if err != nil {
 		if ErrNilOperand.Is(err) {
@@ -463,9 +445,6 @@ func NewIn(left sql.Expression, right sql.Expression) *In {
 
 // Eval implements the Expression interface.
 func (in *In) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.In")
-	defer span.Finish()
-
 	typ := in.Left().Type()
 	leftElems := sql.NumColumns(typ)
 	left, err := in.Left().Eval(ctx, row)
@@ -554,9 +533,6 @@ func NewNotIn(left sql.Expression, right sql.Expression) *NotIn {
 
 // Eval implements the Expression interface.
 func (in *NotIn) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.NotIn")
-	defer span.Finish()
-
 	typ := in.Left().Type()
 	leftElems := sql.NumColumns(typ)
 	left, err := in.Left().Eval(ctx, row)

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/spf13/cast"
 	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -91,9 +90,6 @@ func (c *Convert) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 
 // Eval implements the Expression interface.
 func (c *Convert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Convert", opentracing.Tag{Key: "type", Value: c.castToType})
-	defer span.Finish()
-
 	val, err := c.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/function/aggregation/avg.go
+++ b/sql/expression/function/aggregation/avg.go
@@ -39,9 +39,6 @@ func (a *Avg) IsNullable() bool {
 
 // Eval implements AggregationExpression interface. (AggregationExpression[Expression]])
 func (a *Avg) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("aggregation.Avg_Eval")
-	defer span.Finish()
-
 	isNoNum := buffer[2].(bool)
 	if isNoNum {
 		return float64(0), nil
@@ -53,7 +50,6 @@ func (a *Avg) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
 	}
 
 	avg := buffer[0]
-	span.LogKV("avg", avg)
 	return avg, nil
 }
 

--- a/sql/expression/function/aggregation/count.go
+++ b/sql/expression/function/aggregation/count.go
@@ -85,10 +85,6 @@ func (c *Count) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
 
 // Eval implements the Aggregation interface.
 func (c *Count) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("aggregation.Count_Eval")
 	count := buffer[0]
-	span.LogKV("count", count)
-	span.Finish()
-
 	return count, nil
 }

--- a/sql/expression/function/aggregation/max.go
+++ b/sql/expression/function/aggregation/max.go
@@ -85,10 +85,6 @@ func (m *Max) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
 
 // Eval implements the Aggregation interface.
 func (m *Max) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("aggregation.Max_Eval")
 	max := buffer[0]
-	span.LogKV("max", max)
-	span.Finish()
-
 	return max, nil
 }

--- a/sql/expression/function/aggregation/min.go
+++ b/sql/expression/function/aggregation/min.go
@@ -85,10 +85,6 @@ func (m *Min) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
 
 // Eval implements the Aggregation interface
 func (m *Min) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("aggregation.Min_Eval")
 	min := buffer[0]
-	span.LogKV("min", min)
-	span.Finish()
-
 	return min, nil
 }

--- a/sql/expression/function/aggregation/sum.go
+++ b/sql/expression/function/aggregation/sum.go
@@ -73,10 +73,7 @@ func (m *Sum) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
 
 // Eval implements the Aggregation interface.
 func (m *Sum) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("aggregation.Sum_Eval")
 	sum := buffer[0]
-	span.LogKV("sum", sum)
-	span.Finish()
 
 	return sum, nil
 }

--- a/sql/expression/function/arraylength.go
+++ b/sql/expression/function/arraylength.go
@@ -38,9 +38,6 @@ func (f *ArrayLength) TransformUp(fn sql.TransformExprFunc) (sql.Expression, err
 
 // Eval implements the Expression interface.
 func (f *ArrayLength) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.ArrayLength")
-	defer span.Finish()
-
 	if !sql.IsArray(f.Child.Type()) {
 		return nil, sql.ErrInvalidType.New(f.Child.Type().Type().String())
 	}

--- a/sql/expression/function/isbinary.go
+++ b/sql/expression/function/isbinary.go
@@ -3,10 +3,6 @@ package function
 import (
 	"bytes"
 	"fmt"
-	"time"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
@@ -27,21 +23,6 @@ func (ib *IsBinary) Eval(
 	ctx *sql.Context,
 	row sql.Row,
 ) (interface{}, error) {
-	var blobSize int
-	span, ctx := ctx.Span("function.IsBinary")
-	defer func() {
-		span.FinishWithOptions(opentracing.FinishOptions{
-			LogRecords: []opentracing.LogRecord{
-				{
-					Timestamp: time.Now(),
-					Fields: []log.Field{
-						log.Int("blobsize", blobSize),
-					},
-				},
-			},
-		})
-	}()
-
 	v, err := ib.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -57,7 +38,6 @@ func (ib *IsBinary) Eval(
 	}
 
 	blobBytes := blob.([]byte)
-	blobSize = len(blobBytes)
 	return isBinary(blobBytes), nil
 }
 

--- a/sql/expression/function/substring.go
+++ b/sql/expression/function/substring.go
@@ -50,9 +50,6 @@ func (s *Substring) Eval(
 	ctx *sql.Context,
 	row sql.Row,
 ) (interface{}, error) {
-	span, ctx := ctx.Span("function.Substring")
-	defer span.Finish()
-
 	str, err := s.str.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -51,8 +51,6 @@ func (y *Year) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (y *Year) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Year")
-	defer span.Finish()
 	return getDatePart(ctx, y.UnaryExpression, row, year)
 }
 
@@ -83,8 +81,6 @@ func (m *Month) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (m *Month) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Month")
-	defer span.Finish()
 	return getDatePart(ctx, m.UnaryExpression, row, month)
 }
 
@@ -115,8 +111,6 @@ func (d *Day) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (d *Day) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Day")
-	defer span.Finish()
 	return getDatePart(ctx, d.UnaryExpression, row, day)
 }
 
@@ -147,8 +141,6 @@ func (h *Hour) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (h *Hour) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Hour")
-	defer span.Finish()
 	return getDatePart(ctx, h.UnaryExpression, row, hour)
 }
 
@@ -179,8 +171,6 @@ func (m *Minute) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (m *Minute) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Minute")
-	defer span.Finish()
 	return getDatePart(ctx, m.UnaryExpression, row, minute)
 }
 
@@ -211,8 +201,6 @@ func (s *Second) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (s *Second) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.Second")
-	defer span.Finish()
 	return getDatePart(ctx, s.UnaryExpression, row, second)
 }
 
@@ -243,8 +231,6 @@ func (d *DayOfYear) Type() sql.Type { return sql.Int32 }
 
 // Eval implements the Expression interface.
 func (d *DayOfYear) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("function.DayOfYear")
-	defer span.Finish()
 	return getDatePart(ctx, d.UnaryExpression, row, dayOfYear)
 }
 

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -24,9 +24,6 @@ func (e *IsNull) IsNullable() bool {
 
 // Eval implements the Expression interface.
 func (e *IsNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.IsNull")
-	defer span.Finish()
-
 	v, err := e.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -43,9 +43,6 @@ func (*And) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (a *And) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.And")
-	defer span.Finish()
-
 	lval, err := a.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -107,9 +104,6 @@ func (*Or) Type() sql.Type {
 
 // Eval implements the Expression interface.
 func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Or")
-	defer span.Finish()
-
 	lval, err := o.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
@@ -19,9 +18,6 @@ func NewTuple(exprs ...sql.Expression) Tuple {
 
 // Eval implements the Expression interface.
 func (t Tuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	span, ctx := ctx.Span("expression.Tuple", opentracing.Tag{Key: "elems", Value: len(t)})
-	defer span.Finish()
-
 	if len(t) == 1 {
 		return t[0].Eval(ctx, row)
 	}

--- a/sql/index.go
+++ b/sql/index.go
@@ -10,6 +10,9 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 )
 
+// IndexBatchSize is the number of rows to save at a time when creating indexes.
+var IndexBatchSize = uint64(10000)
+
 // IndexKeyValueIter is an iterator of index key values, that is, a tuple of
 // the values that will be index keys.
 type IndexKeyValueIter interface {

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -143,7 +143,7 @@ func TestSaveAndLoad(t *testing.T) {
 
 	found := false
 	for _, span := range tracer.Spans {
-		if span == "pilosa.Save" {
+		if span == "pilosa.Save.bitBatch" {
 			found = true
 			break
 		}


### PR DESCRIPTION
## Indexes

* `sql.IndexBatchSize` used also for iterator logging. This changes from the previous log every 100 rows. This could be configurable at some point.
* Changed logs to show information in fields instead of message. Added duration to some of them.

```
INFO[0002] starting to save the index                    driver=pilosa id=path
DEBU[0005] still creating index                          driver=pilosa duration=2.683461277s id=path rows=10000
DEBU[0007] still creating index                          driver=pilosa duration=2.452943261s id=path rows=20000
INFO[0009] starting to save the index                    driver=pilosa id=author
DEBU[0010] still creating index                          driver=pilosa duration=2.375128917s id=path rows=30000
DEBU[0013] still creating index                          driver=pilosa duration=3.048582511s id=path rows=40000
DEBU[0015] still creating index                          driver=pilosa duration=2.541468854s id=path rows=50000
DEBU[0015] finished pilosa indexing                      duration=6.366508715s mapping=187.117302ms pilosa=122.940448ms rows=1934
INFO[0015] index successfully created                    driver=pilosa id=author
DEBU[0018] still creating index                          driver=pilosa duration=2.620018315s id=path rows=60000
```

* Moved pilosa import call from `bitBatch` to Driver as [suggested by @kuba--](https://github.com/src-d/go-mysql-server/pull/250#discussion_r199116057)
* Partial spans for iterator, mapping and pilosa saving. Done each batch.
* These new spans are children of `plan.backgroundIndexCreate` so they are easier to understand (they come one after another).

![pilosa-spans](https://user-images.githubusercontent.com/1829/42215610-49081a1c-7ebf-11e8-84d6-25c423184590.png)

## General

* Do not create spans for expressions as they add too much noise and doesn't seem too useful.
* Use tag instead of log to save the plan.