### PR TITLE
sql: implement EXPLODE and generators

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -125,7 +125,12 @@ func (h *Handler) ComQuery(
 			return err
 		}
 
-		r.Rows = append(r.Rows, rowToSQL(schema, row))
+		outputRow, err := rowToSQL(schema, row)
+		if err != nil {
+			return err
+		}
+
+		r.Rows = append(r.Rows, outputRow)
 		r.RowsAffected++
 	}
 
@@ -203,13 +208,17 @@ func (h *Handler) handleKill(conn *mysql.Conn, query string) (bool, error) {
 	return true, nil
 }
 
-func rowToSQL(s sql.Schema, row sql.Row) []sqltypes.Value {
+func rowToSQL(s sql.Schema, row sql.Row) ([]sqltypes.Value, error) {
 	o := make([]sqltypes.Value, len(row))
+	var err error
 	for i, v := range row {
-		o[i] = s[i].Type.SQL(v)
+		o[i], err = s[i].Type.SQL(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return o
+	return o, nil
 }
 
 func schemaToFields(s sql.Schema) []*query.Field {

--- a/sql/analyzer/resolve_generators.go
+++ b/sql/analyzer/resolve_generators.go
@@ -1,0 +1,97 @@
+package analyzer
+
+import (
+	"gopkg.in/src-d/go-errors.v1"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/expression/function"
+	"github.com/src-d/go-mysql-server/sql/plan"
+)
+
+var (
+	errMultipleGenerators = errors.NewKind("there can't be more than 1 instance of EXPLODE in a SELECT")
+	errExplodeNotArray    = errors.NewKind("argument of type %q given to EXPLODE, expecting array")
+)
+
+func resolveGenerators(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+		p, ok := n.(*plan.Project)
+		if !ok {
+			return n, nil
+		}
+
+		projection := p.Projections
+
+		g, err := findGenerator(projection)
+		if err != nil {
+			return nil, err
+		}
+
+		// There might be no generator in the project, in that case we don't
+		// have to do anything.
+		if g == nil {
+			return n, nil
+		}
+
+		projection[g.idx] = g.expr
+
+		var name string
+		if n, ok := g.expr.(sql.Nameable); ok {
+			name = n.Name()
+		} else {
+			name = g.expr.String()
+		}
+
+		return plan.NewGenerate(
+			plan.NewProject(projection, p.Child),
+			expression.NewGetField(g.idx, g.expr.Type(), name, g.expr.IsNullable()),
+		), nil
+	})
+}
+
+type generator struct {
+	idx  int
+	expr sql.Expression
+}
+
+// findGenerator will find in the given projection a generator column. If there
+// is no generator, it will return nil.
+// If there are is than one generator or the argument to explode is not an
+// array it will fail.
+// All occurrences of Explode will be replaced with Generate.
+func findGenerator(exprs []sql.Expression) (*generator, error) {
+	var g = &generator{idx: -1}
+	for i, e := range exprs {
+		var found bool
+		switch e := e.(type) {
+		case *function.Explode:
+			found = true
+			g.expr = function.NewGenerate(e.Child)
+		case *expression.Alias:
+			if exp, ok := e.Child.(*function.Explode); ok {
+				found = true
+				g.expr = expression.NewAlias(
+					function.NewGenerate(exp.Child),
+					e.Name(),
+				)
+			}
+		}
+
+		if found {
+			if g.idx >= 0 {
+				return nil, errMultipleGenerators.New()
+			}
+			g.idx = i
+
+			if !sql.IsArray(g.expr.Type()) {
+				return nil, errExplodeNotArray.New(g.expr.Type())
+			}
+		}
+	}
+
+	if g.expr == nil {
+		return nil, nil
+	}
+
+	return g, nil
+}

--- a/sql/analyzer/resolve_generators_test.go
+++ b/sql/analyzer/resolve_generators_test.go
@@ -1,0 +1,117 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-errors.v1"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/expression/function"
+	"github.com/src-d/go-mysql-server/sql/plan"
+)
+
+func TestResolveGenerators(t *testing.T) {
+	testCases := []struct {
+		name     string
+		node     sql.Node
+		expected sql.Node
+		err      *errors.Kind
+	}{
+		{
+			name: "regular explode",
+			node: plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Int64, "a", false),
+					function.NewExplode(expression.NewGetField(1, sql.Array(sql.Int64), "b", false)),
+					expression.NewGetField(2, sql.Int64, "c", false),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+			expected: plan.NewGenerate(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Int64, "a", false),
+						function.NewGenerate(expression.NewGetField(1, sql.Array(sql.Int64), "b", false)),
+						expression.NewGetField(2, sql.Int64, "c", false),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+				expression.NewGetField(1, sql.Array(sql.Int64), "EXPLODE(b)", false),
+			),
+			err: nil,
+		},
+		{
+			name: "explode with alias",
+			node: plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Int64, "a", false),
+					expression.NewAlias(
+						function.NewExplode(
+							expression.NewGetField(1, sql.Array(sql.Int64), "b", false),
+						),
+						"x",
+					),
+					expression.NewGetField(2, sql.Int64, "c", false),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+			expected: plan.NewGenerate(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Int64, "a", false),
+						expression.NewAlias(
+							function.NewGenerate(
+								expression.NewGetField(1, sql.Array(sql.Int64), "b", false),
+							),
+							"x",
+						),
+						expression.NewGetField(2, sql.Int64, "c", false),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+				expression.NewGetField(1, sql.Array(sql.Int64), "x", false),
+			),
+			err: nil,
+		},
+		{
+			name: "non array type on explode",
+			node: plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Int64, "a", false),
+					function.NewExplode(expression.NewGetField(1, sql.Int64, "b", false)),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+			expected: nil,
+			err:      errExplodeNotArray,
+		},
+		{
+			name: "more than one generator",
+			node: plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Int64, "a", false),
+					function.NewExplode(expression.NewGetField(1, sql.Array(sql.Int64), "b", false)),
+					function.NewExplode(expression.NewGetField(2, sql.Array(sql.Int64), "c", false)),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+			expected: nil,
+			err:      errMultipleGenerators,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			result, err := resolveGenerators(sql.NewEmptyContext(), nil, tt.node)
+			if tt.err != nil {
+				require.Error(err)
+				require.True(tt.err.Is(err))
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, result)
+			}
+		})
+	}
+}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -34,6 +34,7 @@ var OnceBeforeDefault = []Rule{
 // OnceAfterDefault contains the rules to be applied just once after the
 // DefaultRules.
 var OnceAfterDefault = []Rule{
+	{"resolve_generators", resolveGenerators},
 	{"remove_unnecessary_converts", removeUnnecessaryConverts},
 	{"assign_catalog", assignCatalog},
 	{"prune_columns", pruneColumns},

--- a/sql/expression/function/explode.go
+++ b/sql/expression/function/explode.go
@@ -1,0 +1,95 @@
+package function
+
+import (
+	"fmt"
+
+	"github.com/src-d/go-mysql-server/sql"
+)
+
+// Explode is a function that generates a row for each value of its child.
+// It is a placeholder expression node.
+type Explode struct {
+	Child sql.Expression
+}
+
+// NewExplode creates a new Explode function.
+func NewExplode(child sql.Expression) sql.Expression {
+	return &Explode{child}
+}
+
+// Resolved implements the sql.Expression interface.
+func (e *Explode) Resolved() bool { return e.Child.Resolved() }
+
+// Children implements the sql.Expression interface.
+func (e *Explode) Children() []sql.Expression { return []sql.Expression{e.Child} }
+
+// IsNullable implements the sql.Expression interface.
+func (e *Explode) IsNullable() bool { return e.Child.IsNullable() }
+
+// Type implements the sql.Expression interface.
+func (e *Explode) Type() sql.Type {
+	return sql.UnderlyingType(e.Child.Type())
+}
+
+// Eval implements the sql.Expression interface.
+func (e *Explode) Eval(*sql.Context, sql.Row) (interface{}, error) {
+	panic("eval method of Explode is only a placeholder")
+}
+
+func (e *Explode) String() string {
+	return fmt.Sprintf("EXPLODE(%s)", e.Child)
+}
+
+// TransformUp implements the sql.Expression interface.
+func (e *Explode) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
+	c, err := f(e.Child)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewExplode(c))
+}
+
+// Generate is a function that generates a row for each value of its child.
+// This is the non-placeholder counterpart of Explode.
+type Generate struct {
+	Child sql.Expression
+}
+
+// NewGenerate creates a new Generate function.
+func NewGenerate(child sql.Expression) sql.Expression {
+	return &Generate{child}
+}
+
+// Resolved implements the sql.Expression interface.
+func (e *Generate) Resolved() bool { return e.Child.Resolved() }
+
+// Children implements the sql.Expression interface.
+func (e *Generate) Children() []sql.Expression { return []sql.Expression{e.Child} }
+
+// IsNullable implements the sql.Expression interface.
+func (e *Generate) IsNullable() bool { return e.Child.IsNullable() }
+
+// Type implements the sql.Expression interface.
+func (e *Generate) Type() sql.Type {
+	return e.Child.Type()
+}
+
+// Eval implements the sql.Expression interface.
+func (e *Generate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	return e.Child.Eval(ctx, row)
+}
+
+func (e *Generate) String() string {
+	return fmt.Sprintf("EXPLODE(%s)", e.Child)
+}
+
+// TransformUp implements the sql.Expression interface.
+func (e *Generate) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
+	c, err := f(e.Child)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewGenerate(c))
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -88,4 +88,5 @@ var Defaults = []sql.Function{
 	sql.Function1{Name: "length", Fn: NewLength},
 	sql.Function1{Name: "char_length", Fn: NewCharLength},
 	sql.Function1{Name: "character_length", Fn: NewCharLength},
+	sql.Function1{Name: "explode", Fn: NewExplode},
 }

--- a/sql/generator.go
+++ b/sql/generator.go
@@ -1,0 +1,57 @@
+package sql
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+// Generator will generate a set of values for a given row.
+type Generator interface {
+	// Next value in the generator.
+	Next() (interface{}, error)
+	// Close the generator and dispose resources.
+	Close() error
+}
+
+// ErrNotGenerator is returned when the value cannot be converted to a
+// generator.
+var ErrNotGenerator = errors.NewKind("cannot convert value of type %T to a generator")
+
+// ToGenerator converts a value to a generator if possible.
+func ToGenerator(v interface{}) (Generator, error) {
+	switch v := v.(type) {
+	case Generator:
+		return v, nil
+	case []interface{}:
+		return NewArrayGenerator(v), nil
+	case nil:
+		return NewArrayGenerator(nil), nil
+	default:
+		return nil, ErrNotGenerator.New(v)
+	}
+}
+
+// NewArrayGenerator creates a generator for a given array.
+func NewArrayGenerator(array []interface{}) Generator {
+	return &arrayGenerator{array, 0}
+}
+
+type arrayGenerator struct {
+	array []interface{}
+	pos   int
+}
+
+func (g *arrayGenerator) Next() (interface{}, error) {
+	if g.pos >= len(g.array) {
+		return nil, io.EOF
+	}
+
+	g.pos++
+	return g.array[g.pos-1], nil
+}
+
+func (g *arrayGenerator) Close() error {
+	g.pos = len(g.array)
+	return nil
+}

--- a/sql/generator_test.go
+++ b/sql/generator_test.go
@@ -1,0 +1,54 @@
+package sql
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrayGenerator(t *testing.T) {
+	require := require.New(t)
+
+	expected := []interface{}{"a", "b", "c"}
+	gen := NewArrayGenerator(expected)
+
+	var values []interface{}
+	for {
+		v, err := gen.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			require.NoError(err)
+		}
+		values = append(values, v)
+	}
+
+	require.Equal(expected, values)
+}
+
+func TestToGenerator(t *testing.T) {
+	require := require.New(t)
+
+	gen, err := ToGenerator([]interface{}{1, 2, 3})
+	require.NoError(err)
+	require.Equal(NewArrayGenerator([]interface{}{1, 2, 3}), gen)
+
+	gen, err = ToGenerator(new(fakeGen))
+	require.NoError(err)
+	require.Equal(new(fakeGen), gen)
+
+	gen, err = ToGenerator(nil)
+	require.NoError(err)
+	require.Equal(NewArrayGenerator(nil), gen)
+
+	_, err = ToGenerator("foo")
+	require.Error(err)
+}
+
+type fakeGen struct{}
+
+func (fakeGen) Next() (interface{}, error) { return nil, fmt.Errorf("not implemented") }
+func (fakeGen) Close() error               { return nil }

--- a/sql/plan/generate.go
+++ b/sql/plan/generate.go
@@ -1,0 +1,152 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+)
+
+// Generate will explode rows using a generator.
+type Generate struct {
+	UnaryNode
+	Column *expression.GetField
+}
+
+// NewGenerate creates a new generate node.
+func NewGenerate(child sql.Node, col *expression.GetField) *Generate {
+	return &Generate{UnaryNode{child}, col}
+}
+
+// Schema implements the sql.Node interface.
+func (g *Generate) Schema() sql.Schema {
+	s := g.Child.Schema()
+	col := s[g.Column.Index()]
+	s[g.Column.Index()] = &sql.Column{
+		Name:     g.Column.Name(),
+		Type:     sql.UnderlyingType(col.Type),
+		Nullable: col.Nullable,
+	}
+	return s
+}
+
+// RowIter implements the sql.Node interface.
+func (g *Generate) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Generate")
+
+	childIter, err := g.Child.RowIter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.NewSpanIter(span, &generateIter{
+		child: childIter,
+		idx:   g.Column.Index(),
+	}), nil
+}
+
+func (g *Generate) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
+	col, err := g.Column.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	field, ok := col.(*expression.GetField)
+	if !ok {
+		return nil, fmt.Errorf("column of Generate node transformed into %T, must be GetField", col)
+	}
+
+	return NewGenerate(g.Child, field), nil
+}
+
+// TransformUp implements the sql.Node interface.
+func (g *Generate) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	child, err := g.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(NewGenerate(child, g.Column))
+}
+
+// TransformExpressionsUp implements the sql.Node interface.
+func (g *Generate) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	child, err := g.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	col, err := g.Column.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	field, ok := col.(*expression.GetField)
+	if !ok {
+		return nil, fmt.Errorf("column of Generate node transformed into %T, must be GetField", col)
+	}
+
+	return NewGenerate(child, field), nil
+}
+
+func (g *Generate) String() string {
+	tp := sql.NewTreePrinter()
+	_ = tp.WriteNode("Generate(%s)", g.Column)
+	_ = tp.WriteChildren(g.Child.String())
+	return tp.String()
+}
+
+type generateIter struct {
+	child sql.RowIter
+	idx   int
+
+	gen sql.Generator
+	row sql.Row
+}
+
+func (i *generateIter) Next() (sql.Row, error) {
+	for {
+		if i.gen == nil {
+			var err error
+			i.row, err = i.child.Next()
+			if err != nil {
+				return nil, err
+			}
+
+			i.gen, err = sql.ToGenerator(i.row[i.idx])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		val, err := i.gen.Next()
+		if err != nil {
+			if err == io.EOF {
+				if err := i.gen.Close(); err != nil {
+					return nil, err
+				}
+
+				i.gen = nil
+				continue
+			}
+			return nil, err
+		}
+
+		var row = make(sql.Row, len(i.row))
+		copy(row, i.row)
+		row[i.idx] = val
+		return row, nil
+	}
+}
+
+func (i *generateIter) Close() error {
+	if i.gen != nil {
+		if err := i.gen.Close(); err != nil {
+			_ = i.child.Close()
+			return err
+		}
+	}
+
+	return i.child.Close()
+}

--- a/sql/plan/generate_test.go
+++ b/sql/plan/generate_test.go
@@ -1,0 +1,88 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+)
+
+func TestGenerateRowIter(t *testing.T) {
+	require := require.New(t)
+
+	child := newFakeNode(
+		sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "foo"},
+			{Name: "b", Type: sql.Array(sql.Text), Source: "foo"},
+			{Name: "c", Type: sql.Int64, Source: "foo"},
+		},
+		sql.RowsToRowIter(
+			sql.Row{"first", sql.NewArrayGenerator([]interface{}{"a", "b"}), int64(1)},
+			sql.Row{"second", sql.NewArrayGenerator([]interface{}{"c", "d"}), int64(2)},
+		),
+	)
+
+	iter, err := NewGenerate(
+		child,
+		expression.NewGetFieldWithTable(1, sql.Array(sql.Text), "foo", "b", false),
+	).RowIter(sql.NewEmptyContext())
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+
+	expected := []sql.Row{
+		{"first", "a", int64(1)},
+		{"first", "b", int64(1)},
+		{"second", "c", int64(2)},
+		{"second", "d", int64(2)},
+	}
+
+	require.Equal(expected, rows)
+}
+
+func TestGenerateSchema(t *testing.T) {
+	require := require.New(t)
+
+	schema := NewGenerate(
+		newFakeNode(
+			sql.Schema{
+				{Name: "a", Type: sql.Text, Source: "foo"},
+				{Name: "b", Type: sql.Array(sql.Text), Source: "foo"},
+				{Name: "c", Type: sql.Int64, Source: "foo"},
+			},
+			nil,
+		),
+		expression.NewGetField(1, sql.Array(sql.Text), "foobar", false),
+	).Schema()
+
+	expected := sql.Schema{
+		{Name: "a", Type: sql.Text, Source: "foo"},
+		{Name: "foobar", Type: sql.Text},
+		{Name: "c", Type: sql.Int64, Source: "foo"},
+	}
+
+	require.Equal(expected, schema)
+}
+
+type fakeNode struct {
+	schema sql.Schema
+	iter   sql.RowIter
+}
+
+func newFakeNode(s sql.Schema, iter sql.RowIter) *fakeNode {
+	return &fakeNode{s, iter}
+}
+
+func (n *fakeNode) Children() []sql.Node                      { return nil }
+func (n *fakeNode) Resolved() bool                            { return true }
+func (n *fakeNode) Schema() sql.Schema                        { return n.schema }
+func (n *fakeNode) RowIter(*sql.Context) (sql.RowIter, error) { return n.iter, nil }
+func (n *fakeNode) String() string                            { return "fakeNode" }
+func (n *fakeNode) TransformUp(sql.TransformNodeFunc) (sql.Node, error) {
+	panic("placeholder")
+}
+func (n *fakeNode) TransformExpressionsUp(sql.TransformExprFunc) (sql.Node, error) {
+	panic("placeholder")
+}


### PR DESCRIPTION
This pull request implements the EXPLODE expressions and generators,
which are used together to provide generation of rows based on a
column or expression that can yield multiple values.

For this, there have been some quite core changes:
- SQL method of sql.Type now returns the sqltypes.Value and an error.
  This avoids panics in this method. Since generators can yield errors
  it's better to just return an error and not just kill the server.
- Array type can now internally handle either arrays or generators,
  making it transparent for the user. If it's used in an EXPLODE
  expression, the generator will be used. Otherwise, it will be
  converted automatically to an array and used without the user even
  knowing what happened behind the scenes. That way, we don't need
  yet another type to represent generators.

Aside from that, there are some new additions:
- New EXPLODE function, which is just a placeholder. EXPLODE type is the
  underlying type of its argument for resolution purposes. During analysis
  Explode nodes will be replaced by Generate functions and a Generate node.
- New Generate function, which is the non-placeholder version of EXPLODE
  and the one that goes into the final execution tree. This one returns
  the same type as its argument and let's the Generate plan node be the
  one that returns the underlying type once the values are generated.
- Generate node, which wraps a Project in which there is one and only one
  explode expression.
- resolve_generators analysis rule, which will turn projects with an
  Explode expression into a Generate node with the project as a children,
  replacing the Explode expressions with Generate expressions.
- validate_explode_usage validation rule, which will ensure explode is
  not used outside a Project node.
