### PR TITLE
sql/parse: allow numbers in index names

### DIFF
--- a/sql/parse/indexes_test.go
+++ b/sql/parse/indexes_test.go
@@ -140,6 +140,19 @@ func TestParseCreateIndex(t *testing.T) {
 			),
 			nil,
 		},
+		{
+			"CREATE INDEX idx_2 ON foo USING bar (baz)",
+			plan.NewCreateIndex(
+				"idx_2",
+				plan.NewUnresolvedTable("foo"),
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("baz"),
+				},
+				"bar",
+				make(map[string]string),
+			),
+			nil,
+		},
 	}
 
 	for _, tt := range testCases {

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -93,27 +93,50 @@ func optional(steps ...parseFunc) parseFunc {
 	}
 }
 
+func readLetter(r *bufio.Reader, buf *bytes.Buffer) error {
+	ru, _, err := r.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+
+		return err
+	}
+
+	buf.WriteRune(ru)
+	return nil
+}
+
+func readValidIdentRune(r *bufio.Reader, buf *bytes.Buffer) error {
+	ru, _, err := r.ReadRune()
+	if err != nil {
+		return err
+	}
+
+	if !unicode.IsLetter(ru) && !unicode.IsDigit(ru) && ru != '_' {
+		if err := r.UnreadRune(); err != nil {
+			return err
+		}
+		return io.EOF
+	}
+
+	buf.WriteRune(ru)
+	return nil
+}
+
 func readIdent(ident *string) parseFunc {
 	return func(r *bufio.Reader) error {
 		var buf bytes.Buffer
-		for {
-			ru, _, err := r.ReadRune()
-			if err == io.EOF {
-				break
-			}
+		if err := readLetter(r, &buf); err != nil {
+			return err
+		}
 
-			if err != nil {
+		for {
+			if err := readValidIdentRune(r, &buf); err == io.EOF {
+				break
+			} else if err != nil {
 				return err
 			}
-
-			if !unicode.IsLetter(ru) && ru != '_' {
-				if err := r.UnreadRune(); err != nil {
-					return err
-				}
-				break
-			}
-
-			buf.WriteRune(ru)
 		}
 
 		*ident = strings.ToLower(buf.String())


### PR DESCRIPTION
Now, identifiers such as index name are `[a-zA-Z][a-zA-Z0-9_]*`. Before it was `[a-zA-Z0-9]+`