### PR TITLE
sql: implement HAVING clause

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -508,6 +508,7 @@ var queries = []struct {
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 		},
 	},
 	{
@@ -515,6 +516,7 @@ var queries = []struct {
 		[]sql.Row{
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 		},
 	},
 	{
@@ -636,6 +638,7 @@ var queries = []struct {
 			{"mytable"},
 			{"othertable"},
 			{"tabletest"},
+			{"bigtable"},
 		},
 	},
 	{
@@ -659,6 +662,8 @@ var queries = []struct {
 			{"i"},
 			{"s2"},
 			{"i2"},
+			{"t"},
+			{"n"},
 		},
 	},
 	{
@@ -672,6 +677,8 @@ var queries = []struct {
 			{"i"},
 			{"s2"},
 			{"i2"},
+			{"t"},
+			{"n"},
 		},
 	},
 	{
@@ -685,6 +692,8 @@ var queries = []struct {
 			{"i"},
 			{"s2"},
 			{"i2"},
+			{"t"},
+			{"n"},
 		},
 	},
 	{
@@ -718,6 +727,7 @@ var queries = []struct {
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
 		},
 	},
 	{
@@ -828,6 +838,7 @@ var queries = []struct {
 			{"mytable"},
 			{"othertable"},
 			{"tabletest"},
+			{"bigtable"},
 		},
 	},
 	{
@@ -836,14 +847,7 @@ var queries = []struct {
 			{"mytable", "BASE TABLE"},
 			{"othertable", "BASE TABLE"},
 			{"tabletest", "BASE TABLE"},
-		},
-	},
-	{
-		"SHOW FULL TABLES",
-		[]sql.Row{
-			{"mytable", "BASE TABLE"},
-			{"othertable", "BASE TABLE"},
-			{"tabletest", "BASE TABLE"},
+			{"bigtable", "BASE TABLE"},
 		},
 	},
 	{
@@ -857,6 +861,7 @@ var queries = []struct {
 		[]sql.Row{
 			{"mytable"},
 			{"othertable"},
+			{"bigtable"},
 		},
 	},
 	{
@@ -948,6 +953,26 @@ var queries = []struct {
 			{int64(2), int64(1)},
 			{int64(3), int64(1)},
 		},
+	},
+	{
+		"SELECT n, COUNT(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+		[]sql.Row{{int64(1), int64(3)}, {int64(2), int64(3)}},
+	},
+	{
+		"SELECT n, MAX(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
+	},
+	{
+		"SELECT substring(mytable.s, 1, 5) as s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
+		[]sql.Row{{"secon"}},
+	},
+	{
+		`
+		SELECT COLUMN_NAME as COLUMN_NAME FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME LIKE '%table'
+		GROUP BY 1 HAVING SUBSTRING(COLUMN_NAME, 1, 1) = "s"
+		`,
+		[]sql.Row{{"s"}, {"s2"}},
 	},
 }
 
@@ -1625,10 +1650,34 @@ func newEngineWithParallelism(t *testing.T, parallelism int) *sqle.Engine {
 		sql.NewRow("c", int32(0)),
 	)
 
+	bigtable := mem.NewPartitionedTable("bigtable", sql.Schema{
+		{Name: "t", Type: sql.Text, Source: "bigtable"},
+		{Name: "n", Type: sql.Int64, Source: "bigtable"},
+	}, testNumPartitions)
+
+	insertRows(
+		t, bigtable,
+		sql.NewRow("a", int64(1)),
+		sql.NewRow("s", int64(2)),
+		sql.NewRow("f", int64(3)),
+		sql.NewRow("g", int64(1)),
+		sql.NewRow("h", int64(2)),
+		sql.NewRow("j", int64(3)),
+		sql.NewRow("k", int64(1)),
+		sql.NewRow("l", int64(2)),
+		sql.NewRow("ñ", int64(4)),
+		sql.NewRow("z", int64(5)),
+		sql.NewRow("x", int64(6)),
+		sql.NewRow("c", int64(7)),
+		sql.NewRow("v", int64(8)),
+		sql.NewRow("b", int64(9)),
+	)
+
 	db := mem.NewDatabase("mydb")
 	db.AddTable("mytable", table)
 	db.AddTable("othertable", table2)
 	db.AddTable("tabletest", table3)
+	db.AddTable("bigtable", bigtable)
 
 	db2 := mem.NewDatabase("foo")
 	db2.AddTable("other_table", table4)

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -314,9 +314,19 @@ func isDefinedInChildProject(n sql.Node, col *expression.UnresolvedColumn) bool 
 
 	var found bool
 	for _, expr := range x.(sql.Expressioner).Expressions() {
-		alias, ok := expr.(*expression.Alias)
-		if ok && strings.ToLower(alias.Name()) == strings.ToLower(col.Name()) {
-			found = true
+		switch expr := expr.(type) {
+		case *expression.Alias:
+			if strings.ToLower(expr.Name()) == strings.ToLower(col.Name()) {
+				found = true
+			}
+		case column:
+			if strings.ToLower(expr.Name()) == strings.ToLower(col.Name()) &&
+				strings.ToLower(expr.Table()) == strings.ToLower(col.Table()) {
+				found = true
+			}
+		}
+
+		if found {
 			break
 		}
 	}

--- a/sql/analyzer/resolve_having.go
+++ b/sql/analyzer/resolve_having.go
@@ -1,0 +1,151 @@
+package analyzer
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+func resolveHaving(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error) {
+	return node.TransformUp(func(node sql.Node) (sql.Node, error) {
+		having, ok := node.(*plan.Having)
+		if !ok {
+			return node, nil
+		}
+
+		if !having.Resolved() {
+			return node, nil
+		}
+
+		// If there are no aggregations there is no need to check anything else
+		// and we can just leave the node as it is.
+		if !hasAggregations(having.Cond) {
+			return node, nil
+		}
+
+		groupBy, ok := having.Child.(*plan.GroupBy)
+		if !ok {
+			return nil, errHavingNeedsGroupBy.New()
+		}
+
+		var aggregate = make([]sql.Expression, len(groupBy.Aggregate))
+		copy(aggregate, groupBy.Aggregate)
+
+		// We need to find all the aggregations in the having that are already present in
+		// the group by and replace them with a GetField. If the aggregation is not
+		// present, we need to move it to the GroupBy and reference it with a GetField.
+		cond, err := having.Cond.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+			agg, ok := e.(sql.Aggregation)
+			if !ok {
+				return e, nil
+			}
+
+			for i, expr := range aggregate {
+				if aggregationEquals(agg, expr) {
+					var name string
+					if n, ok := expr.(sql.Nameable); ok {
+						name = n.Name()
+					} else {
+						name = expr.String()
+					}
+
+					return expression.NewGetField(
+						i,
+						expr.Type(),
+						name,
+						expr.IsNullable(),
+					), nil
+				}
+			}
+
+			aggregate = append(aggregate, agg)
+			return expression.NewGetField(
+				len(aggregate)-1,
+				agg.Type(),
+				agg.String(),
+				agg.IsNullable(),
+			), nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		var result sql.Node = plan.NewHaving(
+			cond,
+			plan.NewGroupBy(aggregate, groupBy.Grouping, groupBy.Child),
+		)
+
+		// If any aggregation was sent to the GroupBy aggregate, we will need
+		// to wrap the new Having in a project that will get rid of all those
+		// extra columns we added.
+		if len(aggregate) != len(groupBy.Aggregate) {
+			var projection = make([]sql.Expression, len(groupBy.Aggregate))
+			for i, e := range groupBy.Aggregate {
+				var table, name string
+				if t, ok := e.(sql.Tableable); ok {
+					table = t.Table()
+				}
+
+				if n, ok := e.(sql.Nameable); ok {
+					name = n.Name()
+				} else {
+					name = e.String()
+				}
+
+				projection[i] = expression.NewGetFieldWithTable(
+					i,
+					e.Type(),
+					table,
+					name,
+					e.IsNullable(),
+				)
+			}
+			result = plan.NewProject(projection, result)
+		}
+
+		return result, nil
+	})
+}
+
+func aggregationEquals(a, b sql.Expression) bool {
+	// First unwrap aliases
+	if alias, ok := b.(*expression.Alias); ok {
+		b = alias.Child
+	} else if alias, ok := a.(*expression.Alias); ok {
+		a = alias.Child
+	}
+
+	switch a := a.(type) {
+	case *aggregation.Count:
+		// it doesn't matter what's inside a Count, the result will be
+		// the same.
+		_, ok := b.(*aggregation.Count)
+		return ok
+	case *aggregation.Sum,
+		*aggregation.Avg,
+		*aggregation.Min,
+		*aggregation.Max:
+		return reflect.DeepEqual(a, b)
+	default:
+		return false
+	}
+}
+
+var errHavingNeedsGroupBy = errors.NewKind("found HAVING clause with no GROUP BY")
+
+func hasAggregations(expr sql.Expression) bool {
+	var has bool
+	expression.Inspect(expr, func(e sql.Expression) bool {
+		_, ok := e.(sql.Aggregation)
+		if ok {
+			has = true
+			return false
+		}
+		return true
+	})
+	return has
+}

--- a/sql/analyzer/resolve_having_test.go
+++ b/sql/analyzer/resolve_having_test.go
@@ -1,0 +1,103 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+func TestResolveHaving(t *testing.T) {
+	require := require.New(t)
+
+	var node sql.Node = plan.NewHaving(
+		expression.NewGreaterThan(
+			aggregation.NewCount(expression.NewStar()),
+			expression.NewLiteral(int64(5), sql.Int64),
+		),
+		plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias(aggregation.NewCount(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+				expression.NewGetField(0, sql.Int64, "foo", false),
+			},
+			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+			plan.NewResolvedTable(mem.NewTable("t", nil)),
+		),
+	)
+
+	var expected sql.Node = plan.NewHaving(
+		expression.NewGreaterThan(
+			expression.NewGetField(0, sql.Int64, "x", false),
+			expression.NewLiteral(int64(5), sql.Int64),
+		),
+		plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias(aggregation.NewCount(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+				expression.NewGetField(0, sql.Int64, "foo", false),
+			},
+			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+			plan.NewResolvedTable(mem.NewTable("t", nil)),
+		),
+	)
+
+	result, err := resolveHaving(sql.NewEmptyContext(), nil, node)
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	node = plan.NewHaving(
+		expression.NewGreaterThan(
+			aggregation.NewCount(expression.NewStar()),
+			expression.NewLiteral(int64(5), sql.Int64),
+		),
+		plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+				expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+			},
+			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+			plan.NewResolvedTable(mem.NewTable("t", nil)),
+		),
+	)
+
+	expected = plan.NewProject(
+		[]sql.Expression{
+			expression.NewGetField(0, sql.Float64, "x", true),
+			expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+		},
+		plan.NewHaving(
+			expression.NewGreaterThan(
+				expression.NewGetField(2, sql.Int64, "COUNT(*)", false),
+				expression.NewLiteral(int64(5), sql.Int64),
+			),
+			plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+					expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+					aggregation.NewCount(expression.NewStar()),
+				},
+				[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+				plan.NewResolvedTable(mem.NewTable("t", nil)),
+			),
+		),
+	)
+
+	result, err = resolveHaving(sql.NewEmptyContext(), nil, node)
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	node = plan.NewHaving(
+		expression.NewGreaterThan(
+			aggregation.NewCount(expression.NewStar()),
+			expression.NewLiteral(int64(5), sql.Int64),
+		),
+		plan.NewResolvedTable(mem.NewTable("t", nil)),
+	)
+
+	_, err = resolveHaving(sql.NewEmptyContext(), nil, node)
+	require.Error(err)
+	require.True(errHavingNeedsGroupBy.Is(err))
+}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -15,6 +15,7 @@ var DefaultRules = []Rule{
 	{"resolve_database", resolveDatabase},
 	{"resolve_star", resolveStar},
 	{"resolve_functions", resolveFunctions},
+	{"resolve_having", resolveHaving},
 	{"reorder_aggregations", reorderAggregations},
 	{"reorder_projection", reorderProjection},
 	{"move_join_conds_to_filter", moveJoinConditionsToFilter},

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1061,6 +1061,30 @@ var fixtures = map[string]sql.Node{
 		)},
 		plan.NewUnresolvedTable("dual", ""),
 	),
+	`SELECT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`: plan.NewHaving(
+		expression.NewGreaterThan(
+			expression.NewUnresolvedFunction("count", true, expression.NewStar()),
+			expression.NewLiteral(int64(5), sql.Int64),
+		),
+		plan.NewGroupBy(
+			[]sql.Expression{expression.NewUnresolvedFunction("count", true, expression.NewStar())},
+			[]sql.Expression{expression.NewUnresolvedColumn("a")},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	),
+	`SELECT DISTINCT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`: plan.NewDistinct(
+		plan.NewHaving(
+			expression.NewGreaterThan(
+				expression.NewUnresolvedFunction("count", true, expression.NewStar()),
+				expression.NewLiteral(int64(5), sql.Int64),
+			),
+			plan.NewGroupBy(
+				[]sql.Expression{expression.NewUnresolvedFunction("count", true, expression.NewStar())},
+				[]sql.Expression{expression.NewUnresolvedColumn("a")},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/plan/having.go
+++ b/sql/plan/having.go
@@ -1,0 +1,79 @@
+package plan
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+// Having node is a filter that supports aggregate expressions. A having node
+// is identical to a filter node in behaviour. The difference is that some
+// analyzer rules work specifically on having clauses and not filters. For
+// that reason, Having is a completely new node instead of using just filter.
+type Having struct {
+	UnaryNode
+	Cond sql.Expression
+}
+
+var _ sql.Expressioner = (*Having)(nil)
+
+// NewHaving creates a new having node.
+func NewHaving(cond sql.Expression, child sql.Node) *Having {
+	return &Having{UnaryNode{Child: child}, cond}
+}
+
+// Resolved implements the sql.Node interface.
+func (h *Having) Resolved() bool { return h.Cond.Resolved() && h.Child.Resolved() }
+
+// Expressions implements the sql.Expressioner interface.
+func (h *Having) Expressions() []sql.Expression { return []sql.Expression{h.Cond} }
+
+// TransformExpressions implements the sql.Expressioner interface.
+func (h *Having) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
+	e, err := h.Cond.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Having{h.UnaryNode, e}, nil
+}
+
+// TransformExpressionsUp implements the sql.Node interface.
+func (h *Having) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	child, err := h.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := h.Cond.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Having{UnaryNode{child}, e}, nil
+}
+
+// TransformUp implements the sql.Node interface.
+func (h *Having) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	child, err := h.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(&Having{UnaryNode{child}, h.Cond})
+}
+
+// RowIter implements the sql.Node interface.
+func (h *Having) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Having")
+	iter, err := h.Child.RowIter(ctx)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+
+	return sql.NewSpanIter(span, NewFilterIter(ctx, h.Cond, iter)), nil
+}
+
+func (h *Having) String() string {
+	p := sql.NewTreePrinter()
+	_ = p.WriteNode("Having(%s)", h.Cond)
+	_ = p.WriteChildren(h.Child.String())
+	return p.String()
+}

--- a/sql/plan/having_test.go
+++ b/sql/plan/having_test.go
@@ -1,0 +1,95 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestHaving(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	childSchema := sql.Schema{
+		{Name: "col1", Type: sql.Text, Nullable: true},
+		{Name: "col2", Type: sql.Text, Nullable: true},
+		{Name: "col3", Type: sql.Int32, Nullable: true},
+		{Name: "col4", Type: sql.Int64, Nullable: true},
+	}
+	child := mem.NewTable("test", childSchema)
+
+	rows := []sql.Row{
+		sql.NewRow("col1_1", "col2_1", int32(1111), int64(2222)),
+		sql.NewRow("col1_2", "col2_2", int32(3333), int64(4444)),
+		sql.NewRow("col1_3", "col2_3", nil, int64(4444)),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
+
+	f := NewHaving(
+		expression.NewEquals(
+			expression.NewGetField(0, sql.Text, "col1", true),
+			expression.NewLiteral("col1_1", sql.Text)),
+		NewResolvedTable(child),
+	)
+
+	require.Equal(1, len(f.Children()))
+
+	iter, err := f.RowIter(ctx)
+	require.NoError(err)
+	require.NotNil(iter)
+
+	row, err := iter.Next()
+	require.NoError(err)
+	require.NotNil(row)
+
+	require.Equal("col1_1", row[0])
+	require.Equal("col2_1", row[1])
+
+	row, err = iter.Next()
+	require.NotNil(err)
+	require.Nil(row)
+
+	f = NewHaving(
+		expression.NewEquals(
+			expression.NewGetField(2, sql.Int32, "col3", true),
+			expression.NewLiteral(int32(1111), sql.Int32),
+		),
+		NewResolvedTable(child),
+	)
+
+	iter, err = f.RowIter(ctx)
+	require.NoError(err)
+	require.NotNil(iter)
+
+	row, err = iter.Next()
+	require.NoError(err)
+	require.NotNil(row)
+
+	require.Equal(int32(1111), row[2])
+	require.Equal(int64(2222), row[3])
+
+	f = NewHaving(
+		expression.NewEquals(
+			expression.NewGetField(3, sql.Int64, "col4", true),
+			expression.NewLiteral(int64(4444), sql.Int64),
+		),
+		NewResolvedTable(child),
+	)
+
+	iter, err = f.RowIter(ctx)
+	require.NoError(err)
+	require.NotNil(iter)
+
+	row, err = iter.Next()
+	require.NoError(err)
+	require.NotNil(row)
+
+	require.Equal(int32(3333), row[2])
+	require.Equal(int64(4444), row[3])
+}


### PR DESCRIPTION
Closes #56

This PR adds support for the HAVING SQL clause, that allows
filtering rows and has support for aggregation functions.

For this, the following changes have been made:
- New `Having` node, which is essentially a Filter, but it is
  a different node for the purpose of differentiating between the
  two of them during the analysis phase.
- Having is now parsed.
- A new rule for resolving the Having node has been added. Because
  of the way aggregations are executed (only inside a GroupBy node)
  it is not possible to execute them in any other node that's not a
  GroupBy. For this reason, this rule pushes down any aggregation
  on a Having node to its child, which is the GroupBy node. If
  the same aggregation is already done on the GroupBy, nothing will
  be added and the aggregation on the Having node will be replaced
  with a reference to the result of the aggregation in the GroupBy.
  Because pushing new aggregations to the GroupBy changes the
  resulting schema, a Project node is added wrapping the Having
  node projecting only the columns the GroupBy was initially
  projecting.