### PR TITLE
sql/analyzer: parallelize sql.Table, not just ResolvedTable

### DIFF
--- a/sql/analyzer/parallelize.go
+++ b/sql/analyzer/parallelize.go
@@ -69,7 +69,7 @@ func isParallelizable(node sql.Node) bool {
 			*plan.OrderedDistinct:
 			ok = false
 			return false
-		case *plan.ResolvedTable:
+		case sql.Table:
 			lastWasTable = true
 			tableSeen = true
 		}


### PR DESCRIPTION
This is gonna be needed for SquashedTables.
ResolvedTable embed sql.Table, so it should not change.