### PR TITLE
sql/analyzer: remove unnecessary qualification of star

### DIFF
--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -106,7 +106,17 @@ func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error)
 
 					return col, nil
 				}
+			default:
+				// If any other kind of expression has a star, just replace it
+				// with an unqualified star because it cannot be expanded.
+				return e.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+					if _, ok := e.(*expression.Star); ok {
+						return expression.NewStar(), nil
+					}
+					return e, nil
+				})
 			}
+
 			return e, nil
 		})
 	})

--- a/sql/analyzer/resolve_columns_test.go
+++ b/sql/analyzer/resolve_columns_test.go
@@ -159,3 +159,36 @@ func TestQualifyColumns(t *testing.T) {
 	require.NoError(err)
 	require.Equal(expected, result)
 }
+
+func TestQualifyColumnsQualifiedStar(t *testing.T) {
+	require := require.New(t)
+	f := getRule("qualify_columns")
+
+	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
+
+	node := plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedFunction(
+				"count",
+				true,
+				expression.NewQualifiedStar("mytable"),
+			),
+		},
+		table,
+	)
+
+	expected := plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedFunction(
+				"count",
+				true,
+				expression.NewStar(),
+			),
+		},
+		table,
+	)
+
+	result, err := f.Apply(sql.NewEmptyContext(), nil, node)
+	require.NoError(err)
+	require.Equal(expected, result)
+}


### PR DESCRIPTION
Fixes the problem at https://github.com/src-d/gitbase/issues/400

After investigating for a bit, turns out the issue in gitbase is that since `*expression.Star` is a column that's never resolved, it always tries to resolve it. After table is squashed, we can no longer get the names to correctly qualify it.
What I did in this fix is just remove the qualification from the star when it's not necessary (which is any case where it's inside any other expression.

I'm not sure this is the best solution for this, though.