### PR TITLE
Perf: Avoid call to Checksum if there are no indexes.

### DIFF
--- a/sql/index.go
+++ b/sql/index.go
@@ -229,7 +229,7 @@ func (r *IndexRegistry) LoadIndexes(dbs Databases) error {
 				}
 
 				var checksum string
-				if c, ok := t.(Checksumable); ok {
+				if c, ok := t.(Checksumable); ok && len(indexes) != 0 {
 					checksum, err = c.Checksum()
 					if err != nil {
 						return err


### PR DESCRIPTION
Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>