### PR TITLE
sql/analyzer: correctly qualify aliases with the same name as col

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -925,6 +925,10 @@ var queries = []struct {
 		"SELECT '2018-05-02' - INTERVAL 1 DAY",
 		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
 	},
+	{
+		`SELECT i AS i FROM mytable ORDER BY i`,
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -197,7 +197,7 @@ func fixRemainingFieldsIndexes(n sql.Node) (sql.Node, error) {
 
 				idx, ok := indexes[tableColumnPair{gf.Table(), gf.Name()}]
 				if !ok {
-					return nil, fmt.Errorf("unable to find column %q of table %q", gf.Name(), gf.Table())
+					return nil, ErrColumnTableNotFound.New(gf.Table(), gf.Name())
 				}
 
 				if idx == gf.Index() {

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -375,8 +375,6 @@ func (d *YearWeek) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, errors.New("YEARWEEK: invalid day")
 	}
 
-	fmt.Println(yyyy, mm, dd)
-
 	mode := int64(0)
 	val, err := d.mode.Eval(ctx, row)
 	if err != nil {


### PR DESCRIPTION
Fixes #675

When there was an alias with the same name as a column in a table,
the column was qualified with the table instead of referencing the
alias.