### PR TITLE
*: correctly handle process management using processlist

### DIFF
--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -154,6 +154,7 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 
 	createIndex := func() {
 		c.createIndex(ctx, log, driver, index, iter, created, ready)
+		c.Catalog.ProcessList.Done(ctx.Pid())
 	}
 
 	log.WithField("async", c.Async).Info("starting to save the index")

--- a/sql/plan/drop_index_test.go
+++ b/sql/plan/drop_index_test.go
@@ -52,3 +52,48 @@ func TestDeleteIndex(t *testing.T) {
 	require.Equal([]string{"idx"}, driver.deleted)
 	require.Nil(catalog.Index("foo", "idx"))
 }
+
+func TestDeleteIndexNotReady(t *testing.T) {
+	require := require.New(t)
+
+	table := mem.NewTable("foo", sql.Schema{
+		{Name: "a", Source: "foo"},
+		{Name: "b", Source: "foo"},
+		{Name: "c", Source: "foo"},
+	})
+
+	driver := new(mockDriver)
+	catalog := sql.NewCatalog()
+	catalog.RegisterIndexDriver(driver)
+	db := mem.NewDatabase("foo")
+	db.AddTable("foo", table)
+	catalog.Databases = append(catalog.Databases, db)
+
+	var expressions = []sql.Expression{
+		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
+		expression.NewGetFieldWithTable(1, sql.Int64, "foo", "a", true),
+	}
+
+	done, ready, err := catalog.AddIndex(&mockIndex{id: "idx", db: "foo", table: "foo", exprs: expressions})
+	require.NoError(err)
+
+	idx := catalog.Index("foo", "idx")
+	require.NotNil(idx)
+	catalog.ReleaseIndex(idx)
+
+	di := NewDropIndex("idx", NewResolvedTable(table))
+	di.Catalog = catalog
+	di.CurrentDatabase = "foo"
+
+	_, err = di.RowIter(sql.NewEmptyContext())
+	require.Error(err)
+	require.True(ErrIndexNotAvailable.Is(err))
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(([]string)(nil), driver.deleted)
+	require.NotNil(catalog.Index("foo", "idx"))
+
+	close(done)
+	<-ready
+}

--- a/sql/plan/processlist_test.go
+++ b/sql/plan/processlist_test.go
@@ -13,15 +13,20 @@ func TestShowProcessList(t *testing.T) {
 
 	n := NewShowProcessList()
 	p := sql.NewProcessList()
-	sess := sql.NewSession("0.0.0.0:1234", "foo")
-	ctx := sql.NewContext(context.Background(), sql.WithSession(sess))
+	sess := sql.NewSession("0.0.0.0:1234", "foo", 1)
+	ctx := sql.NewContext(context.Background(), sql.WithPid(1), sql.WithSession(sess))
 
-	pid := p.AddProcess(ctx, sql.QueryProcess, "SELECT foo")
-	p.AddProgressItem(pid, "a", 5)
-	p.AddProgressItem(pid, "b", 6)
+	ctx, err := p.AddProcess(ctx, sql.QueryProcess, "SELECT foo")
+	require.NoError(err)
 
-	pid = p.AddProcess(ctx, sql.CreateIndexProcess, "SELECT bar")
-	p.AddProgressItem(pid, "foo", 2)
+	p.AddProgressItem(ctx.Pid(), "a", 5)
+	p.AddProgressItem(ctx.Pid(), "b", 6)
+
+	ctx = sql.NewContext(context.Background(), sql.WithPid(2), sql.WithSession(sess))
+	ctx, err = p.AddProcess(ctx, sql.CreateIndexProcess, "SELECT bar")
+	require.NoError(err)
+
+	p.AddProgressItem(ctx.Pid(), "foo", 2)
 
 	p.UpdateProgress(1, "a", 3)
 	p.UpdateProgress(1, "a", 1)

--- a/sql/session_test.go
+++ b/sql/session_test.go
@@ -11,7 +11,7 @@ import (
 func TestSessionConfig(t *testing.T) {
 	require := require.New(t)
 
-	sess := NewSession("foo", "bar")
+	sess := NewSession("foo", "bar", 1)
 
 	typ, v := sess.Get("foo")
 	require.Equal(Null, typ)


### PR DESCRIPTION
Closes #371 

Summary of changes:

- Session manager, no longer tracks contexts created for queries, only sessions. Contexts are managed by the ProcessList as part of the Process.
- Pid is available from Context now, and connection id from the Session.
- trackProcess rule does no longer register the process, only attaches step information and wraps the node if needed to track completion.
- KILL correctly handled: query just kills query but keeps connection, connection drops connection and all associated queries.
- KILL connection is also tested now (using unsafe, though :( )
- DROP INDEX cannot drop indexes that are currently being created.