### PR TITLE
plan: types in lowecase on SHOW CREATE TABLE

### DIFF
--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -78,7 +78,7 @@ func (i *showCreateTablesIter) Next() (sql.Row, error) {
 	composedCreateTableStatement := produceCreateStatement(table)
 
 	return sql.NewRow(
-		i.table,                      // "Table" string
+		i.table, // "Table" string
 		composedCreateTableStatement, // "Create Table" string
 	), nil
 }
@@ -89,7 +89,8 @@ func produceCreateStatement(table sql.Table) string {
 
 	// Statement creation parts for each column
 	for indx, col := range schema {
-		createStmtPart := fmt.Sprintf("  `%s` %s", col.Name, col.Type.Type())
+		createStmtPart := fmt.Sprintf("  `%s` %s", col.Name,
+			strings.ToLower(col.Type.Type().String()))
 
 		if !col.Nullable {
 			createStmtPart = fmt.Sprintf("%s NOT NULL", createStmtPart)

--- a/sql/plan/show_create_table_test.go
+++ b/sql/plan/show_create_table_test.go
@@ -37,9 +37,9 @@ func TestShowCreateTable(t *testing.T) {
 
 	expected := sql.NewRow(
 		table.Name(),
-		"CREATE TABLE `test-table` (\n  `baz` TEXT NOT NULL,\n"+
-			"  `zab` INT32 DEFAULT 0,\n"+
-			"  `bza` INT64 DEFAULT 0\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		"CREATE TABLE `test-table` (\n  `baz` text NOT NULL,\n"+
+			"  `zab` int32 DEFAULT 0,\n"+
+			"  `bza` int64 DEFAULT 0\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 	)
 
 	require.Equal(expected, row)


### PR DESCRIPTION
Signed-off-by: Máximo Cuadros <mcuadros@gmail.com>

As seen in MySQL the types in a SHOW CREATE TABLE result should be written lowercase. 
This is a requirement to make work properly SQLAlchemey, you can test the current issues with this small script:

```python
import sqlalchemy
from sqlalchemy import inspect

engine = sqlalchemy.create_engine('mysql+pymysql://root:@127.0.0.1:3306/mydb')
with engine.connect() as conn:
    inspector = inspect(engine)

    cols = inspector.get_columns("commits", "gitbase")
```

Result:

```
✗ gitbase (master) ✗ python foo.py
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'repository_id'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'commit_hash'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'commit_author_name'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'commit_author_email'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TIMESTAMP' of column 'commit_author_when'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'committer_name'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
/usr/lib/python3.7/site-packages/sqlalchemy/dialects/mysql/reflection.py:193: SAWarning: Did not recognize type 'TEXT' of column 'committer_email'
  "Did not recognize type '%s' of column '%s'" % (type_, name)
```


How looks like a `SHOW CREATE TABLE` in MySQL

```
| wp_links | CREATE TABLE `wp_links` (
  `link_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `link_url` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_name` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_image` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_target` varchar(25) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_description` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_visible` varchar(20) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT 'Y',
  `link_owner` bigint(20) unsigned NOT NULL DEFAULT '1',
  `link_rating` int(11) NOT NULL DEFAULT '0',
  `link_updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `link_rel` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  `link_notes` mediumtext COLLATE utf8mb4_unicode_520_ci NOT NULL,
  `link_rss` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
  PRIMARY KEY (`link_id`),
  KEY `link_visible` (`link_visible`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci |````