### PR TITLE
sql/analyzer: fix use of declared aliases in the same projection

### DIFF
--- a/sql/analyzer/resolve_columns_test.go
+++ b/sql/analyzer/resolve_columns_test.go
@@ -54,7 +54,7 @@ func TestQualifyColumnsProject(t *testing.T) {
 
 func TestMisusedAlias(t *testing.T) {
 	require := require.New(t)
-	f := getRule("resolve_columns")
+	f := getRule("check_aliases")
 
 	table := mem.NewTable("mytable", sql.Schema{
 		{Name: "i", Type: sql.Int32},
@@ -71,12 +71,7 @@ func TestMisusedAlias(t *testing.T) {
 		plan.NewResolvedTable(table),
 	)
 
-	// the first iteration wrap the unresolved column "alias_i" as a maybeAlias
-	n, err := f.Apply(sql.NewEmptyContext(), nil, node)
-	require.NoError(err)
-
-	// if maybeAlias is not resolved it fails
-	_, err = f.Apply(sql.NewEmptyContext(), nil, n)
+	_, err := f.Apply(sql.NewEmptyContext(), nil, node)
 	require.EqualError(err, ErrMisusedAlias.New("alias_i").Error())
 }
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -27,6 +27,7 @@ var DefaultRules = []Rule{
 var OnceBeforeDefault = []Rule{
 	{"resolve_subqueries", resolveSubqueries},
 	{"resolve_tables", resolveTables},
+	{"check_aliases", checkAliases},
 }
 
 // OnceAfterDefault contains the rules to be applied just once after the


### PR DESCRIPTION
Fixes #590 

Since this is just a SQL syntax issue finally I've just added a new rule to check the aliases usage at the beginning of the analysis phase that runs once before the default rules. This way it doesn't interfere with the transformations made by the rest of the rules.
