### PR TITLE
sql: add support for show indexes

### DIFF
--- a/sql/analyzer/index_catalog.go
+++ b/sql/analyzer/index_catalog.go
@@ -5,7 +5,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
 
-// indexCatalog sets the catalog in the CreateIndex and DropIndex nodes.
+// indexCatalog sets the catalog in the CreateIndexm, DropIndex and ShowIndexes nodes.
 func indexCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	if !n.Resolved() {
 		return n, nil
@@ -25,6 +25,9 @@ func indexCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 		nc.Catalog = a.Catalog
 		nc.CurrentDatabase = a.CurrentDatabase
 		return &nc, nil
+	case *plan.ShowIndexes:
+		node.Registry = a.Catalog.IndexRegistry
+		return node, nil
 	default:
 		return n, nil
 	}

--- a/sql/analyzer/index_catalog_test.go
+++ b/sql/analyzer/index_catalog_test.go
@@ -13,9 +13,13 @@ func TestCatalogIndex(t *testing.T) {
 	require := require.New(t)
 	f := getRule("index_catalog")
 
+	db := mem.NewDatabase("foo")
 	c := sql.NewCatalog()
+	c.AddDatabase(db)
+
 	a := NewDefault(c)
 	a.CurrentDatabase = "foo"
+	a.Catalog.IndexRegistry = sql.NewIndexRegistry()
 
 	tbl := mem.NewTable("foo", nil)
 
@@ -34,4 +38,12 @@ func TestCatalogIndex(t *testing.T) {
 	require.True(ok)
 	require.Equal(c, di.Catalog)
 	require.Equal("foo", di.CurrentDatabase)
+
+	node, err = f.Apply(sql.NewEmptyContext(), a, plan.NewShowIndexes(db, "table-test", nil))
+	require.NoError(err)
+
+	si, ok := node.(*plan.ShowIndexes)
+	require.True(ok)
+	require.Equal(db, si.Database)
+	require.Equal(c.IndexRegistry, si.Registry)
 }

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -17,11 +17,10 @@ func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error
 	case *plan.ShowIndexes:
 		db, err := a.Catalog.Database(a.CurrentDatabase)
 		if err != nil {
-			return n, err
+			return nil, err
 		}
 
 		v.Database = db
-		v.Registry = a.Catalog.IndexRegistry
 	case *plan.ShowTables:
 		db, err := a.Catalog.Database(a.CurrentDatabase)
 		if err != nil {

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -14,6 +14,14 @@ func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error
 	// TODO Database should implement node,
 	// and ShowTables and CreateTable nodes should be binaryNodes
 	switch v := n.(type) {
+	case *plan.ShowIndexes:
+		db, err := a.Catalog.Database(a.CurrentDatabase)
+		if err != nil {
+			return n, err
+		}
+
+		v.Database = db
+		v.Registry = a.Catalog.IndexRegistry
 	case *plan.ShowTables:
 		db, err := a.Catalog.Database(a.CurrentDatabase)
 		if err != nil {

--- a/sql/index.go
+++ b/sql/index.go
@@ -277,6 +277,25 @@ func (r *IndexRegistry) Index(db, id string) Index {
 	return idx
 }
 
+// IndexesByTable returns a slice of all the indexes existing on the given table.
+func (r *IndexRegistry) IndexesByTable(db, table string) []Index {
+	r.mut.RLock()
+	defer r.mut.RUnlock()
+
+	indexes := []Index{}
+	for _, key := range r.indexOrder {
+		idx := r.indexes[key]
+		if idx.Database() == db &&
+			idx.Table() == table && r.statuses[key] == IndexReady {
+
+			indexes = append(indexes, idx)
+			r.retainIndex(db, idx.ID())
+		}
+	}
+
+	return indexes
+}
+
 // IndexByExpression returns an index by the given expression. It will return
 // nil it the index is not found. If more than one expression is given, all
 // of them must match for the index to be matched.

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -8,6 +8,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIndexesByTable(t *testing.T) {
+	var require = require.New(t)
+
+	var r = NewIndexRegistry()
+	r.indexOrder = []indexKey{
+		{"foo", "bar_idx_1"},
+		{"foo", "bar_idx_2"},
+		{"foo", "bar_idx_3"},
+		{"foo", "baz_idx_1"},
+		{"oof", "rab_idx_1"},
+	}
+
+	r.indexes = map[indexKey]Index{
+		indexKey{"foo", "bar_idx_1"}: &dummyIdx{
+			database: "foo",
+			table:    "bar",
+			id:       "bar_idx_1",
+			expr:     []Expression{dummyExpr{1, "2"}},
+		},
+		indexKey{"foo", "bar_idx_2"}: &dummyIdx{
+			database: "foo",
+			table:    "bar",
+			id:       "bar_idx_2",
+			expr:     []Expression{dummyExpr{2, "3"}},
+		},
+		indexKey{"foo", "bar_idx_3"}: &dummyIdx{
+			database: "foo",
+			table:    "bar",
+			id:       "bar_idx_3",
+			expr:     []Expression{dummyExpr{3, "4"}},
+		},
+		indexKey{"foo", "baz_idx_1"}: &dummyIdx{
+			database: "foo",
+			table:    "baz",
+			id:       "baz_idx_1",
+			expr:     []Expression{dummyExpr{4, "5"}},
+		},
+		indexKey{"oof", "rab_idx_1"}: &dummyIdx{
+			database: "oof",
+			table:    "rab",
+			id:       "rab_idx_1",
+			expr:     []Expression{dummyExpr{5, "6"}},
+		},
+	}
+
+	r.statuses[indexKey{"foo", "bar_idx_1"}] = IndexReady
+	r.statuses[indexKey{"foo", "bar_idx_2"}] = IndexReady
+	r.statuses[indexKey{"foo", "bar_idx_3"}] = IndexNotReady
+	r.statuses[indexKey{"foo", "baz_idx_1"}] = IndexReady
+	r.statuses[indexKey{"oof", "rab_idx_1"}] = IndexReady
+
+	indexes := r.IndexesByTable("foo", "bar")
+	require.Len(indexes, 2)
+
+	for i, idx := range indexes {
+		expected := r.indexes[r.indexOrder[i]]
+		require.Equal(expected, idx)
+		r.ReleaseIndex(idx)
+	}
+}
+
 func TestIndexByExpression(t *testing.T) {
 	require := require.New(t)
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -32,6 +32,7 @@ var (
 	describeTablesRegex = regexp.MustCompile(`^describe\s+table\s+(.*)`)
 	createIndexRegex    = regexp.MustCompile(`^create\s+index\s+`)
 	dropIndexRegex      = regexp.MustCompile(`^drop\s+index\s+`)
+	showIndexRegex      = regexp.MustCompile(`^show\s+(index|indexes|keys)\s+(from|in)\s+\S+\s*`)
 	describeRegex       = regexp.MustCompile(`^(describe|desc|explain)\s+(.*)\s+`)
 )
 
@@ -53,6 +54,8 @@ func Parse(ctx *sql.Context, s string) (sql.Node, error) {
 		return parseCreateIndex(s)
 	case dropIndexRegex.MatchString(lowerQuery):
 		return parseDropIndex(s)
+	case showIndexRegex.MatchString(lowerQuery):
+		return parseShowIndex(s)
 	case describeRegex.MatchString(lowerQuery):
 		return parseDescribeQuery(ctx, s)
 	}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -624,6 +624,7 @@ var fixtures = map[string]sql.Node{
 		[]sql.Expression{},
 		plan.NewUnresolvedTable("foo"),
 	),
+	`SHOW INDEXES FROM foo`: plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -625,6 +625,11 @@ var fixtures = map[string]sql.Node{
 		plan.NewUnresolvedTable("foo"),
 	),
 	`SHOW INDEXES FROM foo`: plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
+	`SHOW INDEX FROM foo`:   plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
+	`SHOW KEYS FROM foo`:    plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
+	`SHOW INDEXES IN foo`:   plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
+	`SHOW INDEX IN foo`:     plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
+	`SHOW KEYS IN foo`:      plan.NewShowIndexes(&sql.UnresolvedDatabase{}, "foo", nil),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -22,7 +22,7 @@ func NewShowIndexes(db sql.Database, table string, registry *sql.IndexRegistry) 
 // Resolved implements the Resolvable interface.
 func (n *ShowIndexes) Resolved() bool {
 	_, ok := n.Database.(*sql.UnresolvedDatabase)
-	return !ok && n.Registry != nil
+	return !ok
 }
 
 // TransformUp implements the Transformable interface.
@@ -82,6 +82,10 @@ type showIndexesIter struct {
 }
 
 func (i *showIndexesIter) Next() (sql.Row, error) {
+	if i.registry == nil {
+		return nil, io.EOF
+	}
+
 	if i.indexes == nil {
 		i.indexes = i.registry.IndexesByTable(i.db, i.table)
 	}

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -1,0 +1,122 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// ShowIndexes is a node that shows the indexes on a table.
+type ShowIndexes struct {
+	Database sql.Database
+	Table    string
+	Registry *sql.IndexRegistry
+}
+
+// NewShowIndexes creates a new ShowIndexes node.
+func NewShowIndexes(db sql.Database, table string, registry *sql.IndexRegistry) sql.Node {
+	return &ShowIndexes{db, table, registry}
+}
+
+// Resolved implements the Resolvable interface.
+func (n *ShowIndexes) Resolved() bool {
+	_, ok := n.Database.(*sql.UnresolvedDatabase)
+	return !ok && n.Registry != nil
+}
+
+// TransformUp implements the Transformable interface.
+func (n *ShowIndexes) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	return f(NewShowTables(n.Database))
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (n *ShowIndexes) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	return n, nil
+}
+
+// String implements the Stringer interface.
+func (n *ShowIndexes) String() string {
+	return fmt.Sprintf("ShowIndexes(%s)", n.Table)
+}
+
+// Schema implements the Node interface.
+func (n *ShowIndexes) Schema() sql.Schema {
+	return sql.Schema{
+		&sql.Column{Name: "Table", Type: sql.Text},
+		&sql.Column{Name: "Non_unique", Type: sql.Int32},
+		&sql.Column{Name: "Key_name", Type: sql.Text},
+		&sql.Column{Name: "Seq_in_index", Type: sql.Int32},
+		&sql.Column{Name: "Column_name", Type: sql.Text, Nullable: true},
+		&sql.Column{Name: "Collation", Type: sql.Text, Nullable: true},
+		&sql.Column{Name: "Cardinality", Type: sql.Int64},
+		&sql.Column{Name: "Sub_part", Type: sql.Int64, Nullable: true},
+		&sql.Column{Name: "Packed", Type: sql.Text, Nullable: true},
+		&sql.Column{Name: "Null", Type: sql.Text},
+		&sql.Column{Name: "Index_type", Type: sql.Text},
+		&sql.Column{Name: "Comment", Type: sql.Text},
+		&sql.Column{Name: "Index_comment", Type: sql.Text},
+		&sql.Column{Name: "Visible", Type: sql.Text},
+		&sql.Column{Name: "Expression", Type: sql.Text, Nullable: true},
+	}
+}
+
+// Children implements the Node interface.
+func (n *ShowIndexes) Children() []sql.Node { return nil }
+
+// RowIter implements the Node interface.
+func (n *ShowIndexes) RowIter(*sql.Context) (sql.RowIter, error) {
+	return &showIndexesIter{
+		db:       n.Database.Name(),
+		table:    n.Table,
+		registry: n.Registry,
+	}, nil
+}
+
+type showIndexesIter struct {
+	db       string
+	table    string
+	registry *sql.IndexRegistry
+	indexes  []sql.Index
+	pos      int
+}
+
+func (i *showIndexesIter) Next() (sql.Row, error) {
+	if i.indexes == nil {
+		i.indexes = i.registry.IndexesByTable(i.db, i.table)
+	}
+
+	if i.pos >= len(i.indexes) {
+		i.Close()
+		return nil, io.EOF
+	}
+
+	idx := i.indexes[i.pos]
+
+	i.pos++
+	return sql.NewRow(
+		i.table,      // "Table" string
+		int32(1),     // "Non_unique" int32
+		idx.ID(),     // "Key_name" string
+		int32(0),     // "Seq_in_index" int32
+		"NULL",       // "Column_name" string
+		"",           // "Collation" string
+		int64(0),     // "Cardinality" int64
+		int64(0),     // "Sub_part" int64
+		"",           // "Packed" string
+		"",           // "Null" sting
+		idx.Driver(), // "Index_type" string
+		"",           // "Comment" string
+		"",           // "Index_comment" string
+		"YES",        // "Visible" string
+		"NULL",       // "Expression" string
+	), nil
+}
+
+func (i *showIndexesIter) Close() error {
+	for _, idx := range i.indexes {
+		i.registry.ReleaseIndex(idx)
+	}
+
+	return nil
+}

--- a/sql/plan/show_indexes_test.go
+++ b/sql/plan/show_indexes_test.go
@@ -1,0 +1,63 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestShowIndexes(t *testing.T) {
+	var require = require.New(t)
+
+	unresolved := NewShowIndexes(&sql.UnresolvedDatabase{}, "table-test", nil)
+	require.False(unresolved.Resolved())
+	require.Nil(unresolved.Children())
+
+	db := mem.NewDatabase("test")
+	db.AddTable("test1", mem.NewTable("test1", nil))
+	db.AddTable("test2", mem.NewTable("test2", nil))
+	db.AddTable("test3", mem.NewTable("test3", nil))
+
+	r := sql.NewIndexRegistry()
+	for table := range db.Tables() {
+		idx := &mockIndex{
+			db:    "test",
+			table: table,
+			id:    "idx_" + table + "_foo",
+			exprs: []sql.ExpressionHash{
+				sql.NewExpressionHash(
+					expression.NewGetFieldWithTable(0, sql.Int32, table, "foo", false),
+				),
+			},
+		}
+
+		created, ready, err := r.AddIndex(idx)
+		require.NoError(err)
+		close(created)
+		<-ready
+
+		showIdxs := NewShowIndexes(db, table, r)
+
+		ctx := sql.NewEmptyContext()
+		rowIter, err := showIdxs.RowIter(ctx)
+		require.NoError(err)
+
+		rows, err := sql.RowIterToRows(rowIter)
+		require.NoError(err)
+		require.Len(rows, 1)
+
+		require.Equal(
+			sql.NewRow(
+				table, int32(1), idx.ID(),
+				int32(0), "NULL", "",
+				int64(0), int64(0), "",
+				"", idx.Driver(), "",
+				"", "YES", "NULL",
+			),
+			rows[0],
+		)
+	}
+}


### PR DESCRIPTION
Closes #303

This add support for `SHOW INDEX|INDEXES|KEYS FROM|IN table` following the same schema [mysql returns](https://dev.mysql.com/doc/refman/8.0/en/show-index.html). Nevertheless, the only valuable info is showed right now is the name of the existing indexes for the requested table.

Let me make a proposal to move all the `ExpressionHash` logic to the driver itself and expose in the index interface a method to retrieve the indexed expressions as text, which is the reason because of it's not possible show a better information about the indexes (we don't have a way to know directly all the expressions are indexed).

After that, the information returned by `show indexes` could be improved.