### PR TITLE
Clear warnings just after successful query.

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1055,13 +1055,27 @@ func TestClearWarnings(t *testing.T) {
 	require := require.New(t)
 	e := newEngine(t)
 	ctx := newCtx()
-	ctx.Session.Warn(&sql.Warning{Code: 1})
-	ctx.Session.Warn(&sql.Warning{Code: 2})
-	ctx.Session.Warn(&sql.Warning{Code: 3})
 
-	_, iter, err := e.Query(ctx, "SHOW WARNINGS")
+	_, iter, err := e.Query(ctx, "-- some empty query as a comment")
+	require.NoError(err)
+	err = iter.Close()
+	require.NoError(err)
+
+	_, iter, err = e.Query(ctx, "-- some empty query as a comment")
+	require.NoError(err)
+	err = iter.Close()
+	require.NoError(err)
+
+	_, iter, err = e.Query(ctx, "-- some empty query as a comment")
+	require.NoError(err)
+	err = iter.Close()
+	require.NoError(err)
+
+	_, iter, err = e.Query(ctx, "SHOW WARNINGS")
 	require.NoError(err)
 	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+	err = iter.Close()
 	require.NoError(err)
 	require.Equal(3, len(rows))
 
@@ -1069,10 +1083,17 @@ func TestClearWarnings(t *testing.T) {
 	require.NoError(err)
 	rows, err = sql.RowIterToRows(iter)
 	require.NoError(err)
+	err = iter.Close()
+	require.NoError(err)
 	require.Equal(1, len(rows))
 
 	_, _, err = e.Query(ctx, "SELECT * FROM mytable LIMIT 1")
 	require.NoError(err)
+	_, err = sql.RowIterToRows(iter)
+	require.NoError(err)
+	err = iter.Close()
+	require.NoError(err)
+
 	require.Equal(0, len(ctx.Session.Warnings()))
 }
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -59,12 +59,13 @@ type BaseSession struct {
 	mu       sync.RWMutex
 	config   map[string]TypedValue
 	warnings []*Warning
+	warncnt  uint16
 }
 
 // Address returns the server address.
 func (s *BaseSession) Address() string { return s.addr }
 
-// User returns session's client information.
+// Client returns session's client information.
 func (s *BaseSession) Client() Client { return s.client }
 
 // Set implements the Session interface.
@@ -127,8 +128,15 @@ func (s *BaseSession) Warnings() []*Warning {
 func (s *BaseSession) ClearWarnings() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.warnings != nil {
-		s.warnings = s.warnings[:0]
+
+	cnt := uint16(len(s.warnings))
+	if s.warncnt == cnt {
+		if s.warnings != nil {
+			s.warnings = s.warnings[:0]
+		}
+		s.warncnt = 0
+	} else {
+		s.warncnt = cnt
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Fixes https://github.com/src-d/go-mysql-server/issues/600

`ClearWarnings`  rule will be execute after every query, but physically it will clear warnings if the query finished with success (when number of warnings didn't change). In other words `SHOW WARNINGS` will show all warnings till you run correct query.