### PR TITLE
Do not pull vt/logutil/level.go

### DIFF
--- a/_scripts/go-vitess/Makefile
+++ b/_scripts/go-vitess/Makefile
@@ -19,6 +19,7 @@ filter-branch:	clone
 	cd ${VITESS_SRC} && \
 	git filter-branch --subdirectory-filter go && \
 	rm -fr README.md cacheservice cmd exit ioutil2 memcache race ratelimiter stats/influxdbbackend stats/opentsdb stats/prometheusbackend testfiles vtbench zk vt/mysqlctl/cephbackupstorage && \
+	rm -fr vt/logutil/level.go && \
 	cp -f "${CWD}/doc.go" "${CWD}/README.md" "${CWD}/LICENSE" ${VITESS_SRC} && \
 	cp -f "${CWD}/vt/log/log.go" "${VITESS_SRC}/vt/log/log.go"
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Following file: https://github.com/vitessio/vitess/blob/master/go/vt/logutil/level.go
Relies on special flags set by `glog` package. If they are not set it panics. After we replaced glog by logrus (https://github.com/src-d/go-vitess/blob/master/vt/log/log.go) vitess panics.

This PR just removes `level.go` file in our vitess fork.