### PR TITLE
pilosa: use different holder per db/table pair

### DIFF
--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -80,6 +80,23 @@ func TestLoadAll(t *testing.T) {
 	require.True(ok)
 
 	require.Equal(i1.index.Name(), i2.index.Name())
+
+	// Load index from another table. Previously this panicked as the same
+	// pilosa.Holder was used for all indexes.
+
+	idx3, err := d.Create("db", "table2", "id1", makeExpressions("table2", "hash1"), nil)
+	require.NoError(err)
+	it3 := &partitionKeyValueIter{
+		partitions:  2,
+		offset:      0,
+		total:       64,
+		expressions: idx3.Expressions(),
+		location:    randLocation,
+	}
+	require.NoError(d.Save(sql.NewEmptyContext(), idx3, it3))
+
+	indexes, err = d.LoadAll("db", "table2")
+	require.NoError(err)
 }
 
 type logLoc struct {


### PR DESCRIPTION
Pilosa holder cannot be opened more than once. It has a channel to
signal opened state (currently unused) that is closed after the first
Open. This causes panics in the next calls:

    panic: close of closed channel

The driver was using one holder for all db/tables. This called
holder.Open once per table. This works well if all indexes belong to the
same db/table but called Open several times when the indexes belong to
more than one db/table pair. Now it has a map of holders so it's only
opened once.

Related to src-d/gitbase#524