### PR TITLE
*: reset proces progress on partition iteration

### DIFF
--- a/sql/analyzer/process.go
+++ b/sql/analyzer/process.go
@@ -47,13 +47,16 @@ func trackProcess(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 			notify := func() {
 				processList.UpdateProgress(ctx.Pid(), name, 1)
 			}
+			reset := func() {
+				processList.ResetProgress(ctx.Pid(), name)
+			}
 
 			var t sql.Table
 			switch table := n.Table.(type) {
 			case sql.IndexableTable:
-				t = plan.NewProcessIndexableTable(table, notify)
+				t = plan.NewProcessIndexableTable(table, notify, reset)
 			default:
-				t = plan.NewProcessTable(table, notify)
+				t = plan.NewProcessTable(table, notify, reset)
 			}
 
 			return plan.NewResolvedTable(t), nil

--- a/sql/plan/process_test.go
+++ b/sql/plan/process_test.go
@@ -61,7 +61,7 @@ func TestProcessTable(t *testing.T) {
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(3)))
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(4)))
 
-	var notifications int
+	var notifications, resets int
 
 	node := NewProject(
 		[]sql.Expression{
@@ -72,6 +72,9 @@ func TestProcessTable(t *testing.T) {
 				table,
 				func() {
 					notifications++
+				},
+				func() {
+					resets++
 				},
 			),
 		),
@@ -92,6 +95,7 @@ func TestProcessTable(t *testing.T) {
 
 	require.ElementsMatch(expected, rows)
 	require.Equal(2, notifications)
+	require.Equal(1, resets)
 }
 
 func TestProcessIndexableTable(t *testing.T) {
@@ -106,12 +110,15 @@ func TestProcessIndexableTable(t *testing.T) {
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(3)))
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(4)))
 
-	var notifications int
+	var notifications, resets int
 
 	pt := NewProcessIndexableTable(
 		table,
 		func() {
 			notifications++
+		},
+		func() {
+			resets++
 		},
 	)
 
@@ -145,4 +152,9 @@ func TestProcessIndexableTable(t *testing.T) {
 
 	require.ElementsMatch(expectedValues, values)
 	require.Equal(2, notifications)
+	require.Equal(0, resets)
+
+	_, err = pt.Partitions(sql.NewEmptyContext())
+	require.NoError(err)
+	require.Equal(1, resets)
 }

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -136,6 +136,26 @@ func (pl *ProcessList) UpdateProgress(pid uint64, name string, delta int64) {
 	p.Progress[name] = progress
 }
 
+// ResetProgress resets the progress of the item with the given name for the
+// process with the given pid.
+func (pl *ProcessList) ResetProgress(pid uint64, name string) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	p, ok := pl.procs[pid]
+	if !ok {
+		return
+	}
+
+	progress, ok := p.Progress[name]
+	if !ok {
+		progress = Progress{Total: -1}
+	}
+
+	progress.Done = 0
+	p.Progress[name] = progress
+}
+
 // AddProgressItem adds a new item to track progress from to the process with
 // the given pid. If the pid does not exist, it will do nothing.
 func (pl *ProcessList) AddProgressItem(pid uint64, name string, total int64) {


### PR DESCRIPTION
Fixes https://github.com/src-d/gitbase/issues/646 (kinda)

The problem is that it's in an InnerJoin, so one of the branches is **fully** iterated N times, where N is the number of rows in the other branch.

So, the maximum allowed progress would be NxM, being M the number of repositories.

There's no way to know N ahead of time so we can't estimate correctly. The only viable "solution" is to reset the progress in each iteration :/

Idk what you guys think about this, but the only reasonable thing I can think of.