### PR TITLE
sql/analyzer: fix columns in the resolveNaturalJoins rule

### DIFF
--- a/sql/analyzer/rules_test.go
+++ b/sql/analyzer/rules_test.go
@@ -443,6 +443,65 @@ func TestResolveNaturalJoins(t *testing.T) {
 	require.Equal(expected, result)
 }
 
+func TestResolveNaturalJoinsColumns(t *testing.T) {
+	rule := getRule("resolve_natural_joins")
+	require := require.New(t)
+
+	left := mem.NewTable("t1", sql.Schema{
+		{Name: "a", Type: sql.Int64, Source: "t1"},
+		{Name: "b", Type: sql.Int64, Source: "t1"},
+		{Name: "c", Type: sql.Int64, Source: "t1"},
+	})
+
+	right := mem.NewTable("t2", sql.Schema{
+		{Name: "d", Type: sql.Int64, Source: "t2"},
+		{Name: "c", Type: sql.Int64, Source: "t2"},
+		{Name: "b", Type: sql.Int64, Source: "t2"},
+		{Name: "e", Type: sql.Int64, Source: "t2"},
+	})
+
+	node := plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedQualifiedColumn("t2", "b"),
+		},
+		plan.NewNaturalJoin(left, right),
+	)
+
+	result, err := rule.Apply(sql.NewEmptyContext(), NewDefault(nil), node)
+	require.NoError(err)
+
+	expected := plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedQualifiedColumn("t1", "b"),
+		},
+		plan.NewProject(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(1, sql.Int64, "t1", "b", false),
+				expression.NewGetFieldWithTable(2, sql.Int64, "t1", "c", false),
+				expression.NewGetFieldWithTable(0, sql.Int64, "t1", "a", false),
+				expression.NewGetFieldWithTable(3, sql.Int64, "t2", "d", false),
+				expression.NewGetFieldWithTable(6, sql.Int64, "t2", "e", false),
+			},
+			plan.NewInnerJoin(
+				left,
+				right,
+				expression.JoinAnd(
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(1, sql.Int64, "t1", "b", false),
+						expression.NewGetFieldWithTable(5, sql.Int64, "t2", "b", false),
+					),
+					expression.NewEquals(
+						expression.NewGetFieldWithTable(2, sql.Int64, "t1", "c", false),
+						expression.NewGetFieldWithTable(4, sql.Int64, "t2", "c", false),
+					),
+				),
+			),
+		),
+	)
+
+	require.Equal(expected, result)
+}
+
 func TestResolveNaturalJoinsEqual(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
Related to https://github.com/src-d/gitbase/issues/365

(When this PR will be merged, a PR updating `go-mysql-server` and adding an integration test in `gitbase`  must be done to close that issue.)

When a natural join is transformed, all the nodes over the transformed node that reference some of the common columns by the right table in the join couldn't resolve them.

With this fix, all those columns resolve now to the left table in the join to be found.
 