### PR TITLE
Make PROCESSLIST and KILL compatible with MySQL

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -164,7 +164,7 @@ func (h *Handler) handleKill(conn *mysql.Conn, query string) (bool, error) {
 		return false, nil
 	}
 
-	id, err := strconv.ParseUint(s[2], 10, 64)
+	id, err := strconv.ParseUint(s[2], 10, 32)
 	if err != nil {
 		return false, err
 	}
@@ -181,15 +181,10 @@ func (h *Handler) handleKill(conn *mysql.Conn, query string) (bool, error) {
 	// - KILL CONNECTION is the same as KILL with no modifier:
 	// It terminates the connection associated with the given processlist_id,
 	// after terminating any statement the connection is executing.
-	if s[1] == "query" {
-		logrus.Infof("kill query: id %d", id)
-		h.e.Catalog.Kill(id)
-	} else {
-		connID, ok := h.e.Catalog.KillConnection(id)
-		if !ok {
-			return false, errConnectionNotFound.New(connID)
-		}
-		logrus.Infof("kill connection: id %d, pid: %d", connID, id)
+	connID := uint32(id)
+	h.e.Catalog.Kill(connID)
+	if s[1] != "query" {
+		logrus.Infof("kill connection: id %d", connID)
 
 		h.mu.Lock()
 		c, ok := h.c[connID]

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -203,7 +203,7 @@ func TestHandlerKill(t *testing.T) {
 	ctx1, err = handler.e.Catalog.AddProcess(ctx1, sql.QueryProcess, "SELECT 1")
 	require.NoError(err)
 
-	err = handler.ComQuery(conn2, "KILL "+fmt.Sprint(ctx1.Pid()), func(res *sqltypes.Result) error {
+	err = handler.ComQuery(conn2, "KILL "+fmt.Sprint(ctx1.ID()), func(res *sqltypes.Result) error {
 		return nil
 	})
 	require.NoError(err)

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -89,7 +89,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		sort.Strings(status)
 
 		rows[i] = process{
-			id:      int64(proc.Pid),
+			id:      int64(proc.Connection),
 			user:    proc.User,
 			time:    int64(proc.Seconds()),
 			state:   strings.Join(status, ", "),

--- a/sql/plan/processlist_test.go
+++ b/sql/plan/processlist_test.go
@@ -45,7 +45,7 @@ func TestShowProcessList(t *testing.T) {
 
 	expected := []sql.Row{
 		{int64(1), "foo", addr, "foo", "query", int64(0), "a(4/5), b(2/6)", "SELECT foo"},
-		{int64(2), "foo", addr, "foo", "create_index", int64(0), "foo(1/2)", "SELECT bar"},
+		{int64(1), "foo", addr, "foo", "create_index", int64(0), "foo(1/2)", "SELECT bar"},
 	}
 
 	require.ElementsMatch(expected, rows)

--- a/sql/processlist_test.go
+++ b/sql/processlist_test.go
@@ -113,7 +113,7 @@ func TestKillConnection(t *testing.T) {
 		}
 	}
 
-	pl.KillConnection(1)
+	pl.Kill(1)
 	require.Len(t, pl.procs, 1)
 
 	// Odds should have been killed


### PR DESCRIPTION
Related to: https://github.com/src-d/gitbase/issues/817
Right now:
- `SHOW PROCESSLIST` lists all running processes where `Id` column contains `CONNECTION_ID`.
- `KILL QUERY connection_id` kills all queries for `connection_id`, but does not close the connection.
- `KILL [CONNECTION] connection_id` terminates all running queries for `connection_id`, and closes the connection.
