### PR TITLE
sql: do not marshal strings containing JSON as a string in convert

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1064,6 +1064,10 @@ var queries = []struct {
 		`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
+	{
+		`SELECT JSON_EXTRACT('[1, 2, 3]', '$.[0]')`,
+		[]sql.Row{{float64(1)}},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -47,13 +47,8 @@ func (j *JSONExtract) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	js, err = sql.JSON.Convert(js)
+	doc, err := unmarshalVal(js)
 	if err != nil {
-		return nil, err
-	}
-
-	var doc interface{}
-	if err := json.Unmarshal(js.([]byte), &doc); err != nil {
 		return nil, err
 	}
 
@@ -82,6 +77,20 @@ func (j *JSONExtract) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	return result, nil
+}
+
+func unmarshalVal(v interface{}) (interface{}, error) {
+	v, err := sql.JSON.Convert(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc interface{}
+	if err := json.Unmarshal(v.([]byte), &doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/sql/type.go
+++ b/sql/type.go
@@ -671,7 +671,16 @@ func (t jsonT) SQL(v interface{}) sqltypes.Value {
 
 // Convert implements Type interface.
 func (t jsonT) Convert(v interface{}) (interface{}, error) {
-	return json.Marshal(v)
+	switch v := v.(type) {
+	case string:
+		var doc interface{}
+		if err := json.Unmarshal([]byte(v), &doc); err != nil {
+			return json.Marshal(v)
+		}
+		return json.Marshal(doc)
+	default:
+		return json.Marshal(v)
+	}
 }
 
 // Compare implements Type interface.

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -200,6 +200,7 @@ func TestBlob(t *testing.T) {
 func TestJSON(t *testing.T) {
 	convert(t, JSON, "", []byte(`""`))
 	convert(t, JSON, []int{1, 2}, []byte("[1,2]"))
+	convert(t, JSON, `{"a": true, "b": 3}`, []byte(`{"a":true,"b":3}`))
 
 	lt(t, JSON, []byte("A"), []byte("B"))
 	eq(t, JSON, []byte("A"), []byte("A"))


### PR DESCRIPTION
Fixes #709

When a string containing JSON (e.g. `{"a": 1, "b": true}`) is passed
to JSON.Convert, it only did `json.Marshal`, so it was marshalled as
a string (e.g. `"{\"a\":1,\"b\":true}"`), which made it impossible
to use a string with JSON_EXTRACT, which would only receive the
string.

Now, JSON.Convert does a first check for strings. If it can be
unmarshalled into JSON, then that JSON is marshalled and returned.
Otherwise, it's a string and marshalled as such.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>