### PR TITLE
sql/*: fix show tables to match MySQL spec

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -800,6 +800,49 @@ var queries = []struct {
 			{nil},
 		},
 	},
+	{
+		"SHOW TABLES",
+		[]sql.Row{
+			{"mytable"},
+			{"othertable"},
+			{"tabletest"},
+		},
+	},
+	{
+		"SHOW FULL TABLES",
+		[]sql.Row{
+			{"mytable", "BASE TABLE"},
+			{"othertable", "BASE TABLE"},
+			{"tabletest", "BASE TABLE"},
+		},
+	},
+	{
+		"SHOW FULL TABLES",
+		[]sql.Row{
+			{"mytable", "BASE TABLE"},
+			{"othertable", "BASE TABLE"},
+			{"tabletest", "BASE TABLE"},
+		},
+	},
+	{
+		"SHOW TABLES FROM foo",
+		[]sql.Row{
+			{"other_table"},
+		},
+	},
+	{
+		"SHOW TABLES LIKE '%table'",
+		[]sql.Row{
+			{"mytable"},
+			{"othertable"},
+		},
+	},
+	{
+		"SHOW TABLES WHERE `Table` = 'mytable'",
+		[]sql.Row{
+			{"mytable"},
+		},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -246,7 +246,54 @@ var fixtures = map[string]sql.Node{
 		}}),
 		[]string{"col1", "col2"},
 	),
-	`SHOW TABLES`: plan.NewShowTables(sql.UnresolvedDatabase("")),
+	`SHOW TABLES`:               plan.NewShowTables(sql.UnresolvedDatabase(""), false),
+	`SHOW FULL TABLES`:          plan.NewShowTables(sql.UnresolvedDatabase(""), true),
+	`SHOW TABLES FROM foo`:      plan.NewShowTables(sql.UnresolvedDatabase("foo"), false),
+	`SHOW TABLES IN foo`:        plan.NewShowTables(sql.UnresolvedDatabase("foo"), false),
+	`SHOW FULL TABLES FROM foo`: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true),
+	`SHOW FULL TABLES IN foo`:   plan.NewShowTables(sql.UnresolvedDatabase("foo"), true),
+	`SHOW TABLES LIKE 'foo'`: plan.NewFilter(
+		expression.NewLike(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase(""), false),
+	),
+	"SHOW TABLES WHERE `Table` = 'foo'": plan.NewFilter(
+		expression.NewEquals(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase(""), false),
+	),
+	`SHOW FULL TABLES LIKE 'foo'`: plan.NewFilter(
+		expression.NewLike(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase(""), true),
+	),
+	"SHOW FULL TABLES WHERE `Table` = 'foo'": plan.NewFilter(
+		expression.NewEquals(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase(""), true),
+	),
+	`SHOW FULL TABLES FROM bar LIKE 'foo'`: plan.NewFilter(
+		expression.NewLike(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true),
+	),
+	"SHOW FULL TABLES FROM bar WHERE `Table` = 'foo'": plan.NewFilter(
+		expression.NewEquals(
+			expression.NewUnresolvedColumn("Table"),
+			expression.NewLiteral("foo", sql.Text),
+		),
+		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true),
+	),
 	`SELECT DISTINCT foo, bar FROM foo;`: plan.NewDistinct(
 		plan.NewProject(
 			[]sql.Expression{

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 )
 
+// ErrTableNotFound is returned when the table could not be found.
 var ErrTableNotFound = errors.NewKind("Table `%s` not found")
 
 // ShowCreateTable is a node that shows the CREATE TABLE statement for a table.
@@ -56,8 +57,8 @@ func (n *ShowCreateTable) String() string {
 }
 
 type showCreateTablesIter struct {
-	db    sql.Database
-	table string
+	db           sql.Database
+	table        string
 	didIteration bool
 }
 

--- a/sql/plan/show_tables_test.go
+++ b/sql/plan/show_tables_test.go
@@ -13,7 +13,7 @@ func TestShowTables(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
-	unresolvedShowTables := NewShowTables(sql.UnresolvedDatabase(""))
+	unresolvedShowTables := NewShowTables(sql.UnresolvedDatabase(""), false)
 
 	require.False(unresolvedShowTables.Resolved())
 	require.Nil(unresolvedShowTables.Children())
@@ -23,7 +23,7 @@ func TestShowTables(t *testing.T) {
 	db.AddTable("test2", mem.NewTable("test2", nil))
 	db.AddTable("test3", mem.NewTable("test3", nil))
 
-	resolvedShowTables := NewShowTables(db)
+	resolvedShowTables := NewShowTables(db, false)
 	require.True(resolvedShowTables.Resolved())
 	require.Nil(resolvedShowTables.Children())
 


### PR DESCRIPTION
Fixes #562 

- Implements all what's in the spec for `SHOW TABLES`, which caused an error before even if we had show tables implemented.
- Fixes a bug on the resolve_database analyzer rule.