### PR TITLE
travis: fix pilosa version installation to v0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 
 install:
   - go get -u github.com/pilosa/go-pilosa
-  - cd "$GOPATH/src/github.com/pilosa/go-pilosa" && git checkout master && cd "$TRAVIS_BUILD_DIR"
+  - cd "$GOPATH/src/github.com/pilosa/go-pilosa" && git checkout v0.9.0 && cd "$TRAVIS_BUILD_DIR"
   - make dependencies
 
 script:


### PR DESCRIPTION
Since the discussion around using dep on libraries is not yet settled I decided to just tweak the hack we already had for it to work.