### PR TITLE
Implement SHOW VARIABLES

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -416,6 +417,37 @@ var queries = []struct {
 			{"a", int32(4)},
 			{"b", int32(2)},
 			{"c", int32(0)},
+		},
+	},
+	{
+		`SHOW VARIABLES`,
+		[]sql.Row{
+			{"auto_increment_increment", int64(1)},
+			{"time_zone", time.Local.String()},
+			{"system_time_zone", time.Local.String()},
+			{"max_allowed_packet", math.MaxInt32},
+			{"sql_mode", ""},
+			{"gtid_mode", int32(0)},
+			{"ndbinfo_version", ""},
+		},
+	},
+	{
+		`SHOW VARIABLES LIKE 'gtid_mode`,
+		[]sql.Row{
+			{"gtid_mode", int32(0)},
+		},
+	},
+	{
+		`SHOW VARIABLES LIKE 'gtid%`,
+		[]sql.Row{
+			{"gtid_mode", int32(0)},
+		},
+	},
+	{
+		`SHOW GLOBAL VARIABLES LIKE '%mode`,
+		[]sql.Row{
+			{"sql_mode", ""},
+			{"gtid_mode", int32(0)},
 		},
 	},
 }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -39,6 +39,7 @@ var (
 	createIndexRegex     = regexp.MustCompile(`^create\s+index\s+`)
 	dropIndexRegex       = regexp.MustCompile(`^drop\s+index\s+`)
 	showIndexRegex       = regexp.MustCompile(`^show\s+(index|indexes|keys)\s+(from|in)\s+\S+\s*`)
+	showVariablesRegex   = regexp.MustCompile(`^show\s+(.*)?variables\s*`)
 	describeRegex        = regexp.MustCompile(`^(describe|desc|explain)\s+(.*)\s+`)
 	fullProcessListRegex = regexp.MustCompile(`^show\s+(full\s+)?processlist$`)
 )
@@ -69,6 +70,8 @@ func Parse(ctx *sql.Context, query string) (sql.Node, error) {
 		return parseDropIndex(s)
 	case showIndexRegex.MatchString(lowerQuery):
 		return parseShowIndex(s)
+	case showVariablesRegex.MatchString(lowerQuery):
+		return parseShowVariables(ctx, s)
 	case describeRegex.MatchString(lowerQuery):
 		return parseDescribeQuery(ctx, s)
 	case fullProcessListRegex.MatchString(lowerQuery):

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -788,6 +788,11 @@ var fixtures = map[string]sql.Node{
 		},
 		plan.NewUnresolvedTable("bar", "foo"),
 	),
+	`SHOW VARIABLES`:                           plan.NewShowVariables(sql.NewEmptyContext().GetAll(), ""),
+	`SHOW GLOBAL VARIABLES`:                    plan.NewShowVariables(sql.NewEmptyContext().GetAll(), ""),
+	`SHOW SESSION VARIABLES`:                   plan.NewShowVariables(sql.NewEmptyContext().GetAll(), ""),
+	`SHOW VARIABLES LIKE 'gtid_mode'`:          plan.NewShowVariables(sql.NewEmptyContext().GetAll(), "gtid_mode"),
+	`SHOW SESSION VARIABLES LIKE 'autocommit'`: plan.NewShowVariables(sql.NewEmptyContext().GetAll(), "autocommit"),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/parse/variables.go
+++ b/sql/parse/variables.go
@@ -1,0 +1,49 @@
+package parse
+
+import (
+	"bufio"
+	"strings"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+func parseShowVariables(ctx *sql.Context, s string) (sql.Node, error) {
+	var (
+		pattern string
+	)
+
+	r := bufio.NewReader(strings.NewReader(s))
+	for _, fn := range []parseFunc{
+		expect("show"),
+		skipSpaces,
+		func(in *bufio.Reader) error {
+			var s string
+			readIdent(&s)(in)
+			switch s {
+			case "global", "session":
+				skipSpaces(in)
+				return expect("variables")(in)
+			case "variables":
+				return nil
+			}
+			return errUnexpectedSyntax.New("show [global | session] variables", s)
+		},
+		skipSpaces,
+		func(in *bufio.Reader) error {
+			if expect("like")(in) == nil {
+				skipSpaces(in)
+				readValue(&pattern)(in)
+			}
+			return nil
+		},
+		skipSpaces,
+		checkEOF,
+	} {
+		if err := fn(r); err != nil {
+			return nil, err
+		}
+	}
+
+	return plan.NewShowVariables(ctx.Session.GetAll(), pattern), nil
+}

--- a/sql/parse/variables.go
+++ b/sql/parse/variables.go
@@ -9,9 +9,7 @@ import (
 )
 
 func parseShowVariables(ctx *sql.Context, s string) (sql.Node, error) {
-	var (
-		pattern string
-	)
+	var pattern string
 
 	r := bufio.NewReader(strings.NewReader(s))
 	for _, fn := range []parseFunc{

--- a/sql/plan/showvariables.go
+++ b/sql/plan/showvariables.go
@@ -9,29 +9,33 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
 
-// ShowVariables is a node that shows the global or session variables
+// ShowVariables is a node that shows the global and session variables
 type ShowVariables struct {
 	config  map[string]sql.TypedValue
 	pattern string
 }
 
-func NewShowVariables(config map[string]sql.TypedValue, pattern string) *ShowVariables {
+// NewShowVariables returns a new ShowVariables reference.
+// config is a variables lookup table
+// like is a "like pattern". If like is an empty string it will return all variables.
+func NewShowVariables(config map[string]sql.TypedValue, like string) *ShowVariables {
 	return &ShowVariables{
 		config:  config,
-		pattern: pattern,
+		pattern: like,
 	}
 }
 
+// Resolved implements sql.Node interface. The function always returns true.
 func (sv *ShowVariables) Resolved() bool {
 	return true
 }
 
-// TransformUp implements the Transformable interface.
+// TransformUp implements the sq.Transformable interface.
 func (sv *ShowVariables) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
 	return f(NewShowVariables(sv.config, sv.pattern))
 }
 
-// TransformExpressionsUp implements the Transformable interface.
+// TransformExpressionsUp implements the sql.Transformable interface.
 func (sv *ShowVariables) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return sv, nil
 }
@@ -45,6 +49,7 @@ func (sv *ShowVariables) String() string {
 	return fmt.Sprintf("SHOW VARIABLES%s", like)
 }
 
+// Schema returns a new Schema reference for "SHOW VARIABLES" query.
 func (*ShowVariables) Schema() sql.Schema {
 	return sql.Schema{
 		&sql.Column{Name: "Variable_name", Type: sql.Text, Nullable: false},
@@ -52,9 +57,11 @@ func (*ShowVariables) Schema() sql.Schema {
 	}
 }
 
+// Children implements sql.Node interface. The function always returns nil.
 func (*ShowVariables) Children() []sql.Node { return nil }
 
-// RowIter implements the Node interface.
+// RowIter implements the sql.Node interface.
+// The function returns an iterator for filtered variables (based on like pattern)
 func (sv *ShowVariables) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 
 	it := &showVariablesIter{}

--- a/sql/plan/showvariables.go
+++ b/sql/plan/showvariables.go
@@ -1,0 +1,104 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// ShowVariables is a node that shows the global or session variables
+type ShowVariables struct {
+	config  map[string]sql.TypedValue
+	pattern string
+}
+
+func NewShowVariables(config map[string]sql.TypedValue, pattern string) *ShowVariables {
+	if config == nil {
+		config = make(map[string]sql.TypedValue)
+	}
+	if _, exists := config["gtid_mode"]; !exists {
+		config["gtid_mode"] = sql.TypedValue{sql.Text, "OFF"}
+	}
+
+	return &ShowVariables{
+		config:  config,
+		pattern: pattern,
+	}
+}
+
+func (sv *ShowVariables) Resolved() bool {
+	return true
+}
+
+// TransformUp implements the Transformable interface.
+func (sv *ShowVariables) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	return f(NewShowVariables(sv.config, sv.pattern))
+}
+
+// TransformExpressionsUp implements the Transformable interface.
+func (sv *ShowVariables) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	return sv, nil
+}
+
+// String implements the Stringer interface.
+func (sv *ShowVariables) String() string {
+	var like string
+	if sv.pattern != "" {
+		like = fmt.Sprintf(" LIKE '%s'", sv.pattern)
+	}
+	return fmt.Sprintf("SHOW VARIABLES%s", like)
+}
+
+func (*ShowVariables) Schema() sql.Schema {
+	return sql.Schema{
+		&sql.Column{Name: "Variable_name", Type: sql.Text, Nullable: false},
+		&sql.Column{Name: "Value", Type: sql.Text, Nullable: true},
+	}
+}
+
+func (*ShowVariables) Children() []sql.Node { return nil }
+
+// RowIter implements the Node interface.
+func (sv *ShowVariables) RowIter(*sql.Context) (sql.RowIter, error) {
+	n := len(sv.config)
+	it := &showVariablesIter{
+		names:  make([]string, n, n),
+		values: make([]sql.TypedValue, n, n),
+		offset: uint32(0),
+		total:  uint32(n),
+	}
+	for k, v := range sv.config {
+		it.names[n-1] = k
+		it.values[n-1] = v
+		n--
+	}
+
+	return it, nil
+}
+
+type showVariablesIter struct {
+	names  []string
+	values []sql.TypedValue
+	offset uint32
+	total  uint32
+}
+
+func (it *showVariablesIter) Next() (sql.Row, error) {
+	i := atomic.LoadUint32(&it.offset)
+	if i >= it.total {
+		return nil, io.EOF
+	}
+	defer atomic.AddUint32(&it.offset, 1)
+
+	return sql.NewRow(it.names[i], it.values[i]), nil
+}
+
+func (it *showVariablesIter) Close() error {
+	atomic.StoreUint32(&it.total, 0)
+	atomic.StoreUint32(&it.offset, 0)
+	it.values = nil
+	it.names = nil
+	return nil
+}

--- a/sql/plan/showvariables_test.go
+++ b/sql/plan/showvariables_test.go
@@ -1,0 +1,68 @@
+package plan
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestShowVariables(t *testing.T) {
+	require := require.New(t)
+
+	ctx := sql.NewEmptyContext()
+	config := ctx.Session.GetAll()
+	sv := NewShowVariables(config, "")
+	require.True(sv.Resolved())
+
+	it, err := sv.RowIter(ctx)
+	require.NoError(err)
+
+	for row, err := it.Next(); err == nil; row, err = it.Next() {
+		key := row[0].(string)
+		val := row[1]
+
+		t.Logf("key: %s\tval: %v\n", key, val)
+
+		require.Equal(config[key].Value, val)
+		delete(config, key)
+	}
+	if err != io.EOF {
+		require.NoError(err)
+	}
+	require.NoError(it.Close())
+	require.Equal(0, len(config))
+}
+
+func TestShowVariablesWithLike(t *testing.T) {
+	require := require.New(t)
+
+	vars := map[string]sql.TypedValue{
+		"int1": {Typ: sql.Int32, Value: 1},
+		"int2": {Typ: sql.Int32, Value: 2},
+		"txt":  {Typ: sql.Text, Value: "abcdefghijklmnoprstuwxyz"},
+	}
+
+	sv := NewShowVariables(vars, "int%")
+	require.True(sv.Resolved())
+
+	it, err := sv.RowIter(sql.NewEmptyContext())
+	require.NoError(err)
+
+	for row, err := it.Next(); err == nil; row, err = it.Next() {
+		key := row[0].(string)
+		val := row[1]
+		require.Equal(vars[key].Value, val)
+		require.Equal(sql.Int32, vars[key].Typ)
+		delete(vars, key)
+	}
+	if err != io.EOF {
+		require.NoError(err)
+	}
+	require.NoError(it.Close())
+	require.Equal(1, len(vars))
+
+	_, ok := vars["txt"]
+	require.True(ok)
+}

--- a/sql/session.go
+++ b/sql/session.go
@@ -95,6 +95,8 @@ func defaultSessionConfig() map[string]TypedValue {
 		"system_time_zone":         TypedValue{Text, time.Local.String()},
 		"max_allowed_packet":       TypedValue{Int32, math.MaxInt32},
 		"sql_mode":                 TypedValue{Text, ""},
+		"gtid_mode":                TypedValue{Int32, int32(0)},
+		"ndbinfo_version":          TypedValue{Text, ""},
 	}
 }
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -28,6 +28,8 @@ type Session interface {
 	Set(key string, typ Type, value interface{})
 	// Get session configuration.
 	Get(key string) (Type, interface{})
+	// GetAll returns a copy of session configuration
+	GetAll() map[string]TypedValue
 	// ID returns the unique ID of the connection.
 	ID() uint32
 }
@@ -38,7 +40,7 @@ type BaseSession struct {
 	addr   string
 	user   string
 	mu     sync.RWMutex
-	config map[string]typedValue
+	config map[string]TypedValue
 }
 
 // User returns the current user of the session.
@@ -51,7 +53,7 @@ func (s *BaseSession) Address() string { return s.addr }
 func (s *BaseSession) Set(key string, typ Type, value interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.config[key] = typedValue{typ, value}
+	s.config[key] = TypedValue{typ, value}
 }
 
 // Get implements the Session interface.
@@ -63,24 +65,36 @@ func (s *BaseSession) Get(key string) (Type, interface{}) {
 		return Null, nil
 	}
 
-	return v.typ, v.value
+	return v.Typ, v.Value
+}
+
+// GetAll returns a copy of session configuration
+func (s *BaseSession) GetAll() map[string]TypedValue {
+	m := make(map[string]TypedValue)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for k, v := range s.config {
+		m[k] = v
+	}
+	return m
 }
 
 // ID implements the Session interface.
 func (s *BaseSession) ID() uint32 { return s.id }
 
-type typedValue struct {
-	typ   Type
-	value interface{}
+type TypedValue struct {
+	Typ   Type
+	Value interface{}
 }
 
-func defaultSessionConfig() map[string]typedValue {
-	return map[string]typedValue{
-		"auto_increment_increment": typedValue{Int64, int64(1)},
-		"time_zone":                typedValue{Text, time.Local.String()},
-		"system_time_zone":         typedValue{Text, time.Local.String()},
-		"max_allowed_packet":       typedValue{Int32, math.MaxInt32},
-		"sql_mode":                 typedValue{Text, ""},
+func defaultSessionConfig() map[string]TypedValue {
+	return map[string]TypedValue{
+		"auto_increment_increment": TypedValue{Int64, int64(1)},
+		"time_zone":                TypedValue{Text, time.Local.String()},
+		"system_time_zone":         TypedValue{Text, time.Local.String()},
+		"max_allowed_packet":       TypedValue{Int32, math.MaxInt32},
+		"sql_mode":                 TypedValue{Text, ""},
 	}
 }
 


### PR DESCRIPTION
Closes: https://github.com/src-d/go-mysql-server/issues/409

The PR implements:
`SHOW [global | session] VARIABLES [LIKE pattern]`

where _global_, _session_ are ignored (we copy config from `BaseSession`).
So far it supports `LIKE` condition. In the future we can also add `WHERE`