### PR TITLE
update readme example snippet to match complete example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here you can see an example using the in-memory database implementation:
 ...
 
 func main() {
-    driver := sqle.New()
+    driver := sqle.NewDefault()
     driver.AddDatabase(createTestDatabase())
 
     auth := mysql.NewAuthServerStatic()
@@ -127,7 +127,7 @@ func createTestDatabase() *mem.Database {
 
 Then, you can connect to the server with any MySQL client:
 ```bash
-> mysql --host=127.0.0.1 --port=3306 -u user -ppass db -e "SELECT * FROM mytable"
+> mysql --host=127.0.0.1 --port=3306 -u user -ppass test -e "SELECT * FROM mytable"
 +----------+-------------------+-------------------------------+---------------------+
 | name     | email             | phone_numbers                 | created_at          |
 +----------+-------------------+-------------------------------+---------------------+


### PR DESCRIPTION
This PR fixes a discrepancy between the example snippet and the [complete example](https://github.com/src-d/go-mysql-server/blob/master/_example/main.go).

It also changes the database name in the command line example to match the example code (although I don't think it matters in this case what database name is provided).