### PR TITLE
sql/analyzer: check non-parallelizable nodes under QueryProcess

### DIFF
--- a/sql/analyzer/parallelize.go
+++ b/sql/analyzer/parallelize.go
@@ -10,10 +10,12 @@ func parallelize(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error)
 		return node, nil
 	}
 
-	// Do not try to parallelize index operations.
-	switch node.(type) {
-	case *plan.CreateIndex, *plan.DropIndex, *plan.Describe, *plan.DescribeQuery:
-		return node, nil
+	if proc, ok := node.(*plan.QueryProcess); ok {
+		// Do not try to parallelize index operations.
+		switch proc.Child.(type) {
+		case *plan.CreateIndex, *plan.DropIndex, *plan.Describe, *plan.DescribeQuery:
+			return node, nil
+		}
 	}
 
 	node, err := node.TransformUp(func(node sql.Node) (sql.Node, error) {


### PR DESCRIPTION
Moving `parallelize` after `track_process` had this subtle side effect.

This is why https://github.com/src-d/gitbase/pull/489#issuecomment-423988685 is failing