### PR TITLE
index/pilosa: do not error when key is not found

### DIFF
--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -141,6 +141,14 @@ func TestSaveAndLoad(t *testing.T) {
 		require.NoError(err)
 	}
 
+	// test that not found values do not cause error
+	lookup, err := sqlIdx.Get("do not exist", "none")
+	require.NoError(err)
+	lit, err := lookup.Values()
+	require.NoError(err)
+	_, err = lit.Next()
+	require.Equal(io.EOF, err)
+
 	found := false
 	for _, span := range tracer.Spans {
 		if span == "pilosa.Save.bitBatch" {

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -254,11 +254,19 @@ func (l *indexLookup) Values() (sql.IndexValueIter, error) {
 		}
 
 		rowID, err := l.mapping.rowID(frm.Name(), l.keys[i])
+		if err == io.EOF {
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
 
 		bitmaps = append(bitmaps, frm.Bitmap(rowID))
+	}
+
+	if len(bitmaps) == 0 {
+		return &indexValueIter{mapping: l.mapping, indexName: l.indexName}, nil
 	}
 
 	resp, err := l.client.Query(index.Intersect(bitmaps...))

--- a/sql/index/pilosa/mapping.go
+++ b/sql/index/pilosa/mapping.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -98,7 +99,7 @@ func (m *mapping) rowID(frameName string, value interface{}) (uint64, error) {
 		return 0, err
 	}
 	if val == nil {
-		return 0, fmt.Errorf("id is nil")
+		return 0, io.EOF
 	}
 
 	return binary.LittleEndian.Uint64(val), err


### PR DESCRIPTION
Caused this error when no rows were found:

```
MySQL [(none)]> select count(file_path) from files where file_path='index.goo';
ERROR 1105 (HY000): unknown error: id is nil
```