### PR TITLE
server: return empty results when query is KILL

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) ComQuery(
 	}
 
 	if handled {
-		return nil
+		return callback(&sqltypes.Result{})
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Fixes #601 