### PR TITLE
sql/(plan,parse): fix show table status behaviour

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -415,7 +415,6 @@ var queries = []struct {
 		[]sql.Row{
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"other_table", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 		},
 	},
 	{
@@ -585,6 +584,14 @@ var queries = []struct {
 	{
 		`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
 		[]sql.Row{},
+	},
+	{
+		`SHOW TABLE STATUS`,
+		[]sql.Row{
+			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+		},
 	},
 }
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1070,6 +1070,10 @@ func parseShowTableStatus(query string) (sql.Node, error) {
 		return nil, err
 	}
 
+	if _, err = buf.Peek(1); err == io.EOF {
+		return plan.NewShowTableStatus(), nil
+	}
+
 	var clause string
 	if err := readIdent(&clause)(buf); err != nil {
 		return nil, err

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -797,6 +797,7 @@ var fixtures = map[string]sql.Node{
 	),
 	`SHOW TABLE STATUS FROM foo`: plan.NewShowTableStatus("foo"),
 	`SHOW TABLE STATUS IN foo`:   plan.NewShowTableStatus("foo"),
+	`SHOW TABLE STATUS`:          plan.NewShowTableStatus(),
 	`SHOW TABLE STATUS WHERE Name = 'foo'`: plan.NewFilter(
 		expression.NewEquals(
 			expression.NewUnresolvedColumn("Name"),

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -53,9 +53,20 @@ func (s *ShowTableStatus) Schema() sql.Schema { return showTableStatusSchema }
 func (s *ShowTableStatus) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	var rows []sql.Row
 	var tables []string
-	for _, db := range s.Catalog.AllDatabases() {
-		if len(s.Databases) > 0 && !stringContains(s.Databases, db.Name()) {
-			continue
+	if len(s.Databases) > 0 {
+		for _, db := range s.Catalog.AllDatabases() {
+			if !stringContains(s.Databases, db.Name()) {
+				continue
+			}
+
+			for t := range db.Tables() {
+				tables = append(tables, t)
+			}
+		}
+	} else {
+		db, err := s.Catalog.Database(s.Catalog.CurrentDatabase())
+		if err != nil {
+			return nil, err
 		}
 
 		for t := range db.Tables() {

--- a/sql/plan/showtablestatus_test.go
+++ b/sql/plan/showtablestatus_test.go
@@ -35,8 +35,6 @@ func TestShowTableStatus(t *testing.T) {
 	expected := []sql.Row{
 		{"t1", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 		{"t2", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-		{"t3", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-		{"t4", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 	}
 
 	require.Equal(expected, rows)


### PR DESCRIPTION
Fixes #530 

- Fixes parsing without FROM/IN/WHERE/LIKE
- When no database specified, only tables from current database should be used, as MySQL does.