### PR TITLE
index/pilosa: speedup index iterator

### DIFF
--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -480,7 +480,7 @@ type indexValueIter struct {
 
 func (it *indexValueIter) Next() ([]byte, error) {
 	if it.bucket == nil {
-		bucket, err := it.mapping.getBucket(it.indexName, true)
+		bucket, err := it.mapping.getBucket(it.indexName, false)
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +496,7 @@ func (it *indexValueIter) Next() ([]byte, error) {
 		}
 
 		if it.tx != nil {
-			it.tx.Commit()
+			it.tx.Rollback()
 		}
 
 		return nil, io.EOF
@@ -516,7 +516,7 @@ func (it *indexValueIter) Next() ([]byte, error) {
 
 func (it *indexValueIter) Close() error {
 	if it.tx != nil {
-		it.tx.Commit()
+		it.tx.Rollback()
 	}
 
 	return it.mapping.close()

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/src-d/go-errors.v1"
 
+	"github.com/boltdb/bolt"
 	pilosa "github.com/pilosa/go-pilosa"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -471,14 +472,33 @@ type indexValueIter struct {
 	bits      []uint64
 	mapping   *mapping
 	indexName string
+
+	// share transaction and bucket on all getLocation calls
+	bucket *bolt.Bucket
+	tx     *bolt.Tx
 }
 
 func (it *indexValueIter) Next() ([]byte, error) {
+	if it.bucket == nil {
+		bucket, err := it.mapping.getBucket(it.indexName, true)
+		if err != nil {
+			return nil, err
+		}
+
+		it.bucket = bucket
+		it.tx = bucket.Tx()
+	}
+
 	if it.offset >= it.total {
 		if err := it.Close(); err != nil {
 			logrus.WithField("err", err.Error()).
 				Error("unable to close the pilosa index value iterator")
 		}
+
+		if it.tx != nil {
+			it.tx.Commit()
+		}
+
 		return nil, io.EOF
 	}
 
@@ -491,10 +511,16 @@ func (it *indexValueIter) Next() ([]byte, error) {
 
 	it.offset++
 
-	return it.mapping.getLocation(it.indexName, colID)
+	return it.mapping.getLocationFromBucket(it.bucket, colID)
 }
 
-func (it *indexValueIter) Close() error { return it.mapping.close() }
+func (it *indexValueIter) Close() error {
+	if it.tx != nil {
+		it.tx.Commit()
+	}
+
+	return it.mapping.close()
+}
 
 var (
 	errUnknownType  = errors.NewKind("unknown type %T received as value")


### PR DESCRIPTION
Each next call to index iterator was searching for the bucket and creating a new transaction. Now the bucket and transaction is created only once and reused during all its life.

Previously:

```
index.Next() 5.445086ms
index.Next() 4.958599ms
index.Next() 4.597905ms
index.Next() 5.394169ms
index.Next() 5.161109ms
```

Now:

```
index.Next() 3.711µs
index.Next() 24.377µs
index.Next() 11.213µs
index.Next() 9.873µs
index.Next() 7.679µs
index.Next() 5.182µs
index.Next() 3.655µs
index.Next() 6.272µs
index.Next() 3.734µs
```

Some tests with queries:

* `create index path on files using pilosa (file_path);` (2620377 rows)

| rows returned | before | after |
| --- | --- | --- |
|160|1.34s|0.10s|
|1342|18s|6.34s|

* `create index author on commits using pilosa (commit_author_name);` (1933 rows)

| rows returned | before | after |
| --- | --- | --- |
|419|3.05s|0.51s|
|142|1.86s|0.84s|





