### PR TITLE
sql/*: add some more compatibility with mysqldump

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -290,6 +290,30 @@ var queries = []struct {
 			{string("third row3")},
 		},
 	},
+	{
+		`SELECT @@GLOBAL.FOO, @@SESSION.BAR`,
+		[]sql.Row{{nil, nil}},
+	},
+	{
+		`SET @@GLOBAL.FOO = 1`,
+		[]sql.Row{},
+	},
+	{
+		`/*!40101 SET NAMES utf8 */;`,
+		[]sql.Row{},
+	},
+	{
+		`SHOW VARIABLES LIKE 'foo%'`,
+		[]sql.Row{},
+	},
+	{
+		`SHOW DATABASES`,
+		[]sql.Row{{"mydb"}},
+	},
+	{
+		`USE foo`,
+		[]sql.Row{},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -830,9 +830,9 @@ func TestQualifyColumns(t *testing.T) {
 	require.Equal(expected, result)
 }
 
-func TestCatalogIndex(t *testing.T) {
+func TestAssignCatalog(t *testing.T) {
 	require := require.New(t)
-	f := getRule("index_catalog")
+	f := getRule("assign_catalog")
 
 	c := sql.NewCatalog()
 	a := NewDefault(c)
@@ -855,6 +855,12 @@ func TestCatalogIndex(t *testing.T) {
 	require.True(ok)
 	require.Equal(c, di.Catalog)
 	require.Equal("foo", di.CurrentDatabase)
+
+	node, err = f.Apply(sql.NewEmptyContext(), a, plan.NewShowDatabases())
+	require.NoError(err)
+	sd, ok := node.(*plan.ShowDatabases)
+	require.True(ok)
+	require.Equal(c, sd.Catalog)
 }
 
 func TestReorderProjection(t *testing.T) {

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -91,3 +91,45 @@ func (p *GetField) WithIndex(n int) sql.Expression {
 	p2.fieldIndex = n
 	return &p2
 }
+
+// UnsupportedGetField is meant to be a GetField that always returns nil,
+// because its missing support for certain features.
+type UnsupportedGetField struct {
+	table string
+	name  string
+}
+
+// NewUnsupportedGetField creates a new UnsupportedGetField expression.
+func NewUnsupportedGetField(table, name string) *UnsupportedGetField {
+	return &UnsupportedGetField{table, name}
+}
+
+// Table implements the Tableable interface.
+func (u *UnsupportedGetField) Table() string { return u.table }
+
+// Name implements the Nameable interface.
+func (u *UnsupportedGetField) Name() string { return u.name }
+
+// Type implements the Expression interface.
+func (UnsupportedGetField) Type() sql.Type { return sql.Text }
+
+// Resolved implements the Expression interface.
+func (UnsupportedGetField) Resolved() bool { return true }
+
+// IsNullable implements the Expression interface.
+func (UnsupportedGetField) IsNullable() bool { return true }
+
+// Children implements the Expression interface.
+func (UnsupportedGetField) Children() []sql.Expression { return nil }
+
+// Eval implements the Expression interface.
+func (UnsupportedGetField) Eval(*sql.Context, sql.Row) (interface{}, error) { return nil, nil }
+
+func (u *UnsupportedGetField) String() string {
+	return fmt.Sprintf("%s.%s", u.table, u.name)
+}
+
+// TransformUp implements the Expression interface.
+func (u *UnsupportedGetField) TransformUp(sql.TransformExprFunc) (sql.Expression, error) {
+	return u, nil
+}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -631,3 +631,53 @@ func TestParseErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveComments(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			`/* FOO BAR BAZ */`,
+			``,
+		},
+		{
+			`SELECT 1 -- something`,
+			`SELECT 1 `,
+		},
+		{
+			`SELECT 1 --something`,
+			`SELECT 1 --something`,
+		},
+		{
+			`SELECT ' -- something'`,
+			`SELECT ' -- something'`,
+		},
+		{
+			`SELECT /* FOO */ 1;`,
+			`SELECT  1;`,
+		},
+		{
+			`SELECT '/* FOO */ 1';`,
+			`SELECT '/* FOO */ 1';`,
+		},
+		{
+			`SELECT "\"/* FOO */ 1\"";`,
+			`SELECT "\"/* FOO */ 1\"";`,
+		},
+		{
+			`SELECT '\'/* FOO */ 1\'';`,
+			`SELECT '\'/* FOO */ 1\'';`,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(
+				t,
+				tt.output,
+				removeComments(tt.input),
+			)
+		})
+	}
+}

--- a/sql/plan/show_databases.go
+++ b/sql/plan/show_databases.go
@@ -1,0 +1,57 @@
+package plan
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// ShowDatabases is a node that shows the databases.
+type ShowDatabases struct {
+	Catalog *sql.Catalog
+}
+
+// NewShowDatabases creates a new show databases node.
+func NewShowDatabases() *ShowDatabases {
+	return new(ShowDatabases)
+}
+
+// Resolved implements the Resolvable interface.
+func (p *ShowDatabases) Resolved() bool {
+	return p.Catalog != nil
+}
+
+// Children implements the Node interface.
+func (*ShowDatabases) Children() []sql.Node {
+	return nil
+}
+
+// Schema implements the Node interface.
+func (*ShowDatabases) Schema() sql.Schema {
+	return sql.Schema{{
+		Name:     "database",
+		Type:     sql.Text,
+		Nullable: false,
+	}}
+}
+
+// RowIter implements the Node interface.
+func (p *ShowDatabases) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	var rows = make([]sql.Row, len(p.Catalog.Databases))
+	for i, db := range p.Catalog.Databases {
+		rows[i] = sql.Row{db.Name()}
+	}
+
+	return sql.RowsToRowIter(rows...), nil
+}
+
+// TransformUp implements the Transformable interface.
+func (p *ShowDatabases) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	np := *p
+	return f(&np)
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (p *ShowDatabases) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	return p, nil
+}
+
+func (p ShowDatabases) String() string {
+	return "ShowDatabases"
+}

--- a/sql/plan/unsupported.go
+++ b/sql/plan/unsupported.go
@@ -1,0 +1,50 @@
+package plan
+
+import (
+	"github.com/sirupsen/logrus"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// Unsupported is a node which is unsupported, but it's implemented as
+// a way to make the query not fail.
+type Unsupported struct {
+	// Message will be logged as a warning when the query executes.
+	Message string
+	// ResultSchema is the schema for the result rows.
+	ResultSchema sql.Schema
+	// Result will be returned in the iterator of this node.
+	Result []sql.Row
+}
+
+// NewUnsupported creates a new unsupported node.
+func NewUnsupported(message string, schema sql.Schema, result ...sql.Row) *Unsupported {
+	return &Unsupported{message, schema, result}
+}
+
+// Resolved implements the Node interface.
+func (Unsupported) Resolved() bool { return true }
+
+// Schema implements the Node interface.
+func (u *Unsupported) Schema() sql.Schema { return u.ResultSchema }
+
+// Children implements the Node interface.
+func (Unsupported) Children() []sql.Node { return nil }
+
+// RowIter implements the Node interface.
+func (u *Unsupported) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("Unsupported")
+	logrus.Warn(u.Message)
+	return sql.NewSpanIter(span, sql.RowsToRowIter(u.Result...)), nil
+}
+
+func (Unsupported) String() string { return "unsupported" }
+
+// TransformExpressionsUp implements the Node interface.
+func (u *Unsupported) TransformExpressionsUp(fn sql.TransformExprFunc) (sql.Node, error) {
+	return u, nil
+}
+
+// TransformUp implements the Node interface.
+func (u *Unsupported) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
+	return u, nil
+}


### PR DESCRIPTION
This is only a part of what should be implemented to be compatible with mysqldump, more info at: https://github.com/src-d/gitbase/issues/361

What this includes:

- Remove comments.
- Empty queries do not crash (see the /* SOME QUERY INSIDE COMMENT*/).
- `SHOW VARIABLES`, which returns a dummy result.
- `SET`, which returns an dummy result.
- `@@GLOBAL.FOO` and `@@SESSION.FOO` always return `nil` and can be resolved.
- `SHOW DATABASES`.
- `LOCK`,  which returns a dummy result.
- `USE`, which returns a dummy result