### PR TITLE
analyzer: correctly search for subquery used columns

### DIFF
--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -79,7 +79,7 @@ func pruneSubqueryColumns(
 		columns[table][col] = struct{}{}
 	}
 
-	findUsedColumns(columns, n)
+	findUsedColumns(columns, n.Child)
 
 	node, err := addSubqueryBarriers(n.Child)
 	if err != nil {

--- a/sql/analyzer/prune_columns_test.go
+++ b/sql/analyzer/prune_columns_test.go
@@ -206,6 +206,70 @@ func TestPruneColumns(t *testing.T) {
 				),
 			),
 		},
+
+		{
+			"used inside subquery and not outside",
+			plan.NewProject(
+				[]sql.Expression{
+					gf(0, "sq", "foo"),
+				},
+				plan.NewSubqueryAlias("sq",
+					plan.NewProject(
+						[]sql.Expression{gf(0, "t1", "foo")},
+						plan.NewInnerJoin(
+							plan.NewProject(
+								[]sql.Expression{
+									gf(0, "t1", "foo"),
+									gf(1, "t1", "bar"),
+									gf(2, "t1", "bax"),
+								},
+								t1,
+							),
+							plan.NewProject(
+								[]sql.Expression{
+									gf(0, "t2", "foo"),
+									gf(1, "t2", "baz"),
+									gf(2, "t2", "bux"),
+								},
+								t2,
+							),
+							expression.NewEquals(
+								gf(0, "t1", "foo"),
+								gf(3, "t2", "foo"),
+							),
+						),
+					),
+				),
+			),
+			plan.NewProject(
+				[]sql.Expression{
+					gf(0, "sq", "foo"),
+				},
+				plan.NewSubqueryAlias("sq",
+					plan.NewProject(
+						[]sql.Expression{gf(0, "t1", "foo")},
+						plan.NewInnerJoin(
+							plan.NewProject(
+								[]sql.Expression{
+									gf(0, "t1", "foo"),
+								},
+								t1,
+							),
+							plan.NewProject(
+								[]sql.Expression{
+									gf(0, "t2", "foo"),
+								},
+								t2,
+							),
+							expression.NewEquals(
+								gf(0, "t1", "foo"),
+								gf(3, "t2", "foo"),
+							),
+						),
+					),
+				),
+			),
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
There was an uncaught bug that pruned columns inside the subquery using only the used columns OUTSIDE the subquery, causing potential issues. Added a test case for this so we don't miss it again.