### PR TITLE
sql/analyzer: only check aliases to qualify in the topmost project

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -929,6 +929,26 @@ var queries = []struct {
 		`SELECT i AS i FROM mytable ORDER BY i`,
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
+	{
+		`
+		SELECT
+			i,
+			foo
+		FROM (
+			SELECT
+				i,
+				COUNT(DISTINCT s) AS foo
+			FROM mytable
+			GROUP BY i
+		) AS q
+		ORDER BY foo DESC
+		`,
+		[]sql.Row{
+			{int64(1), int64(1)},
+			{int64(2), int64(1)},
+			{int64(3), int64(1)},
+		},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 
 	"gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-mysql-server.v0/internal/similartext"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 	"gopkg.in/src-d/go-vitess.v1/vt/sqlparser"
-	"gopkg.in/src-d/go-mysql-server.v0/internal/similartext"
 )
 
 func checkAliases(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -313,15 +313,13 @@ func isDefinedInChildProject(n sql.Node, col *expression.UnresolvedColumn) bool 
 	}
 
 	var found bool
-	plan.InspectExpressions(x, func(e sql.Expression) bool {
-		alias, ok := e.(*expression.Alias)
+	for _, expr := range x.(sql.Expressioner).Expressions() {
+		alias, ok := expr.(*expression.Alias)
 		if ok && strings.ToLower(alias.Name()) == strings.ToLower(col.Name()) {
 			found = true
-			return false
+			break
 		}
-
-		return true
-	})
+	}
 
 	return found
 }


### PR DESCRIPTION
Because aliases on the topmost project or groupby were checked using
plan.InspectExpressions, it did so recursively. That was not the
intended behaviour, since it could find other aliases in a subquery
or other nodes down the tree.
Instead, now only the expressions of the project or groupby are
checked.