### PR TITLE
docs: specify caveats about pilosa version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ To install it, run:
 go get gopkg.in/src-d/go-mysql-server.v0
 ```
 
+You might run into trouble using `go get` on the library because of breaking changes introduced in `go-pilosa`, which is used for indexes. To fix these issues you can do the following:
+
+```
+cd $GOPATH/src/github.com/pilosa/go-pilosa
+git checkout v0.9.0
+```
+
+Right now, we only support versions v0.9.x from pilosa. In the future, a more robust solution to this problem will be provided.
+
 ## Documentation
 
 * [go-mysql-server godoc](https://godoc.org/github.com/src-d/go-mysql-server)


### PR DESCRIPTION
Since we're now attached to v0.9.0, I thought it would be worth adding to the README in case anyone wants to contribute to reduce the friction as much as possible.