### PR TITLE
sql: change Index and IndexDriver interfaces and remove ExpressionHash logic

### DIFF
--- a/sql/analyzer/assign_indexes.go
+++ b/sql/analyzer/assign_indexes.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 
@@ -587,9 +586,9 @@ func getMultiColumnIndexForExpressions(
 			*expression.GreaterThan,
 			*expression.LessThanOrEqual,
 			*expression.GreaterThanOrEqual:
-			var values = make([]interface{}, len(index.ExpressionHashes()))
-			for i, e := range index.ExpressionHashes() {
-				col := findColumnByHash(exprs, e)
+			var values = make([]interface{}, len(index.Expressions()))
+			for i, e := range index.Expressions() {
+				col := findColumn(exprs, e)
 				used[col.expr] = struct{}{}
 				var val interface{}
 				val, err = col.val.Eval(sql.NewEmptyContext(), nil)
@@ -601,10 +600,10 @@ func getMultiColumnIndexForExpressions(
 
 			lookup, err = comparisonIndexLookup(e.(expression.Comparer), index, values...)
 		case *expression.Between:
-			var lowers = make([]interface{}, len(index.ExpressionHashes()))
-			var uppers = make([]interface{}, len(index.ExpressionHashes()))
-			for i, e := range index.ExpressionHashes() {
-				col := findColumnByHash(exprs, e)
+			var lowers = make([]interface{}, len(index.Expressions()))
+			var uppers = make([]interface{}, len(index.Expressions()))
+			for i, e := range index.Expressions() {
+				col := findColumn(exprs, e)
 				used[col.expr] = struct{}{}
 				between := col.expr.(*expression.Between)
 				lowers[i], err = between.Lower.Eval(sql.NewEmptyContext(), nil)
@@ -654,9 +653,9 @@ type columnExpr struct {
 	expr sql.Expression
 }
 
-func findColumnByHash(cols []columnExpr, hash sql.ExpressionHash) *columnExpr {
+func findColumn(cols []columnExpr, column string) *columnExpr {
 	for _, col := range cols {
-		if bytes.Compare(sql.NewExpressionHash(col.col), hash) == 0 {
+		if col.col.String() == column {
 			return &col
 		}
 	}

--- a/sql/analyzer/assign_indexes_test.go
+++ b/sql/analyzer/assign_indexes_test.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"strings"
 	"testing"
@@ -949,14 +948,12 @@ var _ sql.NegateIndex = (*dummyIndex)(nil)
 
 func (dummyIndex) Database() string { return "" }
 func (dummyIndex) Driver() string   { return "" }
-func (i dummyIndex) ExpressionHashes() []sql.ExpressionHash {
-	var hashes []sql.ExpressionHash
+func (i dummyIndex) Expressions() []string {
+	var exprs []string
 	for _, e := range i.expr {
-		h := sha1.New()
-		h.Write([]byte(e.String()))
-		hashes = append(hashes, h.Sum(nil))
+		exprs = append(exprs, e.String())
 	}
-	return hashes
+	return exprs
 }
 
 func (i dummyIndex) AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLookup, error) {

--- a/sql/core.go
+++ b/sql/core.go
@@ -1,8 +1,6 @@
 package sql // import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 
 	"gopkg.in/src-d/go-errors.v1"
@@ -77,30 +75,6 @@ type Expression interface {
 	TransformUp(TransformExprFunc) (Expression, error)
 	// Children returns the children expressions of this expression.
 	Children() []Expression
-}
-
-// ExpressionHash is a SHA-1 checksum
-type ExpressionHash []byte
-
-// NewExpressionHash returns a new SHA1 hash for given Expression instance.
-// SHA1 checksum will be calculated based on ex.String().
-func NewExpressionHash(ex Expression) ExpressionHash {
-	h := sha1.Sum([]byte(ex.String()))
-	return ExpressionHash(h[:])
-}
-
-// DecodeExpressionHash  decodes a hexadecimal string to ExpressionHash
-func DecodeExpressionHash(hexstr string) (ExpressionHash, error) {
-	h, err := hex.DecodeString(hexstr)
-	if err != nil {
-		return nil, err
-	}
-	return ExpressionHash(h), nil
-}
-
-// EncodeExpressionHash encodes an ExpressionHash to hexadecimal string
-func EncodeExpressionHash(h ExpressionHash) string {
-	return hex.EncodeToString(h)
 }
 
 // Aggregation implements an aggregation expression, where an

--- a/sql/index/config.go
+++ b/sql/index/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -28,15 +27,9 @@ type Config struct {
 
 // NewConfig creates a new Config instance for given driver's configuration
 func NewConfig(db, table, id string,
-	expressionHashes []sql.ExpressionHash,
+	expressions []string,
 	driverID string,
 	driverConfig map[string]string) *Config {
-
-	expressions := make([]string, len(expressionHashes))
-
-	for i, h := range expressionHashes {
-		expressions[i] = sql.EncodeExpressionHash(h)
-	}
 
 	cfg := &Config{
 		DB:          db,
@@ -48,16 +41,6 @@ func NewConfig(db, table, id string,
 	cfg.Drivers[driverID] = driverConfig
 
 	return cfg
-}
-
-// ExpressionHashes returns a slice of ExpressionHash for this configuration.
-// Implementation decodes hex strings into byte slices.
-func (cfg *Config) ExpressionHashes() []sql.ExpressionHash {
-	h := make([]sql.ExpressionHash, len(cfg.Expressions))
-	for i, hexstr := range cfg.Expressions {
-		h[i], _ = sql.DecodeExpressionHash(hexstr)
-	}
-	return h
 }
 
 // Driver returns an configuration for the particular driverID.

--- a/sql/index/config_test.go
+++ b/sql/index/config_test.go
@@ -1,14 +1,12 @@
 package index
 
 import (
-	"crypto/sha1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
 func TestConfig(t *testing.T) {
@@ -21,16 +19,11 @@ func TestConfig(t *testing.T) {
 	require.NoError(err)
 	defer os.RemoveAll(path)
 
-	h1 := sha1.Sum([]byte("h1"))
-	h2 := sha1.Sum([]byte("h2"))
-	exh1 := sql.ExpressionHash(h1[:])
-	exh2 := sql.ExpressionHash(h2[:])
-
 	cfg1 := NewConfig(
 		db,
 		table,
 		id,
-		[]sql.ExpressionHash{exh1, exh2},
+		[]string{"h1", "h2"},
 		"DriverID",
 		map[string]string{
 			"port": "10101",

--- a/sql/index/pilosa/driver.go
+++ b/sql/index/pilosa/driver.go
@@ -187,8 +187,8 @@ func (d *Driver) Save(
 		return err
 	}
 
-	d.frames = make([]*pilosa.Frame, len(idx.expressionHashes()))
-	for i, e := range idx.expressionHashes() {
+	d.frames = make([]*pilosa.Frame, len(idx.Expressions()))
+	for i, e := range idx.Expressions() {
 		frm, err := pilosaIndex.Frame(frameName(idx.ID(), e))
 		if err != nil {
 			return err
@@ -302,7 +302,7 @@ func (d *Driver) Delete(idx sql.Index) error {
 
 	frames := index.Frames()
 	for _, ex := range idx.Expressions() {
-		frm, ok := frames[frameName(idx.ID(), newExpressionHash(ex))]
+		frm, ok := frames[frameName(idx.ID(), ex)]
 		if !ok {
 			continue
 		}
@@ -414,10 +414,10 @@ func indexName(db, table string) string {
 	return fmt.Sprintf("%s-%x", IndexNamePrefix, h.Sum(nil))
 }
 
-func frameName(id string, ex expressionHash) string {
+func frameName(id string, ex string) string {
 	h := sha1.New()
 	io.WriteString(h, id)
-	h.Write(ex)
+	io.WriteString(h, ex)
 	return fmt.Sprintf("%s-%x", FrameNamePrefix, h.Sum(nil))
 }
 

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -102,13 +102,10 @@ func TestSaveAndLoad(t *testing.T) {
 	sqlIdx, err := d.Create(db, table, id, expressions, nil)
 	require.NoError(err)
 
-	idx, ok := sqlIdx.(*pilosaIndex)
-	require.True(ok)
-
 	it := &testIndexKeyValueIter{
 		offset:      0,
 		total:       64,
-		expressions: idx.expressionHashes(),
+		expressions: sqlIdx.Expressions(),
 		location:    randLocation,
 	}
 
@@ -199,13 +196,10 @@ func TestSaveAndGetAll(t *testing.T) {
 	sqlIdx, err := d.Create(db, table, id, expressions, nil)
 	require.NoError(err)
 
-	idx, ok := sqlIdx.(*pilosaIndex)
-	require.True(ok)
-
 	it := &testIndexKeyValueIter{
 		offset:      0,
 		total:       64,
-		expressions: idx.expressionHashes(),
+		expressions: sqlIdx.Expressions(),
 		location:    randLocation,
 	}
 
@@ -435,23 +429,17 @@ func TestIntersection(t *testing.T) {
 	sqlIdxPath, err := d.Create(db, table, idxPath, expPath, nil)
 	require.NoError(err)
 
-	idxl, ok := sqlIdxLang.(*pilosaIndex)
-	require.True(ok)
-
-	idxp, ok := sqlIdxPath.(*pilosaIndex)
-	require.True(ok)
-
 	itLang := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxl.expressionHashes(),
+		expressions: sqlIdxLang.Expressions(),
 		location:    offsetLocation,
 	}
 
 	itPath := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxp.expressionHashes(),
+		expressions: sqlIdxPath.Expressions(),
 		location:    offsetLocation,
 	}
 
@@ -519,23 +507,17 @@ func TestUnion(t *testing.T) {
 	sqlIdxPath, err := d.Create(db, table, idxPath, expPath, nil)
 	require.NoError(err)
 
-	idxl, ok := sqlIdxLang.(*pilosaIndex)
-	require.True(ok)
-
-	idxp, ok := sqlIdxPath.(*pilosaIndex)
-	require.True(ok)
-
 	itLang := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxl.expressionHashes(),
+		expressions: sqlIdxLang.Expressions(),
 		location:    offsetLocation,
 	}
 
 	itPath := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxp.expressionHashes(),
+		expressions: sqlIdxPath.Expressions(),
 		location:    offsetLocation,
 	}
 
@@ -614,23 +596,18 @@ func TestDifference(t *testing.T) {
 
 	sqlIdxPath, err := d.Create(db, table, idxPath, expPath, nil)
 	require.NoError(err)
-	idxl, ok := sqlIdxLang.(*pilosaIndex)
-	require.True(ok)
-
-	idxp, ok := sqlIdxPath.(*pilosaIndex)
-	require.True(ok)
 
 	itLang := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxl.expressionHashes(),
+		expressions: sqlIdxLang.Expressions(),
 		location:    offsetLocation,
 	}
 
 	itPath := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: idxp.expressionHashes(),
+		expressions: sqlIdxPath.Expressions(),
 		location:    offsetLocation,
 	}
 
@@ -693,7 +670,7 @@ func TestUnionDiffAsc(t *testing.T) {
 	it := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: pilosaIdx.expressionHashes(),
+		expressions: pilosaIdx.Expressions(),
 		location:    offsetLocation,
 	}
 
@@ -753,7 +730,7 @@ func TestInterRanges(t *testing.T) {
 	it := &testIndexKeyValueIter{
 		offset:      0,
 		total:       10,
-		expressions: pilosaIdx.expressionHashes(),
+		expressions: pilosaIdx.Expressions(),
 		location:    offsetLocation,
 	}
 
@@ -877,7 +854,7 @@ func (i *fixtureKeyValueIter) Close() error { return nil }
 type testIndexKeyValueIter struct {
 	offset      int
 	total       int
-	expressions []expressionHash
+	expressions []string
 	location    func(int) []byte
 
 	records []struct {
@@ -895,7 +872,7 @@ func (it *testIndexKeyValueIter) Next() ([]interface{}, []byte, error) {
 
 	values := make([]interface{}, len(it.expressions))
 	for i, e := range it.expressions {
-		values[i] = hex.EncodeToString(e) + "-" + hex.EncodeToString(b)
+		values[i] = e + "-" + hex.EncodeToString(b)
 	}
 
 	it.records = append(it.records, struct {

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -1,21 +1,12 @@
 package pilosa
 
 import (
-	"crypto/sha1"
-
 	errors "gopkg.in/src-d/go-errors.v1"
 
 	pilosa "github.com/pilosa/go-pilosa"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/index"
 )
-
-type expressionHash []byte
-
-func newExpressionHash(ex string) expressionHash {
-	h := sha1.Sum([]byte(ex))
-	return expressionHash(h[:])
-}
 
 // pilosaIndex is an pilosa implementation of sql.Index interface
 type pilosaIndex struct {
@@ -27,15 +18,9 @@ type pilosaIndex struct {
 	table       string
 	id          string
 	expressions []string
-	hashes      []expressionHash
 }
 
 func newPilosaIndex(path string, client *pilosa.Client, cfg *index.Config) *pilosaIndex {
-	hashes := make([]expressionHash, len(cfg.Expressions))
-	for i, e := range cfg.Expressions {
-		hashes[i] = newExpressionHash(e)
-	}
-
 	return &pilosaIndex{
 		path:        path,
 		client:      client,
@@ -43,7 +28,6 @@ func newPilosaIndex(path string, client *pilosa.Client, cfg *index.Config) *pilo
 		table:       cfg.Table,
 		id:          cfg.ID,
 		expressions: cfg.Expressions,
-		hashes:      hashes,
 		mapping:     newMapping(path),
 	}
 }
@@ -76,7 +60,7 @@ func (idx *pilosaIndex) Get(keys ...interface{}) (sql.IndexLookup, error) {
 		index:       index,
 		mapping:     idx.mapping,
 		keys:        keys,
-		expressions: idx.expressionHashes(),
+		expressions: idx.expressions,
 	}, nil
 }
 
@@ -92,7 +76,7 @@ func (idx *pilosaIndex) Has(key ...interface{}) (bool, error) {
 
 	// We can make this loop parallel, but does it make sense?
 	// For how many (maximum) keys will be asked by one function call?
-	for i, expr := range idx.expressionHashes() {
+	for i, expr := range idx.expressions {
 		name := frameName(idx.ID(), expr)
 
 		val, err := idx.mapping.get(name, key[i])
@@ -126,11 +110,6 @@ func (idx *pilosaIndex) Expressions() []string {
 	return idx.expressions
 }
 
-// expressionHashes returns the hashes of the indexed expressions.
-func (idx *pilosaIndex) expressionHashes() []expressionHash {
-	return idx.hashes
-}
-
 func (pilosaIndex) Driver() string { return DriverID }
 
 func (idx *pilosaIndex) AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLookup, error) {
@@ -154,7 +133,7 @@ func (idx *pilosaIndex) AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLook
 			index:       index,
 			mapping:     idx.mapping,
 			keys:        keys,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 		},
 		gte: keys,
 		lt:  nil,
@@ -185,7 +164,7 @@ func (idx *pilosaIndex) AscendLessThan(keys ...interface{}) (sql.IndexLookup, er
 			index:       index,
 			mapping:     idx.mapping,
 			keys:        keys,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 		},
 		gte: nil,
 		lt:  keys,
@@ -219,7 +198,7 @@ func (idx *pilosaIndex) AscendRange(greaterOrEqual, lessThan []interface{}) (sql
 			client:      idx.client,
 			index:       index,
 			mapping:     idx.mapping,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 		},
 		gte: greaterOrEqual,
 		lt:  lessThan,
@@ -250,7 +229,7 @@ func (idx *pilosaIndex) DescendGreater(keys ...interface{}) (sql.IndexLookup, er
 			index:       index,
 			mapping:     idx.mapping,
 			keys:        keys,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 			reverse:     true,
 		},
 		gt:  keys,
@@ -282,7 +261,7 @@ func (idx *pilosaIndex) DescendLessOrEqual(keys ...interface{}) (sql.IndexLookup
 			index:       index,
 			mapping:     idx.mapping,
 			keys:        keys,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 			reverse:     true,
 		},
 		gt:  nil,
@@ -317,7 +296,7 @@ func (idx *pilosaIndex) DescendRange(lessOrEqual, greaterThan []interface{}) (sq
 			client:      idx.client,
 			index:       index,
 			mapping:     idx.mapping,
-			expressions: idx.expressionHashes(),
+			expressions: idx.expressions,
 			reverse:     true,
 		},
 		gt:  greaterThan,
@@ -349,6 +328,6 @@ func (idx *pilosaIndex) Not(keys ...interface{}) (sql.IndexLookup, error) {
 		index:       index,
 		mapping:     idx.mapping,
 		keys:        keys,
-		expressions: idx.expressionHashes(),
+		expressions: idx.expressions,
 	}, nil
 }

--- a/sql/index/pilosa/lookup.go
+++ b/sql/index/pilosa/lookup.go
@@ -37,7 +37,7 @@ type indexLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []expressionHash
+	expressions []string
 	operations  []*lookupOperation
 }
 
@@ -176,7 +176,7 @@ type filteredLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []expressionHash
+	expressions []string
 	operations  []*lookupOperation
 
 	reverse bool
@@ -698,7 +698,7 @@ type negateLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []expressionHash
+	expressions []string
 	operations  []*lookupOperation
 }
 

--- a/sql/index/pilosa/lookup.go
+++ b/sql/index/pilosa/lookup.go
@@ -37,7 +37,7 @@ type indexLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []sql.ExpressionHash
+	expressions []expressionHash
 	operations  []*lookupOperation
 }
 
@@ -176,7 +176,7 @@ type filteredLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []sql.ExpressionHash
+	expressions []expressionHash
 	operations  []*lookupOperation
 
 	reverse bool
@@ -698,7 +698,7 @@ type negateLookup struct {
 	index       *pilosa.Index
 	mapping     *mapping
 	keys        []interface{}
-	expressions []sql.ExpressionHash
+	expressions []expressionHash
 	operations  []*lookupOperation
 }
 

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"testing"
 
@@ -321,7 +320,7 @@ type loadDriver struct {
 }
 
 func (d loadDriver) ID() string { return d.id }
-func (loadDriver) Create(db, table, id string, expressionHashes []ExpressionHash, config map[string]string) (Index, error) {
+func (loadDriver) Create(db, table, id string, expressions []Expression, config map[string]string) (Index, error) {
 	panic("create is a placeholder")
 }
 func (d loadDriver) LoadAll(db, table string) ([]Index, error) {
@@ -345,14 +344,12 @@ type dummyIdx struct {
 
 var _ Index = (*dummyIdx)(nil)
 
-func (i dummyIdx) ExpressionHashes() []ExpressionHash {
-	var hashes []ExpressionHash
+func (i dummyIdx) Expressions() []string {
+	var exprs []string
 	for _, e := range i.expr {
-		h := sha1.New()
-		h.Write([]byte(e.String()))
-		hashes = append(hashes, h.Sum(nil))
+		exprs = append(exprs, e.String())
 	}
-	return hashes
+	return exprs
 }
 func (i dummyIdx) ID() string                              { return i.id }
 func (i dummyIdx) Get(...interface{}) (IndexLookup, error) { panic("not implemented") }

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -99,7 +99,7 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		return nil, ErrInvalidIndexDriver.New(c.Driver)
 	}
 
-	columns, exprs, exprHashes, err := getColumnsAndPrepareExpressions(c.Exprs)
+	columns, exprs, err := getColumnsAndPrepareExpressions(c.Exprs)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		c.CurrentDatabase,
 		nameable.Name(),
 		c.Name,
-		exprHashes,
+		exprs,
 		c.Config,
 	)
 	if err != nil {
@@ -280,11 +280,10 @@ func (c *CreateIndex) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
 // to match a row with only the returned columns in that same order.
 func getColumnsAndPrepareExpressions(
 	exprs []sql.Expression,
-) ([]string, []sql.Expression, []sql.ExpressionHash, error) {
+) ([]string, []sql.Expression, error) {
 	var columns []string
 	var seen = make(map[string]int)
 	var expressions = make([]sql.Expression, len(exprs))
-	var expressionHashes = make([]sql.ExpressionHash, len(exprs))
 
 	for i, e := range exprs {
 		ex, err := e.TransformUp(func(e sql.Expression) (sql.Expression, error) {
@@ -312,14 +311,13 @@ func getColumnsAndPrepareExpressions(
 		})
 
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
 		expressions[i] = ex
-		expressionHashes[i] = sql.NewExpressionHash(ex)
 	}
 
-	return columns, expressions, expressionHashes, nil
+	return columns, expressions, nil
 }
 
 type evalKeyValueIter struct {

--- a/sql/plan/drop_index_test.go
+++ b/sql/plan/drop_index_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"crypto/sha1"
 	"testing"
 	"time"
 
@@ -31,15 +30,8 @@ func TestDeleteIndex(t *testing.T) {
 		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
 		expression.NewGetFieldWithTable(1, sql.Int64, "foo", "a", true),
 	}
-	var hashes []sql.ExpressionHash
 
-	for _, e := range expressions {
-		h := sha1.Sum([]byte(e.String()))
-		exh := sql.ExpressionHash(h[:])
-		hashes = append(hashes, exh)
-	}
-
-	done, ready, err := catalog.AddIndex(&mockIndex{id: "idx", db: "foo", table: "foo", exprs: hashes})
+	done, ready, err := catalog.AddIndex(&mockIndex{id: "idx", db: "foo", table: "foo", exprs: expressions})
 	require.NoError(err)
 	close(done)
 	<-ready

--- a/sql/plan/show_indexes_test.go
+++ b/sql/plan/show_indexes_test.go
@@ -27,10 +27,8 @@ func TestShowIndexes(t *testing.T) {
 			db:    "test",
 			table: table,
 			id:    "idx_" + table + "_foo",
-			exprs: []sql.ExpressionHash{
-				sql.NewExpressionHash(
-					expression.NewGetFieldWithTable(0, sql.Int32, table, "foo", false),
-				),
+			exprs: []sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int32, table, "foo", false),
 			},
 		}
 


### PR DESCRIPTION
Closes #305 

- Changed `Index` and `IndexDriver` interfaces to remove the use of `ExpressionHash`
- Removed all the logic related to `ExpressionHash`.
- Now the `config.yml` file for pilosa indexes doesn't store expression hashes anymore:
```yml
db: ""
table: refs
id: refs_name_idx
expressions:
- refs.ref_name
drivers:
  pilosa: {}
```