### PR TITLE
 sql: implement struct types

### DIFF
--- a/sql/analyzer/resolve_columns_test.go
+++ b/sql/analyzer/resolve_columns_test.go
@@ -186,14 +186,24 @@ func TestQualifyColumns(t *testing.T) {
 
 	node = plan.NewProject(
 		[]sql.Expression{
-			expression.NewUnresolvedQualifiedColumn("foo", "i"),
+			expression.NewUnresolvedQualifiedColumn("i", "some_field"),
 		},
-		plan.NewTableAlias("a", plan.NewResolvedTable(table)),
+		plan.NewResolvedTable(table),
 	)
 
-	_, err = f.Apply(sql.NewEmptyContext(), nil, node)
-	require.Error(err)
-	require.True(sql.ErrTableNotFound.Is(err))
+	expected = plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedField(
+				expression.NewUnresolvedColumn("i"),
+				"some_field",
+			),
+		},
+		plan.NewResolvedTable(table),
+	)
+
+	result, err = f.Apply(sql.NewEmptyContext(), nil, node)
+	require.NoError(err)
+	require.Equal(expected, result)
 
 	node = plan.NewProject(
 		[]sql.Expression{

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -12,6 +12,7 @@ var DefaultRules = []Rule{
 	{"resolve_grouping_columns", resolveGroupingColumns},
 	{"qualify_columns", qualifyColumns},
 	{"resolve_columns", resolveColumns},
+	{"resolve_struct_fields", resolveStructFields},
 	{"resolve_database", resolveDatabase},
 	{"resolve_star", resolveStar},
 	{"resolve_functions", resolveFunctions},

--- a/sql/expression/unresolved.go
+++ b/sql/expression/unresolved.go
@@ -135,3 +135,51 @@ func (uf *UnresolvedFunction) WithChildren(children ...sql.Expression) (sql.Expr
 	}
 	return NewUnresolvedFunction(uf.name, uf.IsAggregate, children...), nil
 }
+
+// UnresolvedField is an unresolved expression to get a field from a struct column.
+type UnresolvedField struct {
+	Struct sql.Expression
+	Name   string
+}
+
+// NewUnresolvedField creates a new UnresolvedField expression.
+func NewUnresolvedField(s sql.Expression, fieldName string) *UnresolvedField {
+	return &UnresolvedField{s, fieldName}
+}
+
+// Children implements the Expression interface.
+func (p *UnresolvedField) Children() []sql.Expression {
+	return []sql.Expression{p.Struct}
+}
+
+// Resolved implements the Expression interface.
+func (p *UnresolvedField) Resolved() bool {
+	return false
+}
+
+// IsNullable returns whether the field is nullable or not.
+func (p *UnresolvedField) IsNullable() bool {
+	panic("unresolved field is a placeholder node, but IsNullable was called")
+}
+
+// Type returns the type of the field.
+func (p *UnresolvedField) Type() sql.Type {
+	panic("unresolved field is a placeholder node, but Type was called")
+}
+
+// Eval implements the Expression interface.
+func (p *UnresolvedField) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	panic("unresolved field is a placeholder node, but Eval was called")
+}
+
+// WithChildren implements the Expression interface.
+func (p *UnresolvedField) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 1)
+	}
+	return &UnresolvedField{children[0], p.Name}, nil
+}
+
+func (p *UnresolvedField) String() string {
+	return fmt.Sprintf("%s.%s", p.Struct, p.Name)
+}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -779,6 +779,20 @@ func exprToExpression(e sqlparser.Expr) (sql.Expression, error) {
 		return expression.NewLiteral(nil, sql.Null), nil
 	case *sqlparser.ColName:
 		if !v.Qualifier.IsEmpty() {
+			// If we find something of the form A.B.C we're going to treat it
+			// as a struct field access.
+			// TODO: this should be handled better when GetFields support being
+			// qualified with the database.
+			if !v.Qualifier.Qualifier.IsEmpty() {
+				return expression.NewUnresolvedField(
+					expression.NewUnresolvedQualifiedColumn(
+						v.Qualifier.Qualifier.String(),
+						v.Qualifier.Name.String(),
+					),
+					v.Name.String(),
+				), nil
+			}
+
 			return expression.NewUnresolvedQualifiedColumn(
 				v.Qualifier.Name.String(),
 				v.Name.String(),

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1173,6 +1173,15 @@ var fixtures = map[string]sql.Node{
 		[]sql.Expression{},
 		plan.NewUnresolvedTable("foo", ""),
 	),
+	`SELECT a.b.c FROM a`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedField(
+				expression.NewUnresolvedQualifiedColumn("a", "b"),
+				"c",
+			),
+		},
+		plan.NewUnresolvedTable("a", ""),
+	),
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
Depends on #720

This PR implements struct types, which will be serialized to JSON
before being sent to the mysql client using the mysql wire proto.

Internally, structs are just `map[string]interface{}`, but they can
actually be anything that's convertible to that, because of the way
the Convert method of the struct type is implemented. That means,
the result of an UDF or a table that returns a struct may be an
actual Go struct and it will then be transformed into the internal
map. It does have a penalty, though, because structs require
encoding to JSON and then decoding into `map[string]interface{}`.
Structs have a schema, identical to a table schema, except their
`Source` will always be empty.

Resolution of columns has also been slightly change in order to
resolve getting fields from structs using the `.` operator, which
required some trade-offs in some rules, such as not erroring
anymore in `qualify_columns` when the table is not found. That
error was delegated to `resolve_columns` in order to make resolution
possible, as the syntax is a bit ambiguous.
The advantage of using dot is the fact that no changes have to be made
to the parser in order for it to work.