### PR TITLE
sql/analyzer: refactor and fix bugs in qualify_columns rule

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1060,6 +1060,10 @@ var queries = []struct {
 		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t GROUP BY t.date_col`,
 		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
 	},
+	{
+		`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/analyzer/resolve_columns_test.go
+++ b/sql/analyzer/resolve_columns_test.go
@@ -79,10 +79,10 @@ func TestQualifyColumns(t *testing.T) {
 	require := require.New(t)
 	f := getRule("qualify_columns")
 
-	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
-	table2 := mem.NewTable("mytable2", sql.Schema{{Name: "i", Type: sql.Int32}})
-	sessionTable := mem.NewTable("@@session", sql.Schema{{Name: "autocommit", Type: sql.Int64}})
-	globalTable := mem.NewTable("@@global", sql.Schema{{Name: "max_allowed_packet", Type: sql.Int64}})
+	table := mem.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32, Source: "mytable"}})
+	table2 := mem.NewTable("mytable2", sql.Schema{{Name: "i", Type: sql.Int32, Source: "mytable2"}})
+	sessionTable := mem.NewTable("@@session", sql.Schema{{Name: "autocommit", Type: sql.Int64, Source: "@@session"}})
+	globalTable := mem.NewTable("@@global", sql.Schema{{Name: "max_allowed_packet", Type: sql.Int64, Source: "@@global"}})
 
 	node := plan.NewProject(
 		[]sql.Expression{

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -68,18 +68,16 @@ func NewSort(sortFields []SortField, child sql.Node) *Sort {
 	}
 }
 
+var _ sql.Expressioner = (*Sort)(nil)
+
 // Resolved implements the Resolvable interface.
 func (s *Sort) Resolved() bool {
-	return s.UnaryNode.Child.Resolved() && s.expressionsResolved()
-}
-
-func (s *Sort) expressionsResolved() bool {
 	for _, f := range s.SortFields {
 		if !f.Column.Resolved() {
 			return false
 		}
 	}
-	return true
+	return s.Child.Resolved()
 }
 
 // RowIter implements the Node interface.


### PR DESCRIPTION
qualify_columns rule has been a source of bugs for quite a long time
due to the way we used to look for columns. Before, we looked for
all available schemas in all the tree of a query (excluding subqueries).
This required a lot of exceptions and treatments for special cases
that have been added over time in order to patch the bugs that kept
appearing.
It had special cases for aliases, for GroupBy, etc that kept complicating
the code and making the rule harder to follow and confusing.

This refactor simplifies the logic of the rule and treats all nodes
in the exact same way so it's simpler, more obvious and easier to
reason about.
Now, a node only has knowledge of the columns (aliases or not) defined
until it reaches the first Project, GroupBy, ResolvedTable or subquery
in each branch of the tree. This way, we can gather all the available
columns and infer the schema (which we cannot just call using the Schema
method because the tree is not resolved yet). Then, qualifying columns
becomes a trivial job once you have the schema.

All the tests of go-mysql-server and gitbase pass with this new
implementation of the rule.

TL;DR: got sick of this rule while debugging a gitbase issue and rewrote it so we don't have to get sick of it anymore while debugging