### PR TITLE
sql: add support for intervals, DATE_SUB and DATE_ADD

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ We support and actively test against certain third-party clients to ensure compa
 |`CONCAT_WS(sep, ...)`|Concatenate any group of fields into a single string. The first argument is the separator for the rest of the arguments. The separator is added between the strings to be concatenated. The separator can be a string, as can the rest of the arguments. If the separator is NULL, the result is NULL.|
 |`CONNECTION_ID()`|Return the current connection ID.|
 |`COUNT(expr)`| Returns a count of the number of non-NULL values of expr in the rows retrieved by a SELECT statement.|
+|`DATE_ADD(date, interval)`|Adds the interval to the given date.|
+|`DATE_SUB(date, interval)`|Subtracts the interval from the given date.|
 |`DAY(date)`|Returns the day of the given date.|
 |`DAYOFWEEK(date)`|Returns the day of the week of the given date.|
 |`DAYOFYEAR(date)`|Returns the day of the year of the given date.|

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -50,6 +50,7 @@
 - USE
 - SHOW DATABASES
 - SHOW WARNINGS
+- INTERVALS
 
 ## Index expressions
 - CREATE INDEX (an index can be created using either column names or a single arbitrary expression).
@@ -67,8 +68,8 @@
 - OR
 
 ## Arithmetic expressions
-- \+
-- \-
+- \+ (including between dates and intervals)
+- \- (including between dates and intervals)
 - \*
 - \\
 - <<
@@ -125,3 +126,5 @@
 - YEAR
 - YEARWEEK
 - NOW
+- DATE_ADD
+- DATE_SUB

--- a/engine_test.go
+++ b/engine_test.go
@@ -909,6 +909,22 @@ var queries = []struct {
 		"SELECT FROM_BASE64('YmFy')",
 		[]sql.Row{{string("bar")}},
 	},
+	{
+		"SELECT DATE_ADD('2018-05-02', INTERVAL 1 DAY)",
+		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
+		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT '2018-05-02' + INTERVAL 1 DAY",
+		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT '2018-05-02' - INTERVAL 1 DAY",
+		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/expression/arithmetic_test.go
+++ b/sql/expression/arithmetic_test.go
@@ -2,6 +2,7 @@ package expression
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -38,6 +39,29 @@ func TestPlus(t *testing.T) {
 	require.Equal(float64(5), result)
 }
 
+func TestPlusInterval(t *testing.T) {
+	require := require.New(t)
+
+	expected := time.Date(2018, time.May, 2, 0, 0, 0, 0, time.UTC)
+	op := NewPlus(
+		NewLiteral("2018-05-01", sql.Text),
+		NewInterval(NewLiteral(int64(1), sql.Int64), "DAY"),
+	)
+
+	result, err := op.Eval(sql.NewEmptyContext(), nil)
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	op = NewPlus(
+		NewInterval(NewLiteral(int64(1), sql.Int64), "DAY"),
+		NewLiteral("2018-05-01", sql.Text),
+	)
+
+	result, err = op.Eval(sql.NewEmptyContext(), nil)
+	require.NoError(err)
+	require.Equal(expected, result)
+}
+
 func TestMinus(t *testing.T) {
 	var testCases = []struct {
 		name        string
@@ -67,6 +91,20 @@ func TestMinus(t *testing.T) {
 		Eval(sql.NewEmptyContext(), sql.NewRow())
 	require.NoError(err)
 	require.Equal(float64(0), result)
+}
+
+func TestMinusInterval(t *testing.T) {
+	require := require.New(t)
+
+	expected := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)
+	op := NewMinus(
+		NewLiteral("2018-05-02", sql.Text),
+		NewInterval(NewLiteral(int64(1), sql.Int64), "DAY"),
+	)
+
+	result, err := op.Eval(sql.NewEmptyContext(), nil)
+	require.NoError(err)
+	require.Equal(expected, result)
 }
 
 func TestMult(t *testing.T) {

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -1,0 +1,177 @@
+package function
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+// DateAdd adds an interval to a date.
+type DateAdd struct {
+	Date     sql.Expression
+	Interval *expression.Interval
+}
+
+// NewDateAdd creates a new date add function.
+func NewDateAdd(args ...sql.Expression) (sql.Expression, error) {
+	if len(args) != 2 {
+		return nil, sql.ErrInvalidArgumentNumber.New("DATE_ADD", 2, len(args))
+	}
+
+	i, ok := args[1].(*expression.Interval)
+	if !ok {
+		return nil, fmt.Errorf("DATE_ADD expects an interval as second parameter")
+	}
+
+	return &DateAdd{args[0], i}, nil
+}
+
+// Children implements the sql.Expression interface.
+func (d *DateAdd) Children() []sql.Expression {
+	return []sql.Expression{d.Date, d.Interval}
+}
+
+// Resolved implements the sql.Expression interface.
+func (d *DateAdd) Resolved() bool {
+	return d.Date.Resolved() && d.Interval.Resolved()
+}
+
+// IsNullable implements the sql.Expression interface.
+func (d *DateAdd) IsNullable() bool {
+	return d.Date.IsNullable() || d.Interval.IsNullable()
+}
+
+// Type implements the sql.Expression interface.
+func (d *DateAdd) Type() sql.Type { return sql.Date }
+
+// TransformUp implements the sql.Expression interface.
+func (d *DateAdd) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
+	date, err := d.Date.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	interval, err := d.Interval.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DateAdd{date, interval.(*expression.Interval)}, nil
+}
+
+// Eval implements the sql.Expression interface.
+func (d *DateAdd) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	date, err := d.Date.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if date == nil {
+		return nil, nil
+	}
+
+	date, err = sql.Timestamp.Convert(date)
+	if err != nil {
+		return nil, err
+	}
+
+	delta, err := d.Interval.EvalDelta(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if delta == nil {
+		return nil, nil
+	}
+
+	return delta.Add(date.(time.Time)), nil
+}
+
+func (d *DateAdd) String() string {
+	return fmt.Sprintf("DATE_ADD(%s, %s)", d.Date, d.Interval)
+}
+
+// DateSub subtracts an interval from a date.
+type DateSub struct {
+	Date     sql.Expression
+	Interval *expression.Interval
+}
+
+// NewDateSub creates a new date add function.
+func NewDateSub(args ...sql.Expression) (sql.Expression, error) {
+	if len(args) != 2 {
+		return nil, sql.ErrInvalidArgumentNumber.New("DATE_SUB", 2, len(args))
+	}
+
+	i, ok := args[1].(*expression.Interval)
+	if !ok {
+		return nil, fmt.Errorf("DATE_SUB expects an interval as second parameter")
+	}
+
+	return &DateSub{args[0], i}, nil
+}
+
+// Children implements the sql.Expression interface.
+func (d *DateSub) Children() []sql.Expression {
+	return []sql.Expression{d.Date, d.Interval}
+}
+
+// Resolved implements the sql.Expression interface.
+func (d *DateSub) Resolved() bool {
+	return d.Date.Resolved() && d.Interval.Resolved()
+}
+
+// IsNullable implements the sql.Expression interface.
+func (d *DateSub) IsNullable() bool {
+	return d.Date.IsNullable() || d.Interval.IsNullable()
+}
+
+// Type implements the sql.Expression interface.
+func (d *DateSub) Type() sql.Type { return sql.Date }
+
+// TransformUp implements the sql.Expression interface.
+func (d *DateSub) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
+	date, err := d.Date.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+	interval, err := d.Interval.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DateSub{date, interval.(*expression.Interval)}, nil
+}
+
+// Eval implements the sql.Expression interface.
+func (d *DateSub) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	date, err := d.Date.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if date == nil {
+		return nil, nil
+	}
+
+	date, err = sql.Timestamp.Convert(date)
+	if err != nil {
+		return nil, err
+	}
+
+	delta, err := d.Interval.EvalDelta(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if delta == nil {
+		return nil, nil
+	}
+
+	return delta.Sub(date.(time.Time)), nil
+}
+
+func (d *DateSub) String() string {
+	return fmt.Sprintf("DATE_SUB(%s, %s)", d.Date, d.Interval)
+}

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -1,0 +1,87 @@
+package function
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestDateAdd(t *testing.T) {
+	require := require.New(t)
+
+	_, err := NewDateAdd()
+	require.Error(err)
+
+	_, err = NewDateAdd(expression.NewLiteral("2018-05-02", sql.Text))
+	require.Error(err)
+
+	_, err = NewDateAdd(
+		expression.NewLiteral("2018-05-02", sql.Text),
+		expression.NewLiteral(int64(1), sql.Int64),
+	)
+	require.Error(err)
+
+	f, err := NewDateAdd(
+		expression.NewGetField(0, sql.Text, "foo", false),
+		expression.NewInterval(
+			expression.NewLiteral(int64(1), sql.Int64),
+			"DAY",
+		),
+	)
+	require.NoError(err)
+
+	ctx := sql.NewEmptyContext()
+	expected := time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)
+
+	result, err := f.Eval(ctx, sql.Row{"2018-05-02"})
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	result, err = f.Eval(ctx, sql.Row{nil})
+	require.NoError(err)
+	require.Nil(result)
+
+	_, err = f.Eval(ctx, sql.Row{"asdasdasd"})
+	require.Error(err)
+}
+func TestDateSub(t *testing.T) {
+	require := require.New(t)
+
+	_, err := NewDateSub()
+	require.Error(err)
+
+	_, err = NewDateSub(expression.NewLiteral("2018-05-02", sql.Text))
+	require.Error(err)
+
+	_, err = NewDateSub(
+		expression.NewLiteral("2018-05-02", sql.Text),
+		expression.NewLiteral(int64(1), sql.Int64),
+	)
+	require.Error(err)
+
+	f, err := NewDateSub(
+		expression.NewGetField(0, sql.Text, "foo", false),
+		expression.NewInterval(
+			expression.NewLiteral(int64(1), sql.Int64),
+			"DAY",
+		),
+	)
+	require.NoError(err)
+
+	ctx := sql.NewEmptyContext()
+	expected := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)
+
+	result, err := f.Eval(ctx, sql.Row{"2018-05-02"})
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	result, err = f.Eval(ctx, sql.Row{nil})
+	require.NoError(err)
+	require.Nil(result)
+
+	_, err = f.Eval(ctx, sql.Row{"asdasdasd"})
+	require.Error(err)
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -78,4 +78,6 @@ var Defaults = []sql.Function{
 	sql.Function1{Name: "sleep", Fn: NewSleep},
 	sql.Function1{Name: "to_base64", Fn: NewToBase64},
 	sql.Function1{Name: "from_base64", Fn: NewFromBase64},
+	sql.FunctionN{Name: "date_add", Fn: NewDateAdd},
+	sql.FunctionN{Name: "date_sub", Fn: NewDateSub},
 }

--- a/sql/expression/interval.go
+++ b/sql/expression/interval.go
@@ -1,0 +1,286 @@
+package expression
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+// Interval defines a time duration.
+type Interval struct {
+	UnaryExpression
+	Unit string
+}
+
+// NewInterval creates a new interval expression.
+func NewInterval(child sql.Expression, unit string) *Interval {
+	return &Interval{UnaryExpression{Child: child}, strings.ToUpper(unit)}
+}
+
+// Type implements the sql.Expression interface.
+func (i *Interval) Type() sql.Type { return sql.Uint64 }
+
+// IsNullable implements the sql.Expression interface.
+func (i *Interval) IsNullable() bool { return i.Child.IsNullable() }
+
+// Eval implements the sql.Expression interface.
+func (i *Interval) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	panic("Interval.Eval is just a placeholder method and should not be called directly")
+}
+
+var (
+	errInvalidIntervalUnit   = errors.NewKind("invalid interval unit: %s")
+	errInvalidIntervalFormat = errors.NewKind("invalid interval format for %q: %s")
+)
+
+// EvalDelta evaluates the expression returning a TimeDelta. This method should
+// be used instead of Eval, as this expression returns a TimeDelta, which is not
+// a valid value that can be returned in Eval.
+func (i *Interval) EvalDelta(ctx *sql.Context, row sql.Row) (*TimeDelta, error) {
+	val, err := i.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if val == nil {
+		return nil, nil
+	}
+
+	var td TimeDelta
+
+	if r, ok := unitTextFormats[i.Unit]; ok {
+		val, err = sql.Text.Convert(val)
+		if err != nil {
+			return nil, err
+		}
+
+		text := val.(string)
+		if !r.MatchString(text) {
+			return nil, errInvalidIntervalFormat.New(i.Unit, text)
+		}
+
+		parts := textFormatParts(text, r)
+
+		switch i.Unit {
+		case "DAY_HOUR":
+			td.Days = parts[0]
+			td.Hours = parts[1]
+		case "DAY_MICROSECOND":
+			td.Days = parts[0]
+			td.Hours = parts[1]
+			td.Minutes = parts[2]
+			td.Seconds = parts[3]
+			td.Microseconds = parts[4]
+		case "DAY_MINUTE":
+			td.Days = parts[0]
+			td.Hours = parts[1]
+			td.Minutes = parts[2]
+		case "DAY_SECOND":
+			td.Days = parts[0]
+			td.Hours = parts[1]
+			td.Minutes = parts[2]
+			td.Seconds = parts[3]
+		case "HOUR_MICROSECOND":
+			td.Hours = parts[0]
+			td.Minutes = parts[1]
+			td.Seconds = parts[2]
+			td.Microseconds = parts[3]
+		case "HOUR_SECOND":
+			td.Hours = parts[0]
+			td.Minutes = parts[1]
+			td.Seconds = parts[2]
+		case "HOUR_MINUTE":
+			td.Hours = parts[0]
+			td.Minutes = parts[1]
+		case "MINUTE_MICROSECOND":
+			td.Minutes = parts[0]
+			td.Seconds = parts[1]
+			td.Microseconds = parts[2]
+		case "MINUTE_SECOND":
+			td.Minutes = parts[0]
+			td.Seconds = parts[1]
+		case "SECOND_MICROSECOND":
+			td.Seconds = parts[0]
+			td.Microseconds = parts[1]
+		case "YEAR_MONTH":
+			td.Years = parts[0]
+			td.Months = parts[1]
+		default:
+			return nil, errInvalidIntervalUnit.New(i.Unit)
+		}
+	} else {
+		val, err = sql.Int64.Convert(val)
+		if err != nil {
+			return nil, err
+		}
+
+		num := val.(int64)
+
+		switch i.Unit {
+		case "DAY":
+			td.Days = num
+		case "HOUR":
+			td.Hours = num
+		case "MINUTE":
+			td.Minutes = num
+		case "SECOND":
+			td.Seconds = num
+		case "MICROSECOND":
+			td.Microseconds = num
+		case "QUARTER":
+			td.Months = num * 3
+		case "MONTH":
+			td.Months = num
+		case "WEEK":
+			td.Days = num * 7
+		case "YEAR":
+			td.Years = num
+		default:
+			return nil, errInvalidIntervalUnit.New(i.Unit)
+		}
+	}
+
+	return &td, nil
+}
+
+// TransformUp implements the sql.Expression interface.
+func (i *Interval) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
+	child, err := i.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewInterval(child, i.Unit), nil
+}
+
+func (i *Interval) String() string {
+	return fmt.Sprintf("INTERVAL %s %s", i.Child, i.Unit)
+}
+
+var unitTextFormats = map[string]*regexp.Regexp{
+	"DAY_HOUR":           regexp.MustCompile(`^(\d+)\s+(\d+)$`),
+	"DAY_MICROSECOND":    regexp.MustCompile(`^(\d+)\s+(\d+):(\d+):(\d+).(\d+)$`),
+	"DAY_MINUTE":         regexp.MustCompile(`^(\d+)\s+(\d+):(\d+)$`),
+	"DAY_SECOND":         regexp.MustCompile(`^(\d+)\s+(\d+):(\d+):(\d+)$`),
+	"HOUR_MICROSECOND":   regexp.MustCompile(`^(\d+):(\d+):(\d+).(\d+)$`),
+	"HOUR_SECOND":        regexp.MustCompile(`^(\d+):(\d+):(\d+)$`),
+	"HOUR_MINUTE":        regexp.MustCompile(`^(\d+):(\d+)$`),
+	"MINUTE_MICROSECOND": regexp.MustCompile(`^(\d+):(\d+).(\d+)$`),
+	"MINUTE_SECOND":      regexp.MustCompile(`^(\d+):(\d+)$`),
+	"SECOND_MICROSECOND": regexp.MustCompile(`^(\d+).(\d+)$`),
+	"YEAR_MONTH":         regexp.MustCompile(`^(\d+)-(\d+)$`),
+}
+
+func textFormatParts(text string, r *regexp.Regexp) []int64 {
+	parts := r.FindStringSubmatch(text)
+	var result []int64
+	for _, p := range parts[1:] {
+		// It is safe to igore the error here, because at this point we know
+		// the string matches the regexp, and that means it can't be an
+		// invalid number.
+		n, _ := strconv.ParseInt(p, 10, 64)
+		result = append(result, n)
+	}
+	return result
+}
+
+// TimeDelta is the difference between a time and another time.
+type TimeDelta struct {
+	Years        int64
+	Months       int64
+	Days         int64
+	Hours        int64
+	Minutes      int64
+	Seconds      int64
+	Microseconds int64
+}
+
+// Add returns the given time plus the time delta.
+func (td TimeDelta) Add(t time.Time) time.Time {
+	return td.apply(t, 1)
+}
+
+// Sub returns the given time minus the time delta.
+func (td TimeDelta) Sub(t time.Time) time.Time {
+	return td.apply(t, -1)
+}
+
+const (
+	day  = 24 * time.Hour
+	week = 7 * day
+)
+
+func (td TimeDelta) apply(t time.Time, sign int64) time.Time {
+	y := int64(t.Year())
+	mo := int64(t.Month())
+	d := t.Day()
+	h := t.Hour()
+	min := t.Minute()
+	s := t.Second()
+	ns := t.Nanosecond()
+
+	if td.Years != 0 {
+		y += td.Years * sign
+	}
+
+	if td.Months != 0 {
+		m := mo + td.Months*sign
+		if m < 1 {
+			mo = 12 + (m % 12)
+			y += m/12 - 1
+		} else if m > 12 {
+			mo = m % 12
+			y += m / 12
+		} else {
+			mo = m
+		}
+
+		// Due to the operations done before, month may be zero, which means it's
+		// december.
+		if mo == 0 {
+			mo = 12
+		}
+	}
+
+	if days := daysInMonth(time.Month(mo), int(y)); days < d {
+		d = days
+	}
+
+	date := time.Date(int(y), time.Month(mo), d, h, min, s, ns, t.Location())
+
+	if td.Days != 0 {
+		date = date.Add(time.Duration(td.Days) * day * time.Duration(sign))
+	}
+
+	if td.Hours != 0 {
+		date = date.Add(time.Duration(td.Hours) * time.Hour * time.Duration(sign))
+	}
+
+	if td.Minutes != 0 {
+		date = date.Add(time.Duration(td.Minutes) * time.Minute * time.Duration(sign))
+	}
+
+	if td.Seconds != 0 {
+		date = date.Add(time.Duration(td.Seconds) * time.Second * time.Duration(sign))
+	}
+
+	if td.Microseconds != 0 {
+		date = date.Add(time.Duration(td.Microseconds) * time.Microsecond * time.Duration(sign))
+	}
+
+	return date
+}
+
+func daysInMonth(month time.Month, year int) int {
+	if month == time.December {
+		return 31
+	}
+
+	date := time.Date(year, month+time.Month(1), 1, 0, 0, 0, 0, time.Local)
+	return date.Add(-1 * day).Day()
+}

--- a/sql/expression/interval_test.go
+++ b/sql/expression/interval_test.go
@@ -1,0 +1,285 @@
+package expression
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestTimeDelta(t *testing.T) {
+	leapYear := date(2004, time.February, 29, 0, 0, 0, 0)
+	testCases := []struct {
+		name   string
+		delta  TimeDelta
+		date   time.Time
+		output time.Time
+	}{
+		{
+			"leap year minus one year",
+			TimeDelta{Years: -1},
+			leapYear,
+			date(2003, time.February, 28, 0, 0, 0, 0),
+		},
+		{
+			"leap year plus one year",
+			TimeDelta{Years: 1},
+			leapYear,
+			date(2005, time.February, 28, 0, 0, 0, 0),
+		},
+		{
+			"plus overflowing months",
+			TimeDelta{Months: 13},
+			leapYear,
+			date(2005, time.March, 29, 0, 0, 0, 0),
+		},
+		{
+			"plus overflowing until december",
+			TimeDelta{Months: 22},
+			leapYear,
+			date(2006, time.December, 29, 0, 0, 0, 0),
+		},
+		{
+			"minus overflowing months",
+			TimeDelta{Months: -13},
+			leapYear,
+			date(2003, time.January, 29, 0, 0, 0, 0),
+		},
+		{
+			"minus overflowing until december",
+			TimeDelta{Months: -14},
+			leapYear,
+			date(2002, time.December, 29, 0, 0, 0, 0),
+		},
+		{
+			"minus months",
+			TimeDelta{Months: -1},
+			leapYear,
+			date(2004, time.January, 29, 0, 0, 0, 0),
+		},
+		{
+			"plus months",
+			TimeDelta{Months: 1},
+			leapYear,
+			date(2004, time.March, 29, 0, 0, 0, 0),
+		},
+		{
+			"minus days",
+			TimeDelta{Days: -2},
+			leapYear,
+			date(2004, time.February, 27, 0, 0, 0, 0),
+		},
+		{
+			"plus days",
+			TimeDelta{Days: 1},
+			leapYear,
+			date(2004, time.March, 1, 0, 0, 0, 0),
+		},
+		{
+			"minus hours",
+			TimeDelta{Hours: -2},
+			leapYear,
+			date(2004, time.February, 28, 22, 0, 0, 0),
+		},
+		{
+			"plus hours",
+			TimeDelta{Hours: 26},
+			leapYear,
+			date(2004, time.March, 1, 2, 0, 0, 0),
+		},
+		{
+			"minus minutes",
+			TimeDelta{Minutes: -2},
+			leapYear,
+			date(2004, time.February, 28, 23, 58, 0, 0),
+		},
+		{
+			"plus minutes",
+			TimeDelta{Minutes: 26},
+			leapYear,
+			date(2004, time.February, 29, 0, 26, 0, 0),
+		},
+		{
+			"minus seconds",
+			TimeDelta{Seconds: -2},
+			leapYear,
+			date(2004, time.February, 28, 23, 59, 58, 0),
+		},
+		{
+			"plus seconds",
+			TimeDelta{Seconds: 26},
+			leapYear,
+			date(2004, time.February, 29, 0, 0, 26, 0),
+		},
+		{
+			"minus microseconds",
+			TimeDelta{Microseconds: -2},
+			leapYear,
+			date(2004, time.February, 28, 23, 59, 59, 999998),
+		},
+		{
+			"plus microseconds",
+			TimeDelta{Microseconds: 26},
+			leapYear,
+			date(2004, time.February, 29, 0, 0, 0, 26),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.delta.Add(tt.date)
+			require.Equal(t, tt.output, result)
+		})
+	}
+}
+
+func TestIntervalEvalDelta(t *testing.T) {
+	testCases := []struct {
+		expr     sql.Expression
+		unit     string
+		row      sql.Row
+		expected TimeDelta
+	}{
+		{
+			NewGetField(0, sql.Int64, "foo", false),
+			"DAY",
+			sql.Row{int64(2)},
+			TimeDelta{Days: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"DAY",
+			nil,
+			TimeDelta{Days: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"MONTH",
+			nil,
+			TimeDelta{Months: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"YEAR",
+			nil,
+			TimeDelta{Years: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"QUARTER",
+			nil,
+			TimeDelta{Months: 6},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"WEEK",
+			nil,
+			TimeDelta{Days: 14},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"HOUR",
+			nil,
+			TimeDelta{Hours: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"MINUTE",
+			nil,
+			TimeDelta{Minutes: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"SECOND",
+			nil,
+			TimeDelta{Seconds: 2},
+		},
+		{
+			NewLiteral(int64(2), sql.Int64),
+			"MICROSECOND",
+			nil,
+			TimeDelta{Microseconds: 2},
+		},
+		{
+			NewLiteral("2 3", sql.Text),
+			"DAY_HOUR",
+			nil,
+			TimeDelta{Days: 2, Hours: 3},
+		},
+		{
+			NewLiteral("2 3:04:05.06", sql.Text),
+			"DAY_MICROSECOND",
+			nil,
+			TimeDelta{Days: 2, Hours: 3, Minutes: 4, Seconds: 5, Microseconds: 6},
+		},
+		{
+			NewLiteral("2 3:04:05", sql.Text),
+			"DAY_SECOND",
+			nil,
+			TimeDelta{Days: 2, Hours: 3, Minutes: 4, Seconds: 5},
+		},
+		{
+			NewLiteral("2 3:04", sql.Text),
+			"DAY_MINUTE",
+			nil,
+			TimeDelta{Days: 2, Hours: 3, Minutes: 4},
+		},
+		{
+			NewLiteral("3:04:05.06", sql.Text),
+			"HOUR_MICROSECOND",
+			nil,
+			TimeDelta{Hours: 3, Minutes: 4, Seconds: 5, Microseconds: 6},
+		},
+		{
+			NewLiteral("3:04:05", sql.Text),
+			"HOUR_SECOND",
+			nil,
+			TimeDelta{Hours: 3, Minutes: 4, Seconds: 5},
+		},
+		{
+			NewLiteral("3:04", sql.Text),
+			"HOUR_MINUTE",
+			nil,
+			TimeDelta{Hours: 3, Minutes: 4},
+		},
+		{
+			NewLiteral("04:05.06", sql.Text),
+			"MINUTE_MICROSECOND",
+			nil,
+			TimeDelta{Minutes: 4, Seconds: 5, Microseconds: 6},
+		},
+		{
+			NewLiteral("04:05", sql.Text),
+			"MINUTE_SECOND",
+			nil,
+			TimeDelta{Minutes: 4, Seconds: 5},
+		},
+		{
+			NewLiteral("04.05", sql.Text),
+			"SECOND_MICROSECOND",
+			nil,
+			TimeDelta{Seconds: 4, Microseconds: 5},
+		},
+		{
+			NewLiteral("1-5", sql.Text),
+			"YEAR_MONTH",
+			nil,
+			TimeDelta{Years: 1, Months: 5},
+		},
+	}
+
+	for _, tt := range testCases {
+		interval := NewInterval(tt.expr, tt.unit)
+		t.Run(interval.String(), func(t *testing.T) {
+			require := require.New(t)
+			result, err := interval.EvalDelta(sql.NewEmptyContext(), tt.row)
+			require.NoError(err)
+			require.Equal(tt.expected, *result)
+		})
+	}
+}
+
+func date(year int, month time.Month, day, hour, min, sec, micro int) time.Time {
+	return time.Date(year, month, day, hour, min, sec, micro*int(time.Microsecond), time.Local)
+}


### PR DESCRIPTION
Fixes #663

This PR introduces a few new features:
- Correctly parsing interval expressions.
- Allow using the + and - operators to subtract from and add to
  dates. e.g. `'2019-04-10' - INTERVAL 1 DAY`.
- New `DATE_ADD` function, which is essentially the same as
  `DATE + INTERVAL`.
- New `DATE_SUB` function, which is essentially the same as
  `DATE - INTERVAL`.
- Validation rule to ensure intervals are only used in certain
  specific places, such as DATE_SUB, DATE_ADD, + and -. Using it
  anywhere else is not valid SQL, but vitess does not catch those
  errors. Plus, even if it's an expression for convenience, its
  `Eval` method is a stub and panics, so it should not be used
  unless it's in an expression that knows how to deal with intervals.
