### PR TITLE
Drop indexes in progress.

### DIFF
--- a/sql/analyzer/index_catalog.go
+++ b/sql/analyzer/index_catalog.go
@@ -5,7 +5,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
 
-// indexCatalog sets the catalog in the CreateIndexm, DropIndex and ShowIndexes nodes.
+// indexCatalog sets the catalog in the CreateIndex, DropIndex and ShowIndexes nodes.
 func indexCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	if !n.Resolved() {
 		return n, nil

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -262,6 +262,41 @@ func TestDelete(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestDeleteSlow(t *testing.T) {
+	require := require.New(t)
+	setup(t)
+	defer cleanup(t)
+
+	db, table, id := "db_name", "table_name", "index_id"
+
+	expressions := []sql.Expression{
+		expression.NewGetFieldWithTable(0, sql.Int64, table, "lang", true),
+		expression.NewGetFieldWithTable(1, sql.Int64, table, "hash", true),
+	}
+
+	d := NewIndexDriver(tmpDir)
+	sqlIdx, err := d.Create(db, table, id, expressions, nil)
+	require.NoError(err)
+
+	it := &partitionKeyValueIter{
+		partitions:  2,
+		offset:      0,
+		total:       1024,
+		expressions: sqlIdx.Expressions(),
+		location:    slowRandLocation,
+	}
+
+	go func() {
+		if e := d.Save(sql.NewEmptyContext(), sqlIdx, it); e != nil {
+			t.Log(e)
+		}
+	}()
+
+	time.Sleep(time.Second)
+	err = d.Delete(sqlIdx, new(partitionIter))
+	require.NoError(err)
+}
+
 func TestLoadAllDirectoryDoesNotExist(t *testing.T) {
 	require := require.New(t)
 	setup(t)
@@ -872,6 +907,12 @@ func randLocation(partition sql.Partition, offset int) string {
 	b := make([]byte, 1)
 	rand.Read(b)
 	return string(partition.Key()) + "-" + string(b)
+}
+
+func slowRandLocation(partition sql.Partition, offset int) string {
+	defer time.Sleep(200 * time.Millisecond)
+
+	return randLocation(partition, offset)
 }
 
 func offsetLocation(partition sql.Partition, offset int) string {

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -92,6 +92,7 @@ func withoutMapping(a sql.Index) sql.Index {
 	if i, ok := a.(*pilosaIndex); ok {
 		b := *i
 		b.mapping = nil
+		b.cancel = nil
 		return &b
 	}
 	return a

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -262,7 +262,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestDeleteSlow(t *testing.T) {
+func TestDeleteInProgress(t *testing.T) {
 	require := require.New(t)
 	setup(t)
 	defer cleanup(t)

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -1,6 +1,9 @@
 package pilosa
 
 import (
+	"context"
+	"sync"
+
 	errors "gopkg.in/src-d/go-errors.v1"
 
 	pilosa "github.com/pilosa/go-pilosa"
@@ -12,6 +15,8 @@ import (
 type pilosaIndex struct {
 	client  *pilosa.Client
 	mapping *mapping
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 
 	db          string
 	table       string

--- a/sql/index/pilosalib/driver_test.go
+++ b/sql/index/pilosalib/driver_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pilosa/pilosa"
 	"github.com/stretchr/testify/require"
@@ -232,6 +233,41 @@ func TestDelete(t *testing.T) {
 	sqlIdx, err := d.Create(db, table, id, expressions, nil)
 	require.NoError(err)
 
+	err = d.Delete(sqlIdx, new(partitionIter))
+	require.NoError(err)
+}
+
+func TestDeleteSlow(t *testing.T) {
+	require := require.New(t)
+	setup(t)
+	defer cleanup(t)
+
+	db, table, id := "db_name", "table_name", "index_id"
+
+	expressions := []sql.Expression{
+		expression.NewGetFieldWithTable(0, sql.Int64, table, "lang", true),
+		expression.NewGetFieldWithTable(1, sql.Int64, table, "hash", true),
+	}
+
+	d := NewDriver(tmpDir)
+	sqlIdx, err := d.Create(db, table, id, expressions, nil)
+	require.NoError(err)
+
+	it := &partitionKeyValueIter{
+		partitions:  2,
+		offset:      0,
+		total:       1024,
+		expressions: sqlIdx.Expressions(),
+		location:    slowRandLocation,
+	}
+
+	go func() {
+		if e := d.Save(sql.NewEmptyContext(), sqlIdx, it); e != nil {
+			t.Log(e)
+		}
+	}()
+
+	time.Sleep(time.Second)
 	err = d.Delete(sqlIdx, new(partitionIter))
 	require.NoError(err)
 }
@@ -897,6 +933,12 @@ func randLocation(partition sql.Partition, offset int) string {
 	b := make([]byte, 1)
 	rand.Read(b)
 	return string(partition.Key()) + "-" + string(b)
+}
+
+func slowRandLocation(partition sql.Partition, offset int) string {
+	defer time.Sleep(200 * time.Millisecond)
+
+	return randLocation(partition, offset)
 }
 
 func offsetLocation(partition sql.Partition, offset int) string {

--- a/sql/index/pilosalib/driver_test.go
+++ b/sql/index/pilosalib/driver_test.go
@@ -237,7 +237,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestDeleteSlow(t *testing.T) {
+func TestDeleteInProgress(t *testing.T) {
 	require := require.New(t)
 	setup(t)
 	defer cleanup(t)

--- a/sql/index/pilosalib/index.go
+++ b/sql/index/pilosalib/index.go
@@ -1,6 +1,9 @@
 package pilosalib
 
 import (
+	"context"
+	"sync"
+
 	"github.com/pilosa/pilosa"
 	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -15,6 +18,8 @@ var (
 type pilosaIndex struct {
 	index   *pilosa.Index
 	mapping *mapping
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 
 	db          string
 	table       string

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -59,7 +59,7 @@ func TestIndexesByTable(t *testing.T) {
 	r.statuses[indexKey{"oof", "rab_idx_1"}] = IndexReady
 
 	indexes := r.IndexesByTable("foo", "bar")
-	require.Len(indexes, 2)
+	require.Len(indexes, 3)
 
 	for i, idx := range indexes {
 		expected := r.indexes[r.indexOrder[i]]

--- a/sql/plan/drop_index.go
+++ b/sql/plan/drop_index.go
@@ -59,7 +59,7 @@ func (d *DropIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}
 	d.Catalog.ReleaseIndex(index)
 
-	done, err := d.Catalog.DeleteIndex(db.Name(), d.Name, false)
+	done, err := d.Catalog.DeleteIndex(db.Name(), d.Name, true)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -97,7 +97,10 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 		return nil, err
 	}
 
-	var nullable string
+	var (
+		nullable string
+		visible  string
+	)
 	columnName, expression := "NULL", show.expression
 	if ok, null := isColumn(show.expression, i.db.Tables()[i.table]); ok {
 		columnName, expression = expression, columnName
@@ -105,7 +108,11 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 			nullable = "YES"
 		}
 	}
-
+	if i.registry.CanUseIndex(show.index) {
+		visible = "YES"
+	} else {
+		visible = "NO"
+	}
 	return sql.NewRow(
 		i.table,             // "Table" string
 		int32(1),            // "Non_unique" int32, Values [0, 1]
@@ -120,7 +127,7 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 		show.index.Driver(), // "Index_type" string
 		"",                  // "Comment" string
 		"",                  // "Index_comment" string
-		"YES",               // "Visible" string, Values [YES, NO]
+		visible,             // "Visible" string, Values [YES, NO]
 		expression,          // "Expression" string
 	), nil
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Closes https://github.com/src-d/go-mysql-server/issues/343

Changes:
Right now we can drop/cancel indexes in progress.
Function `IndexesByTable` returns all indexes (`NotReady` as well), so if you want to know status you have to call `CanUseIndex`. 
Delete index uses `force` flag (what cancel the context what breaks and deletes the index).
`SHOW INDEX FROM...` shows all indexes, but `NotReady` indexes have *NO* in column `Visible`, otherwise *YES*.