### PR TITLE
allow all expressions in grouping, resolve orderby expressions

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -868,6 +868,14 @@ var queries = []struct {
 		"ROLLBACK",
 		[]sql.Row{},
 	},
+	{
+		"SELECT substring(s, 1, 1) FROM mytable ORDER BY substring(s, 1, 1)",
+		[]sql.Row{{"f"}, {"s"}, {"t"}},
+	},
+	{
+		"SELECT substring(s, 1, 1), count(*) FROM mytable GROUP BY substring(s, 1, 1)",
+		[]sql.Row{{"f", int32(1)}, {"s", int32(1)}, {"t", int32(1)}},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -353,15 +353,13 @@ func updateBuffer(
 		return n.Update(ctx, buffers[idx], row)
 	case *expression.Alias:
 		return updateBuffer(ctx, buffers, idx, n.Child, row)
-	case *expression.GetField:
+	default:
 		val, err := expr.Eval(ctx, row)
 		if err != nil {
 			return err
 		}
 		buffers[idx] = sql.NewRow(val)
 		return nil
-	default:
-		return ErrGroupBy.New(n.String())
 	}
 }
 
@@ -393,12 +391,10 @@ func evalBuffer(
 		return n.Eval(ctx, buffer)
 	case *expression.Alias:
 		return evalBuffer(ctx, n.Child, buffer)
-	case *expression.GetField:
+	default:
 		if len(buffer) > 0 {
 			return buffer[0], nil
 		}
 		return nil, nil
-	default:
-		return nil, ErrGroupBy.New(n.String())
 	}
 }

--- a/sql/plan/group_by_test.go
+++ b/sql/plan/group_by_test.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation"
 )
 
-func TestGroupBy_Schema(t *testing.T) {
+func TestGroupBySchema(t *testing.T) {
 	require := require.New(t)
 
 	child := mem.NewTable("test", nil)
@@ -25,7 +25,7 @@ func TestGroupBy_Schema(t *testing.T) {
 	}, gb.Schema())
 }
 
-func TestGroupBy_Resolved(t *testing.T) {
+func TestGroupByResolved(t *testing.T) {
 	require := require.New(t)
 
 	child := mem.NewTable("test", nil)
@@ -42,7 +42,7 @@ func TestGroupBy_Resolved(t *testing.T) {
 	require.False(gb.Resolved())
 }
 
-func TestGroupBy_RowIter(t *testing.T) {
+func TestGroupByRowIter(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
@@ -96,7 +96,7 @@ func TestGroupBy_RowIter(t *testing.T) {
 	require.Equal(sql.NewRow("col1_2", int64(4444)), rows[1])
 }
 
-func TestGroupBy_EvalEmptyBuffer(t *testing.T) {
+func TestGroupByEvalEmptyBuffer(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
@@ -105,7 +105,7 @@ func TestGroupBy_EvalEmptyBuffer(t *testing.T) {
 	require.Nil(r)
 }
 
-func TestGroupBy_Error(t *testing.T) {
+func TestGroupByAggregationGrouping(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
@@ -140,8 +140,15 @@ func TestGroupBy_Error(t *testing.T) {
 		NewResolvedTable(child),
 	)
 
-	_, err := sql.NodeToRows(ctx, p)
-	require.Error(err)
+	rows, err := sql.NodeToRows(ctx, p)
+	require.NoError(err)
+
+	expected := []sql.Row{
+		{int32(3), false},
+		{int32(2), false},
+	}
+
+	require.Equal(expected, rows)
 }
 
 func BenchmarkGroupBy(b *testing.B) {


### PR DESCRIPTION
Closes #630 

This fixes 2 problems:

- Not supporting arbitrary expressions in grouping
- Not taking into account the children of the groupby expressions when reordering the projections underneath