### PR TITLE
sql: use custom boolean coercion logic in condition evaluation

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1230,6 +1230,10 @@ var queries = []struct {
 		`SELECT (NULL+1)`,
 		[]sql.Row{{nil}},
 	},
+	{
+		`SELECT * FROM mytable WHERE NULL AND i = 3`,
+		[]sql.Row{},
+	},
 }
 
 func TestQueries(t *testing.T) {

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -107,12 +107,12 @@ func (i *FilterIter) Next() (sql.Row, error) {
 			return nil, err
 		}
 
-		result, err := i.cond.Eval(i.ctx, row)
+		ok, err := sql.EvaluateCondition(i.ctx, i.cond, row)
 		if err != nil {
 			return nil, err
 		}
 
-		if result == true {
+		if ok {
 			return row, nil
 		}
 	}

--- a/sql/type.go
+++ b/sql/type.go
@@ -616,25 +616,13 @@ func (t booleanT) Convert(v interface{}) (interface{}, error) {
 	case bool:
 		return b, nil
 	case int, int64, int32, int16, int8, uint, uint64, uint32, uint16, uint8:
-		if b != 0 {
-			return true, nil
-		}
-		return false, nil
+		return b != 0, nil
 	case time.Duration:
-		if int64(b) != 0 {
-			return true, nil
-		}
-		return false, nil
+		return int64(b) != 0, nil
 	case time.Time:
-		if b.UnixNano() != 0 {
-			return true, nil
-		}
-		return false, nil
+		return b.UnixNano() != 0, nil
 	case float32, float64:
-		if int(math.Round(v.(float64))) != 0 {
-			return true, nil
-		}
-		return false, nil
+		return int(math.Round(v.(float64))) != 0, nil
 	case string:
 		return false, fmt.Errorf("unable to cast string to bool")
 


### PR DESCRIPTION
Part of the fix for https://github.com/src-d/gitbase/issues/902

The idea is to use `EvaluateCondition` as a common logic for filtering in both gitbase squashed tables and go-mysql-server.

Right now, in go-mysql-server we just check the result `== true`, which not only is not correct but is not consistent with how gitbase does it.
In gitbase we use `sql.Boolean.Convert`, but by definition the convert method of boolean can't handle some types.

That's why I added some helper function for this with the type coercion logic that we can also reuse on gitbase.