### PR TITLE
Add explicit error when ON clause is missed for JOIN statement

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -493,11 +493,14 @@ func tableExprToTable(
 			return plan.NewNaturalJoin(left, right), nil
 		}
 
+		if t.Condition.On == nil {
+			return nil, ErrUnsupportedSyntax.New("missed ON clause for JOIN statement")
+		}
+
 		cond, err := exprToExpression(t.Condition.On)
 		if err != nil {
 			return nil, err
 		}
-
 		return plan.NewInnerJoin(left, right, cond), nil
 	}
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -909,6 +909,10 @@ var fixturesErrors = map[string]*errors.Kind{
 	`LOCK TABLES foo AS READ`:                              errUnexpectedSyntax,
 	`LOCK TABLES foo LOW_PRIORITY READ`:                    errUnexpectedSyntax,
 	`SELECT * FROM mytable WHERE i IN (SELECT i FROM foo)`: ErrUnsupportedSubqueryExpression,
+	`SELECT * FROM files
+		JOIN commit_files
+		JOIN refs
+	`: ErrUnsupportedSyntax,
 }
 
 func TestParseErrors(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Closes https://github.com/src-d/go-mysql-server/issues/553