### PR TITLE
add version udf

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -16,18 +16,19 @@ type Engine struct {
 }
 
 // New creates a new Engine
-func New(c *sql.Catalog, a *analyzer.Analyzer) *Engine {
+func New(c *sql.Catalog, a *analyzer.Analyzer, versionPostfix string) *Engine {
 	c.RegisterFunctions(function.Defaults)
+	c.RegisterFunction("version", sql.FunctionN(function.NewVersion(versionPostfix)))
+
 	return &Engine{c, a}
 }
 
 // NewDefault creates a new default Engine.
 func NewDefault() *Engine {
 	c := sql.NewCatalog()
-	c.RegisterFunctions(function.Defaults)
-
 	a := analyzer.NewDefault(c)
-	return &Engine{c, a}
+
+	return New(c, a, "go-mysql-server")
 }
 
 // Query executes a query without attaching to any context.

--- a/engine_test.go
+++ b/engine_test.go
@@ -289,6 +289,12 @@ var queries = []struct {
 			{string("third row3")},
 		},
 	},
+	{
+		"SELECT version()",
+		[]sql.Row{
+			{string("8.0.11-go-mysql-server")},
+		},
+	},
 }
 
 func TestQueries(t *testing.T) {
@@ -926,7 +932,7 @@ func TestReadOnly(t *testing.T) {
 
 	a := analyzer.NewBuilder(catalog).ReadOnly().Build()
 	a.CurrentDatabase = "mydb"
-	e := sqle.New(catalog, a)
+	e := sqle.New(catalog, a, "")
 
 	_, _, err := e.Query(sql.NewEmptyContext(), `SELECT i FROM mytable`)
 	require.NoError(err)

--- a/sql/expression/function/version.go
+++ b/sql/expression/function/version.go
@@ -1,0 +1,49 @@
+package function
+
+import (
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+const mysqlVersion = "8.0.11"
+
+// Version is a function that returns server version.
+type Version string
+
+// NewVersion creates a new Version UDF.
+func NewVersion(versionPostfix string) func(...sql.Expression) (sql.Expression, error) {
+	return func(...sql.Expression) (sql.Expression, error) {
+		// need to return pointer because sql.Expression methods expect pointer receivers
+		e := Version(versionPostfix)
+		return &e, nil
+	}
+}
+
+// Type implements the Expression interface.
+func (f *Version) Type() sql.Type { return sql.Text }
+
+// IsNullable implements the Expression interface.
+func (f *Version) IsNullable() bool {
+	return false
+}
+
+func (f *Version) String() string {
+	return "version"
+}
+
+// TransformUp implements the Expression interface.
+func (f *Version) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
+	return fn(f)
+}
+
+// Resolved implements the Expression interface.
+func (f *Version) Resolved() bool {
+	return true
+}
+
+// Children implements the Expression interface.
+func (f *Version) Children() []sql.Expression { return nil }
+
+// Eval implements the Expression interface.
+func (f *Version) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	return mysqlVersion + "-" + string(*f), nil
+}

--- a/sql/expression/function/version_test.go
+++ b/sql/expression/function/version_test.go
@@ -1,0 +1,21 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+const versionPostfix = "test"
+
+func TestNewVersion(t *testing.T) {
+	require := require.New(t)
+
+	f, _ := NewVersion(versionPostfix)()
+	ctx := sql.NewEmptyContext()
+
+	val, err := f.Eval(ctx, sql.NewRow(nil))
+	require.NoError(err)
+	require.Equal("8.0.11-"+versionPostfix, val)
+}


### PR DESCRIPTION
Implement [VERSION](https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_version) udf.

usage:

```go
driver.Catalog.RegisterFunction("version", sql.Function0(function.NewVersion("0.1.1")))
```

```
mysql> select VERSION();
+---------+
| version |
+---------+
| 0.1.1   |
+---------+
1 row in set (0.00 sec)
```

Context: https://github.com/src-d/gitbase-playground/issues/184#issuecomment-402809742
