### PR TITLE
sql/parse: allow qualified table names on SHOW CREATE TABLE

### DIFF
--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1007,7 +1007,9 @@ var fixtures = map[string]sql.Node{
 		),
 		plan.NewShowCollation(),
 	),
-	`ROLLBACK`: plan.NewRollback(),
+	`ROLLBACK`:                           plan.NewRollback(),
+	"SHOW CREATE TABLE `mytable`":        plan.NewShowCreateTable("", nil, "mytable"),
+	"SHOW CREATE TABLE `mydb`.`mytable`": plan.NewShowCreateTable("mydb", nil, "mytable"),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/parse/show_create_test.go
+++ b/sql/parse/show_create_test.go
@@ -32,9 +32,27 @@ func TestParseShowCreateTableQuery(t *testing.T) {
 		},
 		{
 			"SHOW CREATE TABLE mytable",
-			plan.NewShowCreateTable(sql.UnresolvedDatabase("").Name(),
-				nil,
-				"mytable"),
+			plan.NewShowCreateTable("", nil, "mytable"),
+			nil,
+		},
+		{
+			"SHOW CREATE TABLE `mytable`",
+			plan.NewShowCreateTable("", nil, "mytable"),
+			nil,
+		},
+		{
+			"SHOW CREATE TABLE mydb.`mytable`",
+			plan.NewShowCreateTable("mydb", nil, "mytable"),
+			nil,
+		},
+		{
+			"SHOW CREATE TABLE `mydb`.mytable",
+			plan.NewShowCreateTable("mydb", nil, "mytable"),
+			nil,
+		},
+		{
+			"SHOW CREATE TABLE `mydb`.`mytable`",
+			plan.NewShowCreateTable("mydb", nil, "mytable"),
 			nil,
 		},
 	}


### PR DESCRIPTION
Fixes #662

Table names in SHOW CREATE TABLE may be qualified with the database
name. This PR adds support for optional database qualifier on SHOW
CREATE TABLE statement.