### PR TITLE
*: pass context to Insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,19 @@ func createTestDatabase() *mem.Database {
     })
 
     db.AddTable(tableName, table)
-    table.Insert(sql.NewRow("John Doe", "john@doe.com", []string{"555-555-555"}, time.Now()))
-    table.Insert(sql.NewRow("John Doe", "johnalt@doe.com", []string{}, time.Now()))
-    table.Insert(sql.NewRow("Jane Doe", "jane@doe.com", []string{}, time.Now()))
-    table.Insert(sql.NewRow("Evil Bob", "evilbob@gmail.com", []string{"555-666-555", "666-666-666"}, time.Now()))
+    ctx := sql.NewEmptyContext()
+
+    rows := []sql.Row{
+        sql.NewRow("John Doe", "john@doe.com", []string{"555-555-555"}, time.Now()),
+        sql.NewRow("John Doe", "johnalt@doe.com", []string{}, time.Now()),
+        sql.NewRow("Jane Doe", "jane@doe.com", []string{}, time.Now()),
+        sql.NewRow("Evil Bob", "evilbob@gmail.com", []string{"555-666-555", "666-666-666"}, time.Now()),
+	}
+
+    for _, row := range rows {
+        table.Insert(ctx, row)
+    }
+    
     return db
 }
 

--- a/benchmark/tpc_h_test.go
+++ b/benchmark/tpc_h_test.go
@@ -122,7 +122,7 @@ func insertDataToTable(t *mem.Table, columnCount int) error {
 			return err
 		}
 
-		if err := t.Insert(row); err != nil {
+		if err := t.Insert(sql.NewEmptyContext(), row); err != nil {
 			return err
 		}
 	}

--- a/engine_test.go
+++ b/engine_test.go
@@ -357,17 +357,24 @@ func TestAmbiguousColumnResolution(t *testing.T) {
 		{Name: "a", Type: sql.Int64, Source: "foo"},
 		{Name: "b", Type: sql.Text, Source: "foo"},
 	})
-	require.Nil(table.Insert(sql.NewRow(int64(1), "foo")))
-	require.Nil(table.Insert(sql.NewRow(int64(2), "bar")))
-	require.Nil(table.Insert(sql.NewRow(int64(3), "baz")))
+
+	insertRows(
+		t, table,
+		sql.NewRow(int64(1), "foo"),
+		sql.NewRow(int64(2), "bar"),
+		sql.NewRow(int64(3), "baz"),
+	)
 
 	table2 := mem.NewTable("bar", sql.Schema{
 		{Name: "b", Type: sql.Text, Source: "bar"},
 		{Name: "c", Type: sql.Int64, Source: "bar"},
 	})
-	require.Nil(table2.Insert(sql.NewRow("qux", int64(3))))
-	require.Nil(table2.Insert(sql.NewRow("mux", int64(2))))
-	require.Nil(table2.Insert(sql.NewRow("pux", int64(1))))
+	insertRows(
+		t, table2,
+		sql.NewRow("qux", int64(3)),
+		sql.NewRow("mux", int64(2)),
+		sql.NewRow("pux", int64(1)),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable(table.Name(), table)
@@ -438,18 +445,26 @@ func TestNaturalJoin(t *testing.T) {
 		{Name: "b", Type: sql.Text, Source: "t1"},
 		{Name: "c", Type: sql.Text, Source: "t1"},
 	})
-	require.Nil(t1.Insert(sql.NewRow("a_1", "b_1", "c_1")))
-	require.Nil(t1.Insert(sql.NewRow("a_2", "b_2", "c_2")))
-	require.Nil(t1.Insert(sql.NewRow("a_3", "b_3", "c_3")))
+
+	insertRows(
+		t, t1,
+		sql.NewRow("a_1", "b_1", "c_1"),
+		sql.NewRow("a_2", "b_2", "c_2"),
+		sql.NewRow("a_3", "b_3", "c_3"),
+	)
 
 	t2 := mem.NewTable("t2", sql.Schema{
 		{Name: "a", Type: sql.Text, Source: "t2"},
 		{Name: "b", Type: sql.Text, Source: "t2"},
 		{Name: "d", Type: sql.Text, Source: "t2"},
 	})
-	require.NoError(t2.Insert(sql.NewRow("a_1", "b_1", "d_1")))
-	require.NoError(t2.Insert(sql.NewRow("a_2", "b_2", "d_2")))
-	require.NoError(t2.Insert(sql.NewRow("a_3", "b_3", "d_3")))
+
+	insertRows(
+		t, t2,
+		sql.NewRow("a_1", "b_1", "d_1"),
+		sql.NewRow("a_2", "b_2", "d_2"),
+		sql.NewRow("a_3", "b_3", "d_3"),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable(t1.Name(), t1)
@@ -482,18 +497,26 @@ func TestNaturalJoinEqual(t *testing.T) {
 		{Name: "b", Type: sql.Text, Source: "t1"},
 		{Name: "c", Type: sql.Text, Source: "t1"},
 	})
-	require.Nil(t1.Insert(sql.NewRow("a_1", "b_1", "c_1")))
-	require.Nil(t1.Insert(sql.NewRow("a_2", "b_2", "c_2")))
-	require.Nil(t1.Insert(sql.NewRow("a_3", "b_3", "c_3")))
+
+	insertRows(
+		t, t1,
+		sql.NewRow("a_1", "b_1", "c_1"),
+		sql.NewRow("a_2", "b_2", "c_2"),
+		sql.NewRow("a_3", "b_3", "c_3"),
+	)
 
 	t2 := mem.NewTable("t2", sql.Schema{
 		{Name: "a", Type: sql.Text, Source: "t2"},
 		{Name: "b", Type: sql.Text, Source: "t2"},
 		{Name: "c", Type: sql.Text, Source: "t2"},
 	})
-	require.Nil(t2.Insert(sql.NewRow("a_1", "b_1", "c_1")))
-	require.Nil(t2.Insert(sql.NewRow("a_2", "b_2", "c_2")))
-	require.Nil(t2.Insert(sql.NewRow("a_3", "b_3", "c_3")))
+
+	insertRows(
+		t, t2,
+		sql.NewRow("a_1", "b_1", "c_1"),
+		sql.NewRow("a_2", "b_2", "c_2"),
+		sql.NewRow("a_3", "b_3", "c_3"),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable(t1.Name(), t1)
@@ -524,16 +547,23 @@ func TestNaturalJoinDisjoint(t *testing.T) {
 	t1 := mem.NewTable("t1", sql.Schema{
 		{Name: "a", Type: sql.Text, Source: "t1"},
 	})
-	require.Nil(t1.Insert(sql.NewRow("a1")))
-	require.Nil(t1.Insert(sql.NewRow("a2")))
-	require.Nil(t1.Insert(sql.NewRow("a3")))
+
+	insertRows(
+		t, t1,
+		sql.NewRow("a1"),
+		sql.NewRow("a2"),
+		sql.NewRow("a3"),
+	)
 
 	t2 := mem.NewTable("t2", sql.Schema{
 		{Name: "b", Type: sql.Text, Source: "t2"},
 	})
-	require.NoError(t2.Insert(sql.NewRow("b1")))
-	require.NoError(t2.Insert(sql.NewRow("b2")))
-	require.NoError(t2.Insert(sql.NewRow("b3")))
+	insertRows(
+		t, t2,
+		sql.NewRow("b1"),
+		sql.NewRow("b2"),
+		sql.NewRow("b3"),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable(t1.Name(), t1)
@@ -573,9 +603,12 @@ func TestInnerNestedInNaturalJoins(t *testing.T) {
 		{Name: "t", Type: sql.Text, Source: "table1"},
 	})
 
-	require.Nil(table1.Insert(sql.NewRow(int32(1), float64(2.1), "table1")))
-	require.Nil(table1.Insert(sql.NewRow(int32(1), float64(2.1), "table1")))
-	require.Nil(table1.Insert(sql.NewRow(int32(10), float64(2.1), "table1")))
+	insertRows(
+		t, table1,
+		sql.NewRow(int32(1), float64(2.1), "table1"),
+		sql.NewRow(int32(1), float64(2.1), "table1"),
+		sql.NewRow(int32(10), float64(2.1), "table1"),
+	)
 
 	table2 := mem.NewTable("table2", sql.Schema{
 		{Name: "i2", Type: sql.Int32, Source: "table2"},
@@ -583,9 +616,12 @@ func TestInnerNestedInNaturalJoins(t *testing.T) {
 		{Name: "t2", Type: sql.Text, Source: "table2"},
 	})
 
-	require.Nil(table2.Insert(sql.NewRow(int32(1), float64(2.2), "table2")))
-	require.Nil(table2.Insert(sql.NewRow(int32(1), float64(2.2), "table2")))
-	require.Nil(table2.Insert(sql.NewRow(int32(20), float64(2.2), "table2")))
+	insertRows(
+		t, table2,
+		sql.NewRow(int32(1), float64(2.2), "table2"),
+		sql.NewRow(int32(1), float64(2.2), "table2"),
+		sql.NewRow(int32(20), float64(2.2), "table2"),
+	)
 
 	table3 := mem.NewTable("table3", sql.Schema{
 		{Name: "i", Type: sql.Int32, Source: "table3"},
@@ -593,9 +629,12 @@ func TestInnerNestedInNaturalJoins(t *testing.T) {
 		{Name: "t3", Type: sql.Text, Source: "table3"},
 	})
 
-	require.Nil(table3.Insert(sql.NewRow(int32(1), float64(2.3), "table3")))
-	require.Nil(table3.Insert(sql.NewRow(int32(2), float64(2.3), "table3")))
-	require.Nil(table3.Insert(sql.NewRow(int32(30), float64(2.3), "table3")))
+	insertRows(
+		t, table3,
+		sql.NewRow(int32(1), float64(2.3), "table3"),
+		sql.NewRow(int32(2), float64(2.3), "table3"),
+		sql.NewRow(int32(30), float64(2.3), "table3"),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable("table1", table1)
@@ -646,31 +685,40 @@ func testQuery(t *testing.T, e *sqle.Engine, q string, r []sql.Row) {
 }
 
 func newEngine(t *testing.T) *sqle.Engine {
-	require := require.New(t)
-
 	table := mem.NewTable("mytable", sql.Schema{
 		{Name: "i", Type: sql.Int64, Source: "mytable"},
 		{Name: "s", Type: sql.Text, Source: "mytable"},
 	})
-	require.NoError(table.Insert(sql.NewRow(int64(1), "first row")))
-	require.NoError(table.Insert(sql.NewRow(int64(2), "second row")))
-	require.NoError(table.Insert(sql.NewRow(int64(3), "third row")))
+
+	insertRows(
+		t, table,
+		sql.NewRow(int64(1), "first row"),
+		sql.NewRow(int64(2), "second row"),
+		sql.NewRow(int64(3), "third row"),
+	)
 
 	table2 := mem.NewTable("othertable", sql.Schema{
 		{Name: "s2", Type: sql.Text, Source: "othertable"},
 		{Name: "i2", Type: sql.Int64, Source: "othertable"},
 	})
-	require.NoError(table2.Insert(sql.NewRow("first", int64(3))))
-	require.NoError(table2.Insert(sql.NewRow("second", int64(2))))
-	require.NoError(table2.Insert(sql.NewRow("third", int64(1))))
+	insertRows(
+		t, table2,
+		sql.NewRow("first", int64(3)),
+		sql.NewRow("second", int64(2)),
+		sql.NewRow("third", int64(1)),
+	)
 
 	table3 := mem.NewTable("tabletest", sql.Schema{
 		{Name: "text", Type: sql.Text, Source: "tabletest"},
 		{Name: "number", Type: sql.Int32, Source: "tabletest"},
 	})
-	require.NoError(table3.Insert(sql.NewRow("a", int32(1))))
-	require.NoError(table3.Insert(sql.NewRow("b", int32(2))))
-	require.NoError(table3.Insert(sql.NewRow("c", int32(3))))
+
+	insertRows(
+		t, table3,
+		sql.NewRow("a", int32(1)),
+		sql.NewRow("b", int32(2)),
+		sql.NewRow("c", int32(3)),
+	)
 
 	db := mem.NewDatabase("mydb")
 	db.AddTable(table.Name(), table)
@@ -873,12 +921,16 @@ func TestOrderByGroupBy(t *testing.T) {
 		{Name: "id", Type: sql.Int64, Source: "members"},
 		{Name: "team", Type: sql.Text, Source: "members"},
 	})
-	require.NoError(table.Insert(sql.NewRow(int64(3), "red")))
-	require.NoError(table.Insert(sql.NewRow(int64(4), "red")))
-	require.NoError(table.Insert(sql.NewRow(int64(5), "orange")))
-	require.NoError(table.Insert(sql.NewRow(int64(6), "orange")))
-	require.NoError(table.Insert(sql.NewRow(int64(7), "orange")))
-	require.NoError(table.Insert(sql.NewRow(int64(8), "purple")))
+
+	insertRows(
+		t, table,
+		sql.NewRow(int64(3), "red"),
+		sql.NewRow(int64(4), "red"),
+		sql.NewRow(int64(5), "orange"),
+		sql.NewRow(int64(6), "orange"),
+		sql.NewRow(int64(7), "orange"),
+		sql.NewRow(int64(8), "purple"),
+	)
 
 	db := mem.NewDatabase("db")
 	db.AddTable(table.Name(), table)
@@ -979,4 +1031,12 @@ func TestReadOnly(t *testing.T) {
 	_, _, err = e.Query(sql.NewEmptyContext(), `INSERT INTO foo (i, s) VALUES(42, 'yolo')`)
 	require.Error(err)
 	require.True(analyzer.ErrQueryNotAllowed.Is(err))
+}
+
+func insertRows(t *testing.T, table sql.Inserter, rows ...sql.Row) {
+	t.Helper()
+
+	for _, r := range rows {
+		require.NoError(t, table.Insert(sql.NewEmptyContext(), r))
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -51,10 +51,18 @@ func createTestDatabase() sql.Database {
 		{Name: "email", Type: sql.Text, Source: "mytable"},
 	})
 	db.AddTable("mytable", table)
-	table.Insert(sql.NewRow("John Doe", "john@doe.com"))
-	table.Insert(sql.NewRow("John Doe", "johnalt@doe.com"))
-	table.Insert(sql.NewRow("Jane Doe", "jane@doe.com"))
-	table.Insert(sql.NewRow("Evil Bob", "evilbob@gmail.com"))
+	ctx := sql.NewEmptyContext()
+
+	rows := []sql.Row{
+		sql.NewRow("John Doe", "john@doe.com"),
+		sql.NewRow("John Doe", "johnalt@doe.com"),
+		sql.NewRow("Jane Doe", "jane@doe.com"),
+		sql.NewRow("Evil Bob", "evilbob@gmail.com"),
+	}
+
+	for _, row := range rows {
+		table.Insert(ctx, row)
+	}
 
 	return db
 }

--- a/mem/table.go
+++ b/mem/table.go
@@ -61,7 +61,7 @@ func (t *Table) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error
 }
 
 // Insert a new row into the table.
-func (t *Table) Insert(row sql.Row) error {
+func (t *Table) Insert(ctx *sql.Context, row sql.Row) error {
 	if len(row) != len(t.schema) {
 		return sql.ErrUnexpectedRowLength.New(len(t.schema), len(row))
 	}

--- a/mem/table_test.go
+++ b/mem/table_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
-func TestTable_Name(t *testing.T) {
+func TestTableName(t *testing.T) {
 	require := require.New(t)
 	s := sql.Schema{
 		{"col1", sql.Text, nil, true, ""},
@@ -33,7 +33,7 @@ func TestTableString(t *testing.T) {
 	require.Equal(expectedString, table.String())
 }
 
-func TestTable_Insert_RowIter(t *testing.T) {
+func TestTableInsert(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
@@ -47,13 +47,13 @@ func TestTable_Insert_RowIter(t *testing.T) {
 	require.NoError(err)
 	require.Len(rows, 0)
 
-	err = table.Insert(sql.NewRow("foo"))
+	err = table.Insert(sql.NewEmptyContext(), sql.NewRow("foo"))
 	rows, err = sql.NodeToRows(ctx, table)
 	require.NoError(err)
 	require.Len(rows, 1)
 	require.Nil(s.CheckRow(rows[0]))
 
-	err = table.Insert(sql.NewRow("bar"))
+	err = table.Insert(sql.NewEmptyContext(), sql.NewRow("bar"))
 	rows, err = sql.NodeToRows(ctx, table)
 	require.NoError(err)
 	require.Len(rows, 2)
@@ -69,9 +69,15 @@ func TestTableIndexKeyValueIter(t *testing.T) {
 		{Name: "bar", Type: sql.Int64},
 	})
 
-	require.NoError(table.Insert(sql.NewRow("foo", int64(1))))
-	require.NoError(table.Insert(sql.NewRow("bar", int64(2))))
-	require.NoError(table.Insert(sql.NewRow("baz", int64(3))))
+	rows := []sql.Row{
+		sql.NewRow("foo", int64(1)),
+		sql.NewRow("bar", int64(2)),
+		sql.NewRow("baz", int64(3)),
+	}
+
+	for _, r := range rows {
+		require.NoError(table.Insert(sql.NewEmptyContext(), r))
+	}
 
 	iter, err := table.IndexKeyValueIter(sql.NewEmptyContext(), []string{"bar"})
 	require.NoError(err)
@@ -111,10 +117,16 @@ func TestTableIndex(t *testing.T) {
 		{Name: "bar", Type: sql.Int64},
 	})
 
-	require.NoError(table.Insert(sql.NewRow("foo", int64(1))))
-	require.NoError(table.Insert(sql.NewRow("bar", int64(2))))
-	require.NoError(table.Insert(sql.NewRow("baz", int64(3))))
-	require.NoError(table.Insert(sql.NewRow("qux", int64(4))))
+	rows := []sql.Row{
+		sql.NewRow("foo", int64(1)),
+		sql.NewRow("bar", int64(2)),
+		sql.NewRow("baz", int64(3)),
+		sql.NewRow("qux", int64(4)),
+	}
+
+	for _, r := range rows {
+		require.NoError(table.Insert(sql.NewEmptyContext(), r))
+	}
 
 	index := &index{keys: []int64{1, 2}}
 

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -21,7 +21,10 @@ func setupMemDB(require *require.Assertions) *sqle.Engine {
 	tableTest := mem.NewTable("test", sql.Schema{{Name: "c1", Type: sql.Int32, Source: "test"}})
 
 	for i := 0; i < 1010; i++ {
-		require.NoError(tableTest.Insert(sql.NewRow(int32(i))))
+		require.NoError(tableTest.Insert(
+			sql.NewEmptyContext(),
+			sql.NewRow(int32(i)),
+		))
 	}
 
 	db.AddTable("test", tableTest)

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -10,7 +10,7 @@ var dualTable = func() sql.Table {
 	t := mem.NewTable("dual", sql.Schema{
 		{Name: "dummy", Source: "dual", Type: sql.Text, Nullable: false},
 	})
-	_ = t.Insert(sql.NewRow("x"))
+	_ = t.Insert(sql.NewEmptyContext(), sql.NewRow("x"))
 	return t
 }()
 

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -57,11 +57,18 @@ func TestValidateGroupBy(t *testing.T) {
 	}
 
 	child := mem.NewTable("test", childSchema)
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_1", int64(2222)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_1", int64(2222)),
+		sql.NewRow("col1_2", int64(4444)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := plan.NewGroupBy(
 		[]sql.Expression{
@@ -95,11 +102,18 @@ func TestValidateGroupByErr(t *testing.T) {
 	}
 
 	child := mem.NewTable("test", childSchema)
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_1", int64(2222)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_1", int64(2222)),
+		sql.NewRow("col1_2", int64(4444)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := plan.NewGroupBy(
 		[]sql.Expression{

--- a/sql/core.go
+++ b/sql/core.go
@@ -192,7 +192,7 @@ type PushdownProjectionAndFiltersTable interface {
 // Inserter allow rows to be inserted in them.
 type Inserter interface {
 	// Insert the given row.
-	Insert(row Row) error
+	Insert(*Context, Row) error
 }
 
 // Database represents the database.

--- a/sql/plan/common_test.go
+++ b/sql/plan/common_test.go
@@ -24,27 +24,33 @@ var benchtable = func() *mem.Table {
 
 	for i := 0; i < 100; i++ {
 		n := fmt.Sprint(i)
-		err := t.Insert(sql.NewRow(
-			repeatStr(n, i%10+1),
-			float64(i),
-			i%2 == 0,
-			int32(i),
-			int64(i),
-			[]byte(repeatStr(n, 100+(i%100))),
-		))
-		if err != nil {
-			panic(err)
-		}
-
-		if i%2 == 0 {
-			err := t.Insert(sql.NewRow(
+		err := t.Insert(
+			sql.NewEmptyContext(),
+			sql.NewRow(
 				repeatStr(n, i%10+1),
 				float64(i),
 				i%2 == 0,
 				int32(i),
 				int64(i),
 				[]byte(repeatStr(n, 100+(i%100))),
-			))
+			),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		if i%2 == 0 {
+			err := t.Insert(
+				sql.NewEmptyContext(),
+				sql.NewRow(
+					repeatStr(n, i%10+1),
+					float64(i),
+					i%2 == 0,
+					int32(i),
+					int64(i),
+					[]byte(repeatStr(n, 100+(i%100))),
+				),
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -182,7 +182,7 @@ func TestCreateIndexWithIter(t *testing.T) {
 		{math.MaxInt64, math.MinInt64},
 	}
 	for _, r := range rows {
-		err := foo.Insert(sql.NewRow(r[0], r[1]))
+		err := foo.Insert(sql.NewEmptyContext(), sql.NewRow(r[0], r[1]))
 		require.NoError(err)
 	}
 

--- a/sql/plan/cross_join_test.go
+++ b/sql/plan/cross_join_test.go
@@ -128,8 +128,13 @@ func TestCrossJoin_Empty(t *testing.T) {
 func insertData(t *testing.T, table *mem.Table) {
 	t.Helper()
 	require := require.New(t)
-	err := table.Insert(sql.NewRow("col1_1", "col2_1", int32(1111), int64(2222)))
-	require.NoError(err)
-	err = table.Insert(sql.NewRow("col1_2", "col2_2", int32(3333), int64(4444)))
-	require.NoError(err)
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", "col2_1", int32(1111), int64(2222)),
+		sql.NewRow("col1_2", "col2_2", int32(3333), int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(table.Insert(sql.NewEmptyContext(), r))
+	}
 }

--- a/sql/plan/distinct_test.go
+++ b/sql/plan/distinct_test.go
@@ -19,11 +19,18 @@ func TestDistinct(t *testing.T) {
 		{Name: "email", Type: sql.Text, Nullable: true},
 	}
 	child := mem.NewTable("test", childSchema)
-	require.NoError(child.Insert(sql.NewRow("john", "john@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("jane", "jane@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("john", "johnx@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("martha", "marthax@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("martha", "martha@doe.com")))
+
+	rows := []sql.Row{
+		sql.NewRow("john", "john@doe.com"),
+		sql.NewRow("jane", "jane@doe.com"),
+		sql.NewRow("john", "johnx@doe.com"),
+		sql.NewRow("martha", "marthax@doe.com"),
+		sql.NewRow("martha", "martha@doe.com"),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := NewProject([]sql.Expression{
 		expression.NewGetField(0, sql.Text, "name", true),
@@ -59,11 +66,18 @@ func TestOrderedDistinct(t *testing.T) {
 		{Name: "email", Type: sql.Text, Nullable: true},
 	}
 	child := mem.NewTable("test", childSchema)
-	require.NoError(child.Insert(sql.NewRow("jane", "jane@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("john", "john@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("john", "johnx@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("martha", "martha@doe.com")))
-	require.NoError(child.Insert(sql.NewRow("martha", "marthax@doe.com")))
+
+	rows := []sql.Row{
+		sql.NewRow("jane", "jane@doe.com"),
+		sql.NewRow("john", "john@doe.com"),
+		sql.NewRow("john", "johnx@doe.com"),
+		sql.NewRow("martha", "martha@doe.com"),
+		sql.NewRow("martha", "marthax@doe.com"),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := NewProject([]sql.Expression{
 		expression.NewGetField(0, sql.Text, "name", true),

--- a/sql/plan/filter_test.go
+++ b/sql/plan/filter_test.go
@@ -20,12 +20,16 @@ func TestFilter(t *testing.T) {
 		{Name: "col4", Type: sql.Int64, Nullable: true},
 	}
 	child := mem.NewTable("test", childSchema)
-	err := child.Insert(sql.NewRow("col1_1", "col2_1", int32(1111), int64(2222)))
-	require.NoError(err)
-	err = child.Insert(sql.NewRow("col1_2", "col2_2", int32(3333), int64(4444)))
-	require.NoError(err)
-	err = child.Insert(sql.NewRow("col1_3", "col2_3", nil, int64(4444)))
-	require.NoError(err)
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", "col2_1", int32(1111), int64(2222)),
+		sql.NewRow("col1_2", "col2_2", int32(3333), int64(4444)),
+		sql.NewRow("col1_3", "col2_3", nil, int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	f := NewFilter(
 		expression.NewEquals(

--- a/sql/plan/group_by_test.go
+++ b/sql/plan/group_by_test.go
@@ -51,11 +51,18 @@ func TestGroupBy_RowIter(t *testing.T) {
 		{Name: "col2", Type: sql.Int64},
 	}
 	child := mem.NewTable("test", childSchema)
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := NewSort(
 		[]SortField{
@@ -99,11 +106,18 @@ func TestGroupBy_Error(t *testing.T) {
 	}
 
 	child := mem.NewTable("test", childSchema)
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_1", int64(2222)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
-	child.Insert(sql.NewRow("col1_1", int64(1111)))
-	child.Insert(sql.NewRow("col1_2", int64(4444)))
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+		sql.NewRow("col1_1", int64(1111)),
+		sql.NewRow("col1_2", int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
 
 	p := NewGroupBy(
 		[]sql.Expression{

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -80,7 +80,7 @@ func (p *InsertInto) Execute(ctx *sql.Context) (int, error) {
 			return i, err
 		}
 
-		if err := insertable.Insert(row); err != nil {
+		if err := insertable.Insert(ctx, row); err != nil {
 			_ = iter.Close()
 			return i, err
 		}

--- a/sql/plan/offset_test.go
+++ b/sql/plan/offset_test.go
@@ -11,7 +11,7 @@ func TestOffsetPlan(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
-	table, _ := getTestingTable()
+	table, _ := getTestingTable(t)
 	offset := NewOffset(0, table)
 	require.Equal(1, len(offset.Children()))
 
@@ -24,7 +24,7 @@ func TestOffset(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
-	table, n := getTestingTable()
+	table, n := getTestingTable(t)
 	offset := NewOffset(1, table)
 
 	iter, err := offset.RowIter(ctx)

--- a/sql/plan/project_test.go
+++ b/sql/plan/project_test.go
@@ -19,8 +19,8 @@ func TestProject(t *testing.T) {
 		{Name: "col2", Type: sql.Text, Nullable: true},
 	}
 	child := mem.NewTable("test", childSchema)
-	child.Insert(sql.NewRow("col1_1", "col2_1"))
-	child.Insert(sql.NewRow("col1_2", "col2_2"))
+	child.Insert(sql.NewEmptyContext(), sql.NewRow("col1_1", "col2_1"))
+	child.Insert(sql.NewEmptyContext(), sql.NewRow("col1_2", "col2_2"))
 	p := NewProject([]sql.Expression{expression.NewGetField(1, sql.Text, "col2", true)}, child)
 	require.Equal(1, len(p.Children()))
 	schema := sql.Schema{

--- a/sql/plan/sort_test.go
+++ b/sql/plan/sort_test.go
@@ -29,7 +29,7 @@ func TestSort(t *testing.T) {
 
 	child := mem.NewTable("test", schema)
 	for _, row := range data {
-		require.NoError(child.Insert(row))
+		require.NoError(child.Insert(sql.NewEmptyContext(), row))
 	}
 
 	sf := []SortField{
@@ -70,7 +70,7 @@ func TestSortAscending(t *testing.T) {
 
 	child := mem.NewTable("test", schema)
 	for _, row := range data {
-		require.NoError(child.Insert(row))
+		require.NoError(child.Insert(sql.NewEmptyContext(), row))
 	}
 
 	sf := []SortField{
@@ -110,7 +110,7 @@ func TestSortDescending(t *testing.T) {
 
 	child := mem.NewTable("test", schema)
 	for _, row := range data {
-		require.NoError(child.Insert(row))
+		require.NoError(child.Insert(sql.NewEmptyContext(), row))
 	}
 
 	sf := []SortField{

--- a/sql/plan/tablealias_test.go
+++ b/sql/plan/tablealias_test.go
@@ -26,7 +26,7 @@ func TestTableAlias(t *testing.T) {
 	}
 
 	for _, r := range rows {
-		require.NoError(table.Insert(r))
+		require.NoError(table.Insert(sql.NewEmptyContext(), r))
 	}
 
 	require.Equal(table.Schema(), alias.Schema())


### PR DESCRIPTION
We were not passing `*sql.Context` to `Insert`. For mem table is not much of a problem, but imagine a data source needs to update indexes after insert or inserts are expensive. Operation is not cancelable without passing context.