### PR TITLE
For numberT cast to the sqltype.

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -420,6 +420,12 @@ var queries = []struct {
 		},
 	},
 	{
+		`SELECT AVG(23.222000)`,
+		[]sql.Row{
+			{float64(23.222)},
+		},
+	},
+	{
 		`SHOW VARIABLES`,
 		[]sql.Row{
 			{"auto_increment_increment", int64(1)},

--- a/sql/expression/function/aggregation/avg_test.go
+++ b/sql/expression/function/aggregation/avg_test.go
@@ -15,6 +15,17 @@ func TestAvg_String(t *testing.T) {
 	require.Equal("AVG(col1)", avg.String())
 }
 
+func TestAvg_Float64(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	avg := NewAvg(expression.NewGetField(0, sql.Float64, "col1", true))
+	buffer := avg.NewBuffer()
+	avg.Update(ctx, buffer, sql.NewRow(float64(23.2220000)))
+
+	require.Equal(float64(23.222), eval(t, avg, buffer))
+}
+
 func TestAvg_Eval_INT32(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()

--- a/sql/type.go
+++ b/sql/type.go
@@ -262,7 +262,22 @@ func (t numberT) Type() query.Type {
 
 // SQL implements Type interface.
 func (t numberT) SQL(v interface{}) sqltypes.Value {
-	return sqltypes.MakeTrusted(t.t, strconv.AppendInt(nil, cast.ToInt64(v), 10))
+	switch t.t {
+	case sqltypes.Int32:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendInt(nil, cast.ToInt64(v), 10))
+	case sqltypes.Int64:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendInt(nil, cast.ToInt64(v), 10))
+	case sqltypes.Uint32:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendUint(nil, cast.ToUint64(v), 10))
+	case sqltypes.Uint64:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendUint(nil, cast.ToUint64(v), 10))
+	case sqltypes.Float32:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendFloat(nil, cast.ToFloat64(v), 'f', -1, 64))
+	case sqltypes.Float64:
+		return sqltypes.MakeTrusted(t.t, strconv.AppendFloat(nil, cast.ToFloat64(v), 'f', -1, 64))
+	default:
+		return sqltypes.MakeTrusted(t.t, []byte{})
+	}
 }
 
 // Convert implements Type interface.

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-vitess.v1/sqltypes"
+	"gopkg.in/src-d/go-vitess.v1/vt/proto/query"
 )
 
 func TestText(t *testing.T) {
@@ -53,6 +54,17 @@ func TestInt64(t *testing.T) {
 	lt(t, Int64, int64(1), int64(2))
 	eq(t, Int64, int64(1), int64(1))
 	gt(t, Int64, int64(3), int64(2))
+}
+
+func TestFloat64(t *testing.T) {
+	require := require.New(t)
+
+	var f = numberT{
+		t: query.Type_FLOAT64,
+	}
+	val := f.SQL(23.222)
+	require.True(val.IsFloat())
+	require.Equal(sqltypes.NewFloat64(23.222), val)
 }
 
 func TestTimestamp(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Right now for `numberT` we cast all values to `Int64`. It impacts aggregation functions like AVG, MIN, MAX, etc.
This PR checks _the number_ type and cast it appropriately.

Closes: https://github.com/src-d/go-mysql-server/issues/450