### PR TITLE
sql: use checksums to determine if indexes are outdated

### DIFF
--- a/sql/index/pilosa/index.go
+++ b/sql/index/pilosa/index.go
@@ -67,9 +67,18 @@ type pilosaIndex struct {
 	table       string
 	id          string
 	expressions []string
+	checksum    string
 }
 
 func newPilosaIndex(idx *pilosa.Index, mapping *mapping, cfg *index.Config) *pilosaIndex {
+	var checksum string
+	for _, c := range cfg.Drivers {
+		if ch, ok := c[sql.ChecksumKey]; ok {
+			checksum = ch
+		}
+		break
+	}
+
 	return &pilosaIndex{
 		index:       newConcurrentPilosaIndex(idx),
 		db:          cfg.DB,
@@ -77,7 +86,12 @@ func newPilosaIndex(idx *pilosa.Index, mapping *mapping, cfg *index.Config) *pil
 		id:          cfg.ID,
 		expressions: cfg.Expressions,
 		mapping:     mapping,
+		checksum:    checksum,
 	}
+}
+
+func (idx *pilosaIndex) Checksum() (string, error) {
+	return idx.checksum, nil
 }
 
 // Get returns an IndexLookup for the given key in the index.

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -81,7 +81,7 @@ func getIndexableTable(t sql.Table) (sql.IndexableTable, error) {
 	case sql.TableWrapper:
 		return getIndexableTable(t.Underlying())
 	default:
-		return nil, ErrInsertIntoNotSupported.New()
+		return nil, ErrNotIndexable.New()
 	}
 }
 
@@ -116,6 +116,13 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	for _, e := range exprs {
 		if e.Type() == sql.Blob || e.Type() == sql.JSON {
 			return nil, ErrExprTypeNotIndexable.New(e, e.Type())
+		}
+	}
+
+	if ch, ok := table.Table.(sql.Checksumable); ok {
+		c.Config[sql.ChecksumKey], err = ch.Checksum()
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
First part of https://github.com/src-d/gitbase/issues/661

After a few attempts, I've settled with this way of handling this, since this is backwards compatible, does not introduce any breaking changes and uses existing mechanisms.

Checksum is sent to the driver using the index configuration that we were not using for anything yet. Instead of changing the API of the drivers to accept a checksum, since this is more of a temporal solution until updates are supported, I preferred to use this way.

Indexes hold the checksum value inside so they can return it. An `sql.Index` may or may not implement `sql.Checksumable`, which makes it really up to the driver to use checksums or not.

Tables may also implement `sql.Checksumable`. If a table is not checksumable, the driver will do nothing related to checksums. If it is, when the driver is loaded it will compare both checksums and mark the index as outdated if they don't match.

A new `IndexOutdated` status has been added for indexes. The index is loaded, so it can be dropped, but it can not be used in any query or overwritten before deleting it. Not loading it if it was outdated would have made it possible for multiple identical indexes to exist at the same time for different versions, which did not make much sense.
When the index is marked as outdated a warning is printed.