### PR TITLE
fix: convert nil value properly for blob type

### DIFF
--- a/sql/type.go
+++ b/sql/type.go
@@ -512,6 +512,8 @@ func (t blobT) SQL(v interface{}) sqltypes.Value {
 // Convert implements Type interface.
 func (t blobT) Convert(v interface{}) (interface{}, error) {
 	switch value := v.(type) {
+	case nil:
+		return []byte(nil), nil
 	case []byte:
 		return value, nil
 	case string:

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -125,6 +125,8 @@ func TestBlob(t *testing.T) {
 	require := require.New(t)
 
 	convert(t, Blob, "", []byte{})
+	convert(t, Blob, nil, []byte(nil))
+	MustConvert(Blob, nil)
 
 	_, err := Blob.Convert(1)
 	require.NotNil(err)


### PR DESCRIPTION
Before this fix, when a nil value was returned for a column with type BLOB, it did panic.