### PR TITLE
sql: support more timestamp formats

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -93,6 +93,18 @@ var queries = []struct {
 		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
 	},
 	{
+		"SELECT SECOND('2007-12-11T20:21:22Z') FROM mytable",
+		[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
+	},
+	{
+		"SELECT DAYOFYEAR('2007-12-11') FROM mytable",
+		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	},
+	{
+		"SELECT DAYOFYEAR('20071211') FROM mytable",
+		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	},
+	{
 		"SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
 		[]sql.Row{{int64(1)}, {int64(2)}},
 	},

--- a/sql/type.go
+++ b/sql/type.go
@@ -367,6 +367,18 @@ func (t timestampT) Type() query.Type {
 // using the format of Go "time" package.
 const TimestampLayout = "2006-01-02 15:04:05"
 
+// TimestampLayouts hold extra timestamps allowed for parsing. It does
+// not have all the layouts supported by mysql. Missing are two digit year
+// versions of common cases and dates that use non common separators.
+//
+// https://github.com/MariaDB/server/blob/mysql-5.5.36/sql-common/my_time.c#L124
+var TimestampLayouts = []string{
+	"2006-01-02",
+	time.RFC3339,
+	"20060102150405",
+	"20060102",
+}
+
 // SQL implements Type interface.
 func (t timestampT) SQL(v interface{}) sqltypes.Value {
 	time := MustConvert(t, v).(time.Time)
@@ -384,7 +396,18 @@ func (t timestampT) Convert(v interface{}) (interface{}, error) {
 	case string:
 		t, err := time.Parse(TimestampLayout, value)
 		if err != nil {
-			return nil, ErrConvertingToTime.Wrap(err, v)
+			failed := true
+			for _, fmt := range TimestampLayouts {
+				if t2, err2 := time.Parse(fmt, value); err2 == nil {
+					t = t2
+					failed = false
+					break
+				}
+			}
+
+			if failed {
+				return nil, ErrConvertingToTime.Wrap(err, v)
+			}
 		}
 		return t.UTC(), nil
 	default:

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -98,6 +98,46 @@ func TestTimestamp(t *testing.T) {
 	gt(t, Timestamp, after, now)
 }
 
+func TestExtraTimestamps(t *testing.T) {
+	tests := []struct {
+		date     string
+		expected string
+	}{
+		{
+			date:     "2018-10-18T05:22:25Z",
+			expected: "2018-10-18 05:22:25",
+		},
+		{
+			date:     "2018-10-18T05:22:25+07:00",
+			expected: "2018-10-17 22:22:25",
+		},
+		{
+			date:     "20181018052225",
+			expected: "2018-10-18 05:22:25",
+		},
+		{
+			date:     "20181018",
+			expected: "2018-10-18 00:00:00",
+		},
+		{
+			date:     "2018-10-18",
+			expected: "2018-10-18 00:00:00",
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.date, func(t *testing.T) {
+			require := require.New(t)
+
+			p, err := Timestamp.Convert(c.date)
+			require.NoError(err)
+
+			str := string([]byte(p.(time.Time).Format(TimestampLayout)))
+			require.Equal(c.expected, str)
+		})
+	}
+}
+
 func TestDate(t *testing.T) {
 	require := require.New(t)
 	now := time.Now().UTC()


### PR DESCRIPTION
MySQL supports multitude of formats to parse datetime data. Not all
formats are supported as some of them require changing the way of
parsing as they support any separator.

Information about datetime parsing can be found here:

https://github.com/MariaDB/server/blob/mysql-5.5.36/sql-common/my_time.c#L124

```
  DESCRIPTION
    At least the following formats are recogniced (based on number of digits)
    YYMMDD, YYYYMMDD, YYMMDDHHMMSS, YYYYMMDDHHMMSS
    YY-MM-DD, YYYY-MM-DD, YY-MM-DD HH.MM.SS
    YYYYMMDDTHHMMSS  where T is a the character T (ISO8601)
    Also dates where all parts are zero are allowed
    The second part may have an optional .###### fraction part.
```