### PR TITLE
sql/plan: correctly count processed index rows globally instead of per partition

### DIFF
--- a/information_schema.go
+++ b/information_schema.go
@@ -8,8 +8,11 @@ import (
 )
 
 const (
-	InformationSchemaDBName   = "information_schema"
-	FilesTableName            = "files"
+	// InformationSchemaDBName is the name of the information schema table.
+	InformationSchemaDBName = "information_schema"
+	// FilesTableName is the name of the files table.
+	FilesTableName = "files"
+	// ColumnStatisticsTableName is the name of the column statistics table.
 	ColumnStatisticsTableName = "column_statistics"
 )
 

--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -143,7 +143,7 @@ func (idx *pilosaIndex) Expressions() []string {
 	return idx.expressions
 }
 
-func (pilosaIndex) Driver() string { return DriverID }
+func (*pilosaIndex) Driver() string { return DriverID }
 
 func (idx *pilosaIndex) AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLookup, error) {
 	if len(keys) != len(idx.expressions) {

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -398,6 +398,7 @@ type loggingPartitionKeyValueIter struct {
 	ctx  *sql.Context
 	log  *logrus.Entry
 	iter sql.PartitionIndexKeyValueIter
+	rows uint64
 }
 
 func newLoggingPartitionKeyValueIter(
@@ -418,7 +419,7 @@ func (i *loggingPartitionKeyValueIter) Next() (sql.Partition, sql.IndexKeyValueI
 		return nil, nil, err
 	}
 
-	return p, newLoggingKeyValueIter(i.ctx, i.log, iter), nil
+	return p, newLoggingKeyValueIter(i.ctx, i.log, iter, &i.rows), nil
 }
 
 func (i *loggingPartitionKeyValueIter) Close() error {
@@ -430,7 +431,7 @@ type loggingKeyValueIter struct {
 	span  opentracing.Span
 	log   *logrus.Entry
 	iter  sql.IndexKeyValueIter
-	rows  uint64
+	rows  *uint64
 	start time.Time
 }
 
@@ -438,12 +439,14 @@ func newLoggingKeyValueIter(
 	ctx *sql.Context,
 	log *logrus.Entry,
 	iter sql.IndexKeyValueIter,
+	rows *uint64,
 ) *loggingKeyValueIter {
 	return &loggingKeyValueIter{
 		ctx:   ctx,
 		log:   log,
 		iter:  iter,
 		start: time.Now(),
+		rows:  rows,
 	}
 }
 
@@ -456,13 +459,13 @@ func (i *loggingKeyValueIter) Next() ([]interface{}, []byte, error) {
 		)
 	}
 
-	i.rows++
-	if i.rows%sql.IndexBatchSize == 0 {
+	(*i.rows)++
+	if *i.rows%sql.IndexBatchSize == 0 {
 		duration := time.Since(i.start)
 
 		i.log.WithFields(logrus.Fields{
 			"duration": duration,
-			"rows":     i.rows,
+			"rows":     *i.rows,
 		}).Debugf("still creating index")
 
 		if i.span != nil {


### PR DESCRIPTION
Fixes #455 