### PR TITLE
expression: support multiple regex engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ go:
 
 go_import_path: gopkg.in/src-d/go-mysql-server.v0
 
+addons:
+  apt:
+    packages:
+      - libonig-dev
+
 matrix:
   fast_finish: true
   allow_failures:
@@ -25,7 +30,7 @@ before_install:
 install:
   - go get -u github.com/golang/dep/cmd/dep
   - touch Gopkg.toml
-  - dep ensure -v -add "github.com/pilosa/go-pilosa@0.9.0" "github.com/pilosa/pilosa@1.0.2"
+  - dep ensure -v -add "github.com/pilosa/go-pilosa@0.9.0" "github.com/pilosa/pilosa@1.0.2" "github.com/moovweb/rubex@b3d9ff6ad7d9b14f94a91c8271cd9ad9e77132e5"
   - make dependencies
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Package configuration
 PROJECT = go-mysql-server
 COMMANDS =
+GOFLAGS = -tags oniguruma
 
 # Including ci Makefile
 MAKEFILE = Makefile.main

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -76,7 +76,7 @@ func Default() string {
 		return "oniguruma"
 	}
 
-	return "native"
+	return "go"
 }
 
 // SetDefault sets the regex engine returned by Default.

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -1,0 +1,85 @@
+package regex
+
+import errors "gopkg.in/src-d/go-errors.v1"
+
+var (
+	// ErrRegexAlreadyRegistered is returned when there is a previously
+	// registered regex engine with the same name.
+	ErrRegexAlreadyRegistered = errors.NewKind("Regex engine already registered: %s")
+	// ErrRegexNameEmpty returned when the name is "".
+	ErrRegexNameEmpty = errors.NewKind("Regex engine name cannot be empty")
+	// ErrRegexNotFound returned when the regex engine is not registered.
+	ErrRegexNotFound = errors.NewKind("Regex engine not found: %s")
+
+	registry      map[string]Constructor
+	defaultEngine string
+)
+
+// Matcher interface is used to compare regexes with strings.
+type Matcher interface {
+	// Match returns true if the text matches the regular expression.
+	Match(text string) bool
+}
+
+// Constructor creates a new Matcher.
+type Constructor func(re string) (Matcher, error)
+
+// Register add a new regex engine to the registry.
+func Register(name string, c Constructor) error {
+	if registry == nil {
+		registry = make(map[string]Constructor)
+	}
+
+	if name == "" {
+		return ErrRegexNameEmpty.New()
+	}
+
+	_, ok := registry[name]
+	if ok {
+		return ErrRegexAlreadyRegistered.New(name)
+	}
+
+	registry[name] = c
+
+	return nil
+}
+
+// Engines returns the list of regex engines names.
+func Engines() []string {
+	var names []string
+
+	for n := range registry {
+		names = append(names, n)
+	}
+
+	return names
+}
+
+// New creates a new Matcher with the specified regex engine.
+func New(name, re string) (Matcher, error) {
+	n, ok := registry[name]
+	if !ok {
+		return nil, ErrRegexNotFound.New(name)
+	}
+
+	return n(re)
+}
+
+// Default returns the default regex engine.
+func Default() string {
+	if defaultEngine != "" {
+		return defaultEngine
+	}
+
+	_, ok := registry["oniguruma"]
+	if ok {
+		return "oniguruma"
+	}
+
+	return "native"
+}
+
+// SetDefault sets the regex engine returned by Default.
+func SetDefault(name string) {
+	defaultEngine = name
+}

--- a/internal/regex/regex_go.go
+++ b/internal/regex/regex_go.go
@@ -2,24 +2,24 @@ package regex
 
 import "regexp"
 
-// Native holds go regex engine Matcher.
-type Native struct {
+// Go holds go regex engine Matcher.
+type Go struct {
 	reg *regexp.Regexp
 }
 
 // Match implements Matcher interface.
-func (r *Native) Match(s string) bool {
+func (r *Go) Match(s string) bool {
 	return r.reg.MatchString(s)
 }
 
-// NewNative creates a new Matcher using go regex engine.
-func NewNative(re string) (Matcher, error) {
+// NewGo creates a new Matcher using go regex engine.
+func NewGo(re string) (Matcher, error) {
 	reg, err := regexp.Compile(re)
 	if err != nil {
 		return nil, err
 	}
 
-	r := Native{
+	r := Go{
 		reg: reg,
 	}
 
@@ -27,7 +27,7 @@ func NewNative(re string) (Matcher, error) {
 }
 
 func init() {
-	err := Register("native", NewNative)
+	err := Register("go", NewGo)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/internal/regex/regex_native.go
+++ b/internal/regex/regex_native.go
@@ -1,0 +1,34 @@
+package regex
+
+import "regexp"
+
+// Native holds go regex engine Matcher.
+type Native struct {
+	reg *regexp.Regexp
+}
+
+// Match implements Matcher interface.
+func (r *Native) Match(s string) bool {
+	return r.reg.MatchString(s)
+}
+
+// NewNative creates a new Matcher using go regex engine.
+func NewNative(re string) (Matcher, error) {
+	reg, err := regexp.Compile(re)
+	if err != nil {
+		return nil, err
+	}
+
+	r := Native{
+		reg: reg,
+	}
+
+	return &r, nil
+}
+
+func init() {
+	err := Register("native", NewNative)
+	if err != nil {
+		panic(err.Error())
+	}
+}

--- a/internal/regex/regex_oniguruma.go
+++ b/internal/regex/regex_oniguruma.go
@@ -1,0 +1,36 @@
+// +build oniguruma
+
+package regex
+
+import "github.com/moovweb/rubex"
+
+// Oniguruma holds a rubex regular expression Matcher.
+type Oniguruma struct {
+	reg *rubex.Regexp
+}
+
+// Match implements Matcher interface.
+func (r *Oniguruma) Match(s string) bool {
+	return r.reg.MatchString(s)
+}
+
+// NewOniguruma creates a new Matcher using oniguruma engine.
+func NewOniguruma(re string) (Matcher, error) {
+	reg, err := rubex.Compile(re)
+	if err != nil {
+		return nil, err
+	}
+
+	r := Oniguruma{
+		reg: reg,
+	}
+
+	return &r, nil
+}
+
+func init() {
+	err := Register("oniguruma", NewOniguruma)
+	if err != nil {
+		panic(err.Error())
+	}
+}

--- a/internal/regex/regex_test.go
+++ b/internal/regex/regex_test.go
@@ -1,0 +1,75 @@
+package regex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func dummy(s string) (Matcher, error) { return nil, nil }
+
+func getDefault() string {
+	for _, n := range Engines() {
+		if n == "oniguruma" {
+			return "oniguruma"
+		}
+	}
+
+	return "native"
+}
+
+func TestRegistration(t *testing.T) {
+	require := require.New(t)
+
+	engines := Engines()
+	require.NotNil(engines)
+	number := len(engines)
+
+	defaultEngine := getDefault()
+	require.Equal(defaultEngine, Default())
+
+	err := Register("", dummy)
+	require.Equal(true, ErrRegexNameEmpty.Is(err))
+	engines = Engines()
+	require.Len(engines, number)
+
+	err = Register("native", dummy)
+	require.Equal(true, ErrRegexAlreadyRegistered.Is(err))
+
+	err = Register("nil", dummy)
+	require.NoError(err)
+	require.Len(Engines(), number+1)
+
+	matcher, err := New("nil", "")
+	require.NoError(err)
+	require.Nil(matcher)
+}
+
+func TestDefault(t *testing.T) {
+	require := require.New(t)
+
+	def := getDefault()
+	require.Equal(def, Default())
+
+	SetDefault("default")
+	require.Equal("default", Default())
+
+	SetDefault("")
+	require.Equal(def, Default())
+}
+
+func TestMatcher(t *testing.T) {
+	for _, name := range Engines() {
+		if name == "nil" {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			m, err := New(name, "a{3}")
+			require.NoError(t, err)
+
+			require.Equal(t, true, m.Match("ooaaaoo"))
+			require.Equal(t, false, m.Match("ooaaoo"))
+		})
+	}
+}

--- a/internal/regex/regex_test.go
+++ b/internal/regex/regex_test.go
@@ -15,7 +15,7 @@ func getDefault() string {
 		}
 	}
 
-	return "native"
+	return "go"
 }
 
 func TestRegistration(t *testing.T) {
@@ -33,7 +33,7 @@ func TestRegistration(t *testing.T) {
 	engines = Engines()
 	require.Len(engines, number)
 
-	err = Register("native", dummy)
+	err = Register("go", dummy)
 	require.Equal(true, ErrRegexAlreadyRegistered.Is(err))
 
 	err = Register("nil", dummy)

--- a/sql/expression/comparison_test.go
+++ b/sql/expression/comparison_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-mysql-server.v0/internal/regex"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 
 	"github.com/stretchr/testify/require"
@@ -173,17 +174,27 @@ func TestGreaterThan(t *testing.T) {
 }
 
 func TestRegexp(t *testing.T) {
+	for _, engine := range regex.Engines() {
+		regex.SetDefault(engine)
+		t.Run(engine, testRegexpCases)
+	}
+}
+
+func testRegexpCases(t *testing.T) {
+	t.Helper()
 	require := require.New(t)
+
 	for resultType, cmpCase := range likeComparisonCases {
 		get0 := NewGetField(0, resultType, "col1", true)
 		require.NotNil(get0)
 		get1 := NewGetField(1, resultType, "col2", true)
 		require.NotNil(get1)
-		eq := NewRegexp(get0, get1)
-		require.NotNil(eq)
-		require.Equal(sql.Boolean, eq.Type())
 		for cmpResult, cases := range cmpCase {
 			for _, pair := range cases {
+				eq := NewRegexp(get0, get1)
+				require.NotNil(eq)
+				require.Equal(sql.Boolean, eq.Type())
+
 				row := sql.NewRow(pair[0], pair[1])
 				require.NotNil(row)
 				cmp := eval(t, eq, row)


### PR DESCRIPTION
Add support to register multiple regular expression engines. The change comes with "native" and "oniguruma". The latter has to be compiled with tag "oniguruma" to be registered.

Right now the session interface does not have possibility to set configuration variables so only one is used. "oniguruma" if it is available or native otherwise.

Fixes #341 