### PR TITLE
sql: add transaction_isolation default value

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -542,6 +542,7 @@ var queries = []struct {
 			{"collation_database", "utf8_bin"},
 			{"ndbinfo_version", ""},
 			{"sql_select_limit", math.MaxInt32},
+			{"transaction_isolation", "READ UNCOMMITTED"},
 		},
 	},
 	{

--- a/sql/session.go
+++ b/sql/session.go
@@ -166,6 +166,7 @@ func DefaultSessionConfig() map[string]TypedValue {
 		"collation_database":       TypedValue{Text, "utf8_bin"},
 		"ndbinfo_version":          TypedValue{Text, ""},
 		"sql_select_limit":         TypedValue{Int32, math.MaxInt32},
+		"transaction_isolation":    TypedValue{Text, "READ UNCOMMITTED"},
 	}
 }
 


### PR DESCRIPTION
Fixes #564 

I added `READ UNCOMMITED` because it's what's most similar to what we do (no transactions at all).

> `READ UNCOMMITTED`
> 
> SELECT statements are performed in a nonlocking fashion, but a possible earlier version of a row > might be used. Thus, using this isolation level, such reads are not consistent. This is also called a dirty read. Otherwise, this isolation level works like READ COMMITTED.