### PR TITLE
sql: add Databaser interface for cleaner analyzer rules

### DIFF
--- a/sql/analyzer/assign_catalog_test.go
+++ b/sql/analyzer/assign_catalog_test.go
@@ -45,7 +45,7 @@ func TestAssignCatalog(t *testing.T) {
 
 	si, ok := node.(*plan.ShowIndexes)
 	require.True(ok)
-	require.Equal(db, si.Database)
+	require.Equal(db, si.Database())
 	require.Equal(c.IndexRegistry, si.Registry)
 
 	node, err = f.Apply(sql.NewEmptyContext(), a, plan.NewShowProcessList())

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -2,7 +2,6 @@ package analyzer
 
 import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
-	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
 
 func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -12,59 +11,27 @@ func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error
 	a.Log("resolve database, node of type: %T", n)
 
 	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
-		switch v := n.(type) {
-		case *plan.ShowIndexes:
-			db, err := a.Catalog.Database(a.Catalog.CurrentDatabase())
-			if err != nil {
-				return nil, err
-			}
-
-			nc := *v
-			nc.Database = db
-			return &nc, nil
-		case *plan.ShowTables:
-			var dbName = v.Database.Name()
-			if dbName == "" {
-				dbName = a.Catalog.CurrentDatabase()
-			}
-
-			db, err := a.Catalog.Database(dbName)
-			if err != nil {
-				return nil, err
-			}
-
-			nc := *v
-			nc.Database = db
-			return &nc, nil
-		case *plan.CreateTable:
-			db, err := a.Catalog.Database(a.Catalog.CurrentDatabase())
-			if err != nil {
-				return nil, err
-			}
-
-			nc := *v
-			nc.Database = db
-			return &nc, nil
-		case *plan.Use:
-			db, err := a.Catalog.Database(v.Database.Name())
-			if err != nil {
-				return nil, err
-			}
-
-			nc := *v
-			nc.Database = db
-			return &nc, nil
-		case *plan.ShowCreateDatabase:
-			db, err := a.Catalog.Database(v.Database.Name())
-			if err != nil {
-				return nil, err
-			}
-
-			nc := *v
-			nc.Database = db
-			return &nc, nil
-		default:
+		d, ok := n.(sql.Databaser)
+		if !ok {
 			return n, nil
 		}
+
+		var dbName = a.Catalog.CurrentDatabase()
+		if db := d.Database(); db != nil {
+			if _, ok := db.(sql.UnresolvedDatabase); !ok {
+				return n, nil
+			}
+
+			if db.Name() != "" {
+				dbName = db.Name()
+			}
+		}
+
+		db, err := a.Catalog.Database(dbName)
+		if err != nil {
+			return nil, err
+		}
+
+		return d.WithDatabase(db)
 	})
 }

--- a/sql/core.go
+++ b/sql/core.go
@@ -117,6 +117,15 @@ type Expressioner interface {
 	TransformExpressions(TransformExprFunc) (Node, error)
 }
 
+// Databaser is a node that contains a reference to a database.
+type Databaser interface {
+	// Database the current database.
+	Database() Database
+	// WithDatabase returns a new node instance with the database replaced with
+	// the one given as parameter.
+	WithDatabase(Database) (Node, error)
+}
+
 // Partition represents a partition from a SQL table.
 type Partition interface {
 	Key() []byte

--- a/sql/plan/show_create_database.go
+++ b/sql/plan/show_create_database.go
@@ -9,7 +9,7 @@ import (
 
 // ShowCreateDatabase returns the SQL for creating a database.
 type ShowCreateDatabase struct {
-	Database    sql.Database
+	db          sql.Database
 	IfNotExists bool
 }
 
@@ -25,9 +25,23 @@ func NewShowCreateDatabase(db sql.Database, ifNotExists bool) *ShowCreateDatabas
 	return &ShowCreateDatabase{db, ifNotExists}
 }
 
+var _ sql.Databaser = (*ShowCreateDatabase)(nil)
+
+// Database implements the sql.Databaser interface.
+func (s *ShowCreateDatabase) Database() sql.Database {
+	return s.db
+}
+
+// WithDatabase implements the sql.Databaser interface.
+func (s *ShowCreateDatabase) WithDatabase(db sql.Database) (sql.Node, error) {
+	nc := *s
+	nc.db = db
+	return &nc, nil
+}
+
 // RowIter implements the sql.Node interface.
 func (s *ShowCreateDatabase) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	var name = s.Database.Name()
+	var name = s.db.Name()
 
 	var buf bytes.Buffer
 
@@ -56,7 +70,7 @@ func (s *ShowCreateDatabase) Schema() sql.Schema {
 }
 
 func (s *ShowCreateDatabase) String() string {
-	return fmt.Sprintf("SHOW CREATE DATABASE %s", s.Database.Name())
+	return fmt.Sprintf("SHOW CREATE DATABASE %s", s.db.Name())
 }
 
 // Children implements the sql.Node interface.
@@ -64,7 +78,7 @@ func (s *ShowCreateDatabase) Children() []sql.Node { return nil }
 
 // Resolved implements the sql.Node interface.
 func (s *ShowCreateDatabase) Resolved() bool {
-	_, ok := s.Database.(sql.UnresolvedDatabase)
+	_, ok := s.db.(sql.UnresolvedDatabase)
 	return !ok
 }
 

--- a/sql/plan/use.go
+++ b/sql/plan/use.go
@@ -8,23 +8,36 @@ import (
 
 // Use changes the current database.
 type Use struct {
-	Database sql.Database
-	Catalog  *sql.Catalog
+	db      sql.Database
+	Catalog *sql.Catalog
 }
 
 // NewUse creates a new Use node.
 func NewUse(db sql.Database) *Use {
-	return &Use{Database: db}
+	return &Use{db: db}
 }
 
 var _ sql.Node = (*Use)(nil)
+var _ sql.Databaser = (*Use)(nil)
+
+// Database implements the sql.Databaser interface.
+func (u *Use) Database() sql.Database {
+	return u.db
+}
+
+// WithDatabase implements the sql.Databaser interface.
+func (u *Use) WithDatabase(db sql.Database) (sql.Node, error) {
+	nc := *u
+	nc.db = db
+	return &nc, nil
+}
 
 // Children implements the sql.Node interface.
 func (Use) Children() []sql.Node { return nil }
 
 // Resolved implements the sql.Node interface.
 func (u *Use) Resolved() bool {
-	_, ok := u.Database.(sql.UnresolvedDatabase)
+	_, ok := u.db.(sql.UnresolvedDatabase)
 	return !ok
 }
 
@@ -33,7 +46,7 @@ func (Use) Schema() sql.Schema { return nil }
 
 // RowIter implements the sql.Node interface.
 func (u *Use) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	u.Catalog.SetCurrentDatabase(u.Database.Name())
+	u.Catalog.SetCurrentDatabase(u.db.Name())
 	return sql.RowsToRowIter(), nil
 }
 
@@ -49,5 +62,5 @@ func (u *Use) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) 
 
 // String implements the sql.Node interface.
 func (u *Use) String() string {
-	return fmt.Sprintf("USE(%s)", u.Database.Name())
+	return fmt.Sprintf("USE(%s)", u.db.Name())
 }


### PR DESCRIPTION
This fixes the messy and very repeated code we had on the `resolve_database` rule, as @kuba-- pointed out in another PR.

Introduces a new interface `Databaser`, which is a node that contains a ref to a database and now all of the nodes that were changed in the `resolve_database` rule can just implement this method and handle all of them the exact same way.