### PR TITLE
level.go doesn't panic anymore.

### DIFF
--- a/_scripts/go-vitess/Makefile
+++ b/_scripts/go-vitess/Makefile
@@ -19,7 +19,6 @@ filter-branch:	clone
 	cd ${VITESS_SRC} && \
 	git filter-branch --subdirectory-filter go && \
 	rm -fr README.md cacheservice cmd exit ioutil2 memcache race ratelimiter stats/influxdbbackend stats/opentsdb stats/prometheusbackend testfiles vtbench zk vt/mysqlctl/cephbackupstorage && \
-	rm -fr vt/logutil/level.go && \
 	cp -f "${CWD}/doc.go" "${CWD}/README.md" "${CWD}/LICENSE" ${VITESS_SRC} && \
 	cp -f "${CWD}/vt/log/log.go" "${VITESS_SRC}/vt/log/log.go"
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

PR https://github.com/vitessio/vitess/pull/4328/files is already merged, so we don't have to delete `level.go` because it doesn't panic, anymore.