### PR TITLE
sql: delete index if there is an error when it's added to the registry

### DIFF
--- a/sql/index.go
+++ b/sql/index.go
@@ -413,6 +413,12 @@ func (r *IndexRegistry) validateIndexToAdd(idx Index) error {
 		}
 
 		if exprListsEqual(i.Expressions(), idx.Expressions()) {
+			if driver, ok := r.drivers[idx.Driver()]; ok {
+				if err := driver.Delete(idx); err != nil {
+					return err
+				}
+			}
+
 			return ErrIndexExpressionAlreadyRegistered.New(
 				strings.Join(idx.Expressions(), ", "),
 			)


### PR DESCRIPTION
Related to https://github.com/src-d/gitbase/issues/411

This is the simplest solution. If we want to avoid create the index if it can't be added to the registry, we must mix a little bit the create index and add index logic to rely on the `IndexRegitry.AddIndex` method to create the index instance. WDYT @src-d/data-retrieval ?