### PR TITLE
Add error for subqueries

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -25,6 +25,9 @@ var (
 	// ErrUnsupportedFeature is thrown when a feature is not already supported
 	ErrUnsupportedFeature = errors.NewKind("unsupported feature: %s")
 
+	// ErrUnsupportedSubqueryExpression is thrown because subqueries are not supported, yet.
+	ErrUnsupportedSubqueryExpression = errors.NewKind("unsupported subquery expression")
+
 	// ErrInvalidSQLValType is returned when a SQLVal type is not valid.
 	ErrInvalidSQLValType = errors.NewKind("invalid SQLVal of type: %d")
 
@@ -783,6 +786,8 @@ func exprToExpression(e sqlparser.Expr) (sql.Expression, error) {
 		return binaryExprToExpression(v)
 	case *sqlparser.UnaryExpr:
 		return unaryExprToExpression(v)
+	case *sqlparser.Subquery:
+		return nil, ErrUnsupportedSubqueryExpression.New()
 	}
 }
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -905,9 +905,10 @@ func TestParse(t *testing.T) {
 }
 
 var fixturesErrors = map[string]*errors.Kind{
-	`SHOW METHEMONEY`:                   ErrUnsupportedFeature,
-	`LOCK TABLES foo AS READ`:           errUnexpectedSyntax,
-	`LOCK TABLES foo LOW_PRIORITY READ`: errUnexpectedSyntax,
+	`SHOW METHEMONEY`:                                      ErrUnsupportedFeature,
+	`LOCK TABLES foo AS READ`:                              errUnexpectedSyntax,
+	`LOCK TABLES foo LOW_PRIORITY READ`:                    errUnexpectedSyntax,
+	`SELECT * FROM mytable WHERE i IN (SELECT i FROM foo)`: ErrUnsupportedSubqueryExpression,
 }
 
 func TestParseErrors(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Closes https://github.com/src-d/gitbase/issues/622

So far we don't support subqueries (for filters/conditions). This PR adds explicit error message for subqueries.