### PR TITLE
sql/analyzer: add rule to evaluate filters ahead of time

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -295,6 +295,10 @@ var queries = []struct {
 			{string("8.0.11-go-mysql-server")},
 		},
 	},
+	{
+		"SELECT * FROM mytable WHERE 1 > 5",
+		[]sql.Row{},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -20,6 +20,7 @@ var DefaultRules = []Rule{
 	{"assign_indexes", assignIndexes},
 	{"pushdown", pushdown},
 	{"move_join_conds_to_filter", moveJoinConditionsToFilter},
+	{"eval_filter", evalFilter},
 	{"optimize_distinct", optimizeDistinct},
 	{"erase_projection", eraseProjection},
 	{"index_catalog", indexCatalog},

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -61,3 +61,8 @@ func (p *Literal) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
 func (*Literal) Children() []sql.Expression {
 	return nil
 }
+
+// Value returns the literal value.
+func (p *Literal) Value() interface{} {
+	return p.value
+}

--- a/sql/plan/empty_table.go
+++ b/sql/plan/empty_table.go
@@ -1,0 +1,27 @@
+package plan
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// EmptyTable is a node representing an empty table.
+var EmptyTable = new(emptyTable)
+
+type emptyTable struct{}
+
+func (emptyTable) Schema() sql.Schema   { return nil }
+func (emptyTable) Children() []sql.Node { return nil }
+func (emptyTable) Resolved() bool       { return true }
+func (e *emptyTable) String() string    { return "EmptyTable" }
+
+func (emptyTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	return sql.RowsToRowIter(), nil
+}
+
+// TransformUp implements the Transformable interface.
+func (e *emptyTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	return f(e)
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (e *emptyTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	return e, nil
+}


### PR DESCRIPTION
Closes #280

This commit adds the `eval_filters` rule to the analyzer, which evaluates all evaluable filters in `Filter` nodes and removes any unnecessary filter. If it turns out the final result of evaluating the filters is true, independently of the non-evaluable expressions, the filter node is just removed. If it's false, the filter node is removed and replaced with a special node called `Nothing` that returns an empty result set while still holding the instance of the inner node.
