### PR TITLE
server: correctly set binary charset on blob fields

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -221,11 +221,9 @@ func rowToSQL(s sql.Schema, row sql.Row) []sqltypes.Value {
 func schemaToFields(s sql.Schema) []*query.Field {
 	fields := make([]*query.Field, len(s))
 	for i, c := range s {
-		var charset uint32
-		if c.Type.Type() == mysql.TypeBlob {
+		var charset uint32 = mysql.CharacterSetUtf8
+		if c.Type == sql.Blob {
 			charset = mysql.CharacterSetBinary
-		} else {
-			charset = mysql.CharacterSetUtf8
 		}
 
 		fields[i] = &query.Field{

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-vitess.v1/mysql"
 	"gopkg.in/src-d/go-vitess.v1/sqltypes"
+	"gopkg.in/src-d/go-vitess.v1/vt/proto/query"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/require"
@@ -222,4 +223,23 @@ func assertNoConnProcesses(t *testing.T, e *sqle.Engine, conn uint32) {
 			t.Errorf("expecting no processes with connection id %d", conn)
 		}
 	}
+}
+
+func TestSchemaToFields(t *testing.T) {
+	require := require.New(t)
+
+	schema := sql.Schema{
+		{Name: "foo", Type: sql.Blob},
+		{Name: "bar", Type: sql.Text},
+		{Name: "baz", Type: sql.Int64},
+	}
+
+	expected := []*query.Field{
+		{Name: "foo", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary},
+		{Name: "bar", Type: query.Type_TEXT, Charset: mysql.CharacterSetUtf8},
+		{Name: "baz", Type: query.Type_INT64, Charset: mysql.CharacterSetUtf8},
+	}
+
+	fields := schemaToFields(schema)
+	require.Equal(expected, fields)
 }


### PR DESCRIPTION
Before, there was an incorrect comparison to check whether the
field was a blob or not. That resulted in all fields, including
blobs, having the UTF8 charset. Now all fields have UTF8 charset
except for BLOBs, which have binary charset.

Also, a test has been added to ensure a correct behaviour.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>