### PR TITLE
sql: convert dates outside of supported time range to correct date

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ To be able to create your own data source implementation you need to implement t
   - `sql.PushdownProjectionAndFiltersTable` interface will provide the same functionality described before, but also will push down the filters used in the executed query. It allows to filter data in advance, and speed up queries.
   - `sql.Indexable` add index capabilities to your table. By implementing this interface you can create and use indexes on this table.
   - `sql.Inserter` can be implemented if your data source tables allow insertions.
+**IMPORTANT:** when you implement your tables, your columns of timestamp and datetime types **must** return dates in the following range: `1000-01-01 00:00:00` to `9999-12-31 23:59:59`. To do so, you can use the builtin function `sql.ToSupportedTimeRange`.
 
 - If you need some custom tree modifications, you can also implement your own `analyzer.Rules`.
 


### PR DESCRIPTION
According to MySQL, dates should range between 1000-01-01 00:00:00
and 9999-12-31 23:59:59. This PR changes the behaviour of Convert
methods of Timestamp and Date types so that values returned by this
method are always within that range.

It also adds an exposed utility function named `ToSupportedTimeRange`
that converts a time to the supported time range for clients to use.

The readme now includes instructions for datasource implementors to
always return their dates within the supported range using the
provided utility function.
The reason go-mysql-server does not handle that for data sources by
default is because there is no obvious place to do so in a generic
way. Tables should be the ones returning correct values.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>