### PR TITLE
Upgrade vitess to v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,6 @@ require (
 	golang.org/x/net v0.0.0-20190227022144-312bce6e941f // indirect
 	google.golang.org/grpc v1.19.0 // indirect
 	gopkg.in/src-d/go-errors.v1 v1.0.0
-	gopkg.in/src-d/go-vitess.v1 v1.7.0
+	gopkg.in/src-d/go-vitess.v1 v1.8.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/src-d/go-errors.v1 v1.0.0 h1:cooGdZnCjYbeS1zb1s6pVAAimTdKceRrpn7aKOnNIfc=
 gopkg.in/src-d/go-errors.v1 v1.0.0/go.mod h1:q1cBlomlw2FnDBDNGlnh6X0jPihy+QxZfMMNxPCbdYg=
-gopkg.in/src-d/go-vitess.v1 v1.7.0 h1:7hYhf5sesJDLxl8//V/q6IyQJ4mOktLmkkfosMM9d00=
-gopkg.in/src-d/go-vitess.v1 v1.7.0/go.mod h1:+g/wDtovsUgE2ioi32fo5Vavrtvfd/N1AvnknTmTvZE=
+gopkg.in/src-d/go-vitess.v1 v1.8.0 h1:6SA2IpcfrYM96SKnqzEVQuQMitA1kAX4VyFbyH7wmug=
+gopkg.in/src-d/go-vitess.v1 v1.8.0/go.mod h1:+g/wDtovsUgE2ioi32fo5Vavrtvfd/N1AvnknTmTvZE=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
We should be able to switch back to _MariaDB connector_.