### PR TITLE
sql/expression: relaxed json_extract

### DIFF
--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -69,10 +69,12 @@ func (j *JSONExtract) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, err
 		}
 
-		result[i], err = jsonpath.JsonPathLookup(doc, path.(string))
+		c, err := jsonpath.Compile(path.(string))
 		if err != nil {
 			return nil, err
 		}
+
+		result[i], _ = c.Lookup(doc) // err ignored
 	}
 
 	if len(result) == 1 {


### PR DESCRIPTION
In the current implementation a query stops to be executed when one of the rows is empty or doesn't fit the json path expression, this PR allows any failure on the query to a value, but fails on a wrong expression. 