### PR TITLE
Adds Proper Apache License 2.0

### DIFF
--- a/_scripts/go-vitess/LICENSE
+++ b/_scripts/go-vitess/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/_scripts/go-vitess/Makefile
+++ b/_scripts/go-vitess/Makefile
@@ -19,7 +19,7 @@ filter-branch:	clone
 	cd ${VITESS_SRC} && \
 	git filter-branch --subdirectory-filter go && \
 	rm -fr README.md cacheservice cmd exit ioutil2 memcache race ratelimiter stats/influxdbbackend stats/opentsdb stats/prometheusbackend testfiles vtbench zk vt/mysqlctl/cephbackupstorage && \
-	cp -f "${CWD}/doc.go" "${CWD}/README.md" ${VITESS_SRC}
+	cp -f "${CWD}/doc.go" "${CWD}/README.md" "${CWD}/LICENSE" ${VITESS_SRC}
 
 rename-packages:
 	cd ${VITESS_SRC} && \

--- a/_scripts/go-vitess/README.md
+++ b/_scripts/go-vitess/README.md
@@ -19,4 +19,4 @@ the issue neither pull requests aren't accepted to this repository.
 
 ## License
 
-Apache License 2.0, see [LICENSE.md](LICENSE.md).
+Apache License 2.0, see [LICENSE](LICENSE).


### PR DESCRIPTION
See prior PR on https://github.com/src-d/go-vitess/pull/4

While the README says that this repo is under the Apache License 2.0, no LICENSE file was found.

This PR adds the proper license file to the repo in Github format and formats the LICENSE/README links to reference the license without Markdown (as in, the file is just LICENSE, not LICENSE.md) for consistency across other srd-d repos.

Don't forget to add the copyright year and name at the bottom of the license. :smile: