### PR TITLE
sql/plan: make sure outdated indexes can be dropped

### DIFF
--- a/sql/plan/drop_index.go
+++ b/sql/plan/drop_index.go
@@ -62,7 +62,7 @@ func (d *DropIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}
 	d.Catalog.ReleaseIndex(index)
 
-	if !d.Catalog.CanUseIndex(index) {
+	if !d.Catalog.CanRemoveIndex(index) {
 		return nil, ErrIndexNotAvailable.New(d.Name)
 	}
 

--- a/sql/plan/drop_index_test.go
+++ b/sql/plan/drop_index_test.go
@@ -97,3 +97,47 @@ func TestDeleteIndexNotReady(t *testing.T) {
 	close(done)
 	<-ready
 }
+
+func TestDeleteIndexOutdated(t *testing.T) {
+	require := require.New(t)
+
+	table := mem.NewTable("foo", sql.Schema{
+		{Name: "a", Source: "foo"},
+		{Name: "b", Source: "foo"},
+		{Name: "c", Source: "foo"},
+	})
+
+	driver := new(mockDriver)
+	catalog := sql.NewCatalog()
+	catalog.RegisterIndexDriver(driver)
+	db := mem.NewDatabase("foo")
+	db.AddTable("foo", table)
+	catalog.AddDatabase(db)
+
+	var expressions = []sql.Expression{
+		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
+		expression.NewGetFieldWithTable(1, sql.Int64, "foo", "a", true),
+	}
+
+	done, ready, err := catalog.AddIndex(&mockIndex{id: "idx", db: "foo", table: "foo", exprs: expressions})
+	require.NoError(err)
+	close(done)
+	<-ready
+
+	idx := catalog.Index("foo", "idx")
+	require.NotNil(idx)
+	catalog.ReleaseIndex(idx)
+	catalog.MarkOutdated(idx)
+
+	di := NewDropIndex("idx", NewResolvedTable(table))
+	di.Catalog = catalog
+	di.CurrentDatabase = "foo"
+
+	_, err = di.RowIter(sql.NewEmptyContext())
+	require.NoError(err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal([]string{"idx"}, driver.deleted)
+	require.Nil(catalog.Index("foo", "idx"))
+}


### PR DESCRIPTION
Fixes #674

Status of the index was not being correctly checked, so outdated
indexes could not be dropped.
Also, the message stating you could drop the index was not printing
correct SQL, not it does.