### PR TITLE
sql: implement new API for node transformation

### DIFF
--- a/mem/table.go
+++ b/mem/table.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"strconv"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // Table represents an in-memory database table.
@@ -312,14 +312,14 @@ func (t *Table) HandledFilters(filters []sql.Expression) []sql.Expression {
 	var handled []sql.Expression
 	for _, f := range filters {
 		var hasOtherFields bool
-		_, _ = f.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		expression.Inspect(f, func(e sql.Expression) bool {
 			if e, ok := e.(*expression.GetField); ok {
 				if e.Table() != t.name || !t.schema.Contains(e.Name(), t.name) {
 					hasOtherFields = true
+					return false
 				}
 			}
-
-			return e, nil
+			return true
 		})
 
 		if !hasOtherFields {

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -16,7 +16,7 @@ func reorderAggregations(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, e
 
 	a.Log("reorder aggregations, node of type: %T", n)
 
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
 		case *plan.GroupBy:
 			if !hasHiddenAggregations(n.Aggregate...) {
@@ -38,7 +38,7 @@ func fixAggregations(projection, grouping []sql.Expression, child sql.Node) (sql
 
 	for i, p := range projection {
 		var transformed bool
-		e, err := p.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		e, err := expression.TransformUp(p, func(e sql.Expression) (sql.Expression, error) {
 			agg, ok := e.(sql.Aggregation)
 			if !ok {
 				return e, nil

--- a/sql/analyzer/assign_catalog.go
+++ b/sql/analyzer/assign_catalog.go
@@ -10,7 +10,7 @@ func assignCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 	span, _ := ctx.Span("assign_catalog")
 	defer span.Finish()
 
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		if !n.Resolved() {
 			return n, nil
 		}

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -20,7 +20,7 @@ func exprToTableFilters(expr sql.Expression) filters {
 	for _, expr := range splitExpression(expr) {
 		var seenTables = make(map[string]struct{})
 		var lastTable string
-		_, _ = expr.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		expression.Inspect(expr, func(e sql.Expression) bool {
 			f, ok := e.(*expression.GetField)
 			if ok {
 				if _, ok := seenTables[f.Table()]; !ok {
@@ -29,7 +29,7 @@ func exprToTableFilters(expr sql.Expression) filters {
 				}
 			}
 
-			return e, nil
+			return true
 		})
 
 		if len(seenTables) == 1 {

--- a/sql/analyzer/parallelize_test.go
+++ b/sql/analyzer/parallelize_test.go
@@ -3,11 +3,11 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/mem"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelize(t *testing.T) {
@@ -222,7 +222,7 @@ func TestRemoveRedundantExchanges(t *testing.T) {
 		),
 	)
 
-	result, err := node.TransformUp(removeRedundantExchanges)
+	result, err := plan.TransformUp(node, removeRedundantExchanges)
 	require.NoError(err)
 	require.Equal(expected, result)
 }

--- a/sql/analyzer/process.go
+++ b/sql/analyzer/process.go
@@ -19,7 +19,7 @@ func trackProcess(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	processList := a.Catalog.ProcessList
 
 	var seen = make(map[string]struct{})
-	n, err := n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	n, err := plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
 		case *plan.ResolvedTable:
 			switch n.Table.(type) {
@@ -73,7 +73,7 @@ func trackProcess(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 
 	// Remove QueryProcess nodes from the subqueries. Otherwise, the process
 	// will be marked as done as soon as a subquery finishes.
-	node, err := n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	node, err := plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		if sq, ok := n.(*plan.SubqueryAlias); ok {
 			if qp, ok := sq.Child.(*plan.QueryProcess); ok {
 				return plan.NewSubqueryAlias(sq.Name(), qp.Child), nil

--- a/sql/analyzer/pushdown_test.go
+++ b/sql/analyzer/pushdown_test.go
@@ -3,11 +3,11 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/mem"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPushdownProjectionAndFilters(t *testing.T) {
@@ -212,7 +212,7 @@ func TestPushdownIndexable(t *testing.T) {
 	require.NoError(err)
 
 	// we need to remove the release function to compare, otherwise it will fail
-	result, err = result.TransformUp(func(node sql.Node) (sql.Node, error) {
+	result, err = plan.TransformUp(result, func(node sql.Node) (sql.Node, error) {
 		switch node := node.(type) {
 		case *releaser:
 			return &releaser{Child: node.Child}, nil

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/plan"
 )
 
 func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -10,7 +11,7 @@ func resolveDatabase(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error
 
 	a.Log("resolve database, node of type: %T", n)
 
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		d, ok := n.(sql.Databaser)
 		if !ok {
 			return n, nil

--- a/sql/analyzer/resolve_functions.go
+++ b/sql/analyzer/resolve_functions.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/plan"
 )
 
 func resolveFunctions(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -10,13 +11,13 @@ func resolveFunctions(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, erro
 	defer span.Finish()
 
 	a.Log("resolve functions, node of type %T", n)
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
 		if n.Resolved() {
 			return n, nil
 		}
 
-		return n.TransformExpressionsUp(func(e sql.Expression) (sql.Expression, error) {
+		return plan.TransformExpressionsUp(n, func(e sql.Expression) (sql.Expression, error) {
 			a.Log("transforming expression of type: %T", e)
 			if e.Resolved() {
 				return e, nil

--- a/sql/analyzer/resolve_generators.go
+++ b/sql/analyzer/resolve_generators.go
@@ -1,11 +1,11 @@
 package analyzer
 
 import (
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/expression/function"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 )
 
 func resolveGenerators(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		p, ok := n.(*plan.Project)
 		if !ok {
 			return n, nil

--- a/sql/analyzer/resolve_orderby.go
+++ b/sql/analyzer/resolve_orderby.go
@@ -3,10 +3,10 @@ package analyzer
 import (
 	"strings"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 func resolveOrderBy(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -14,7 +14,7 @@ func resolveOrderBy(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error)
 	defer span.Finish()
 
 	a.Log("resolving order bys, node of type: %T", n)
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
 		sort, ok := n.(*plan.Sort)
 		if !ok {
@@ -175,7 +175,7 @@ func pushSortDown(sort *plan.Sort) (sql.Node, error) {
 func resolveOrderByLiterals(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	a.Log("resolve order by literals")
 
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		sort, ok := n.(*plan.Sort)
 		if !ok {
 			return n, nil

--- a/sql/analyzer/resolve_stars.go
+++ b/sql/analyzer/resolve_stars.go
@@ -11,7 +11,7 @@ func resolveStar(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	defer span.Finish()
 
 	a.Log("resolving star, node of type: %T", n)
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
 		if n.Resolved() {
 			return n, nil

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -10,7 +10,7 @@ func resolveSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, err
 	defer span.Finish()
 
 	a.Log("resolving subqueries")
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
 		case *plan.SubqueryAlias:
 			a.Log("found subquery %q with child of type %T", n.Name(), n.Child)

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -21,7 +21,7 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 	defer span.Finish()
 
 	a.Log("resolve table, node of type: %T", n)
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		a.Log("transforming node of type: %T", n)
 		if n.Resolved() {
 			return n, nil

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -676,17 +676,12 @@ func TestValidateExplodeUsage(t *testing.T) {
 
 type dummyNode struct{ resolved bool }
 
-func (n dummyNode) String() string                                    { return "dummynode" }
-func (n dummyNode) Resolved() bool                                    { return n.resolved }
-func (dummyNode) Schema() sql.Schema                                  { return nil }
-func (dummyNode) Children() []sql.Node                                { return nil }
-func (dummyNode) RowIter(*sql.Context) (sql.RowIter, error)           { return nil, nil }
-func (dummyNode) TransformUp(sql.TransformNodeFunc) (sql.Node, error) { return nil, nil }
-func (dummyNode) TransformExpressionsUp(
-	sql.TransformExprFunc,
-) (sql.Node, error) {
-	return nil, nil
-}
+func (n dummyNode) String() string                           { return "dummynode" }
+func (n dummyNode) Resolved() bool                           { return n.resolved }
+func (dummyNode) Schema() sql.Schema                         { return nil }
+func (dummyNode) Children() []sql.Node                       { return nil }
+func (dummyNode) RowIter(*sql.Context) (sql.RowIter, error)  { return nil, nil }
+func (dummyNode) WithChildren(...sql.Node) (sql.Node, error) { return nil, nil }
 
 func getValidationRule(name string) Rule {
 	for _, rule := range DefaultValidationRules {

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -31,13 +31,12 @@ func (e *Alias) String() string {
 	return fmt.Sprintf("%s as %s", e.Child, e.name)
 }
 
-// TransformUp implements the Expression interface.
-func (e *Alias) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *Alias) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-	return f(NewAlias(child, e.name))
+	return NewAlias(children[0], e.name), nil
 }
 
 // Name implements the Nameable interface.

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -137,19 +137,12 @@ func isInterval(expr sql.Expression) bool {
 	return ok
 }
 
-// TransformUp implements the Expression interface.
-func (a *Arithmetic) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	l, err := a.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (a *Arithmetic) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(a, len(children), 2)
 	}
-
-	r, err := a.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewArithmetic(l, r, a.Op))
+	return NewArithmetic(children[0], children[1], a.Op), nil
 }
 
 // Eval implements the Expression interface.
@@ -549,12 +542,10 @@ func (e *UnaryMinus) String() string {
 	return fmt.Sprintf("-%s", e.Child)
 }
 
-// TransformUp implements the sql.Expression interface.
-func (e *UnaryMinus) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	c, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *UnaryMinus) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-
-	return f(NewUnaryMinus(c))
+	return NewUnaryMinus(children[0]), nil
 }

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -98,22 +98,10 @@ func (b *Between) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return cmpLower >= 0 && cmpUpper <= 0, nil
 }
 
-// TransformUp implements the Expression interface.
-func (b *Between) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	val, err := b.Val.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (b *Between) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 3 {
+		return nil, sql.ErrInvalidChildrenNumber.New(b, len(children), 3)
 	}
-
-	lower, err := b.Lower.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	upper, err := b.Upper.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewBetween(val, lower, upper))
+	return NewBetween(children[0], children[1], children[2]), nil
 }

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -52,11 +52,10 @@ func (e *Not) String() string {
 	return fmt.Sprintf("NOT(%s)", e.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (e *Not) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *Not) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-	return f(NewNot(child))
+	return NewNot(children[0]), nil
 }

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/internal/regex"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // Comparer implements a comparison expression.
@@ -157,19 +157,12 @@ func (e *Equals) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return result == 0, nil
 }
 
-// TransformUp implements the Expression interface.
-func (e *Equals) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := e.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *Equals) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 2)
 	}
-
-	right, err := e.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewEquals(left, right))
+	return NewEquals(children[0], children[1]), nil
 }
 
 func (e *Equals) String() string {
@@ -278,19 +271,12 @@ func (re *Regexp) compareRegexp(ctx *sql.Context, row sql.Row) (interface{}, err
 	return ok, nil
 }
 
-// TransformUp implements the Expression interface.
-func (re *Regexp) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := re.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (re *Regexp) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(re, len(children), 2)
 	}
-
-	right, err := re.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewRegexp(left, right))
+	return NewRegexp(children[0], children[1]), nil
 }
 
 func (re *Regexp) String() string {
@@ -321,19 +307,12 @@ func (gt *GreaterThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 	return result == 1, nil
 }
 
-// TransformUp implements the Expression interface.
-func (gt *GreaterThan) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := gt.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (gt *GreaterThan) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(gt, len(children), 2)
 	}
-
-	right, err := gt.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewGreaterThan(left, right))
+	return NewGreaterThan(children[0], children[1]), nil
 }
 
 func (gt *GreaterThan) String() string {
@@ -364,19 +343,12 @@ func (lt *LessThan) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return result == -1, nil
 }
 
-// TransformUp implements the Expression interface.
-func (lt *LessThan) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := lt.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (lt *LessThan) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(lt, len(children), 2)
 	}
-
-	right, err := lt.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewLessThan(left, right))
+	return NewLessThan(children[0], children[1]), nil
 }
 
 func (lt *LessThan) String() string {
@@ -408,19 +380,12 @@ func (gte *GreaterThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{},
 	return result > -1, nil
 }
 
-// TransformUp implements the Expression interface.
-func (gte *GreaterThanOrEqual) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := gte.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (gte *GreaterThanOrEqual) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(gte, len(children), 2)
 	}
-
-	right, err := gte.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewGreaterThanOrEqual(left, right))
+	return NewGreaterThanOrEqual(children[0], children[1]), nil
 }
 
 func (gte *GreaterThanOrEqual) String() string {
@@ -452,19 +417,12 @@ func (lte *LessThanOrEqual) Eval(ctx *sql.Context, row sql.Row) (interface{}, er
 	return result < 1, nil
 }
 
-// TransformUp implements the Expression interface.
-func (lte *LessThanOrEqual) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := lte.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (lte *LessThanOrEqual) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(lte, len(children), 2)
 	}
-
-	right, err := lte.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewLessThanOrEqual(left, right))
+	return NewLessThanOrEqual(children[0], children[1]), nil
 }
 
 func (lte *LessThanOrEqual) String() string {
@@ -544,19 +502,12 @@ func (in *In) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 }
 
-// TransformUp implements the Expression interface.
-func (in *In) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := in.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (in *In) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(in, len(children), 2)
 	}
-
-	right, err := in.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewIn(left, right))
+	return NewIn(children[0], children[1]), nil
 }
 
 func (in *In) String() string {
@@ -632,19 +583,12 @@ func (in *NotIn) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 }
 
-// TransformUp implements the Expression interface.
-func (in *NotIn) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := in.Left().TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (in *NotIn) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(in, len(children), 2)
 	}
-
-	right, err := in.Right().TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewNotIn(left, right))
+	return NewNotIn(children[0], children[1]), nil
 }
 
 func (in *NotIn) String() string {

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/spf13/cast"
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // ErrConvertExpression is returned when a conversion is not possible.
@@ -90,14 +90,12 @@ func (c *Convert) String() string {
 	return fmt.Sprintf("convert(%v, %v)", c.Child, c.castToType)
 }
 
-// TransformUp implements the Expression interface.
-func (c *Convert) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := c.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (c *Convert) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
 	}
-
-	return f(NewConvert(child, c.castToType))
+	return NewConvert(children[0], c.castToType), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -53,8 +53,10 @@ func (*DefaultColumn) Eval(ctx *sql.Context, r sql.Row) (interface{}, error) {
 	panic("default column is a placeholder node, but Eval was called")
 }
 
-// TransformUp implements the sql.Expression interface.
-func (c *DefaultColumn) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	n := *c
-	return f(&n)
+// WithChildren implements the Expression interface.
+func (c *DefaultColumn) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 0)
+	}
+	return c, nil
 }

--- a/sql/expression/function/aggregation/avg.go
+++ b/sql/expression/function/aggregation/avg.go
@@ -53,13 +53,12 @@ func (a *Avg) Eval(ctx *sql.Context, buffer sql.Row) (interface{}, error) {
 	return sum / float64(rows), nil
 }
 
-// TransformUp implements AggregationExpression interface.
-func (a *Avg) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := a.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (a *Avg) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(a, len(children), 1)
 	}
-	return f(NewAvg(child))
+	return NewAvg(children[0]), nil
 }
 
 // NewBuffer implements AggregationExpression interface. (AggregationExpression)

--- a/sql/expression/function/aggregation/count.go
+++ b/sql/expression/function/aggregation/count.go
@@ -45,13 +45,12 @@ func (c *Count) String() string {
 	return fmt.Sprintf("COUNT(%s)", c.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (c *Count) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := c.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (c *Count) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
 	}
-	return f(NewCount(child))
+	return NewCount(children[0]), nil
 }
 
 // Update implements the Aggregation interface.

--- a/sql/expression/function/aggregation/first.go
+++ b/sql/expression/function/aggregation/first.go
@@ -27,13 +27,12 @@ func (f *First) String() string {
 	return fmt.Sprintf("FIRST(%s)", f.Child)
 }
 
-// TransformUp implements the Transformable interface.
-func (f *First) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := f.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the sql.Expression interface.
+func (f *First) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
 	}
-	return fn(NewFirst(child))
+	return NewFirst(children[0]), nil
 }
 
 // NewBuffer creates a new buffer to compute the result.

--- a/sql/expression/function/aggregation/last.go
+++ b/sql/expression/function/aggregation/last.go
@@ -27,13 +27,12 @@ func (l *Last) String() string {
 	return fmt.Sprintf("LAST(%s)", l.Child)
 }
 
-// TransformUp implements the Transformable interface.
-func (l *Last) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := l.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the sql.Expression interface.
+func (l *Last) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 1)
 	}
-	return fn(NewLast(child))
+	return NewLast(children[0]), nil
 }
 
 // NewBuffer creates a new buffer to compute the result.

--- a/sql/expression/function/aggregation/max.go
+++ b/sql/expression/function/aggregation/max.go
@@ -38,13 +38,12 @@ func (m *Max) IsNullable() bool {
 	return false
 }
 
-// TransformUp implements the Transformable interface.
-func (m *Max) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := m.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (m *Max) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(m, len(children), 1)
 	}
-	return f(NewMax(child))
+	return NewMax(children[0]), nil
 }
 
 // NewBuffer creates a new buffer to compute the result.

--- a/sql/expression/function/aggregation/min.go
+++ b/sql/expression/function/aggregation/min.go
@@ -38,13 +38,12 @@ func (m *Min) IsNullable() bool {
 	return true
 }
 
-// TransformUp implements the Transformable interface.
-func (m *Min) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := m.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (m *Min) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(m, len(children), 1)
 	}
-	return f(NewMin(child))
+	return NewMin(children[0]), nil
 }
 
 // NewBuffer creates a new buffer to compute the result.

--- a/sql/expression/function/aggregation/sum.go
+++ b/sql/expression/function/aggregation/sum.go
@@ -27,13 +27,12 @@ func (m *Sum) String() string {
 	return fmt.Sprintf("SUM(%s)", m.Child)
 }
 
-// TransformUp implements the Transformable interface.
-func (m *Sum) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := m.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (m *Sum) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(m, len(children), 1)
 	}
-	return f(NewSum(child))
+	return NewSum(children[0]), nil
 }
 
 // NewBuffer creates a new buffer to compute the result.

--- a/sql/expression/function/arraylength.go
+++ b/sql/expression/function/arraylength.go
@@ -26,13 +26,12 @@ func (f *ArrayLength) String() string {
 	return fmt.Sprintf("array_length(%s)", f.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (f *ArrayLength) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := f.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (f *ArrayLength) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
 	}
-	return fn(NewArrayLength(child))
+	return NewArrayLength(children[0]), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -32,13 +32,12 @@ func (c *Ceil) String() string {
 	return fmt.Sprintf("CEIL(%s)", c.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (c *Ceil) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := c.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (c *Ceil) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
 	}
-	return fn(NewCeil(child))
+	return NewCeil(children[0]), nil
 }
 
 // Eval implements the Expression interface.
@@ -99,13 +98,12 @@ func (f *Floor) String() string {
 	return fmt.Sprintf("FLOOR(%s)", f.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (f *Floor) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := f.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (f *Floor) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
 	}
-	return fn(NewFloor(child))
+	return NewFloor(children[0]), nil
 }
 
 // Eval implements the Expression interface.
@@ -269,30 +267,7 @@ func (r *Round) Type() sql.Type {
 	return sql.Int32
 }
 
-// TransformUp implements the Expression interface.
-func (r *Round) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, 2)
-
-	arg, err := r.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	args[0] = arg
-
-	args[1] = nil
-	if r.Right != nil {
-		var arg sql.Expression
-		arg, err = r.Right.TransformUp(f)
-		if err != nil {
-			return nil, err
-		}
-		args[1] = arg
-	}
-
-	expr, err := NewRound(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(expr)
+// WithChildren implements the Expression interface.
+func (r *Round) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewRound(children...)
 }

--- a/sql/expression/function/coalesce.go
+++ b/sql/expression/function/coalesce.go
@@ -59,29 +59,9 @@ func (c *Coalesce) String() string {
 	return fmt.Sprintf("coalesce(%s)", strings.Join(args, ", "))
 }
 
-// TransformUp implements the sql.Expression interface.
-func (c *Coalesce) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var (
-		args = make([]sql.Expression, len(c.args))
-		err  error
-	)
-
-	for i, arg := range c.args {
-		if arg != nil {
-			arg, err = arg.TransformUp(fn)
-			if err != nil {
-				return nil, err
-			}
-		}
-		args[i] = arg
-	}
-
-	expr, err := NewCoalesce(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(expr)
+// WithChildren implements the Expression interface.
+func (*Coalesce) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewCoalesce(children...)
 }
 
 // Resolved implements the sql.Expression interface.

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // Concat joins several strings together.
@@ -63,23 +63,9 @@ func (f *Concat) String() string {
 	return fmt.Sprintf("concat(%s)", strings.Join(args, ", "))
 }
 
-// TransformUp implements the Expression interface.
-func (f *Concat) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, len(f.args))
-	for i, arg := range f.args {
-		a, err := arg.TransformUp(fn)
-		if err != nil {
-			return nil, err
-		}
-		args[i] = a
-	}
-
-	expr, err := NewConcat(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(expr)
+// WithChildren implements the Expression interface.
+func (*Concat) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewConcat(children...)
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/function/concat_ws.go
+++ b/sql/expression/function/concat_ws.go
@@ -61,23 +61,9 @@ func (f *ConcatWithSeparator) String() string {
 	return fmt.Sprintf("concat_ws(%s)", strings.Join(args, ", "))
 }
 
-// TransformUp implements the Expression interface.
-func (f *ConcatWithSeparator) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, len(f.args))
-	for i, arg := range f.args {
-		a, err := arg.TransformUp(fn)
-		if err != nil {
-			return nil, err
-		}
-		args[i] = a
-	}
-
-	expr, err := NewConcatWithSeparator(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(expr)
+// WithChildren implements the Expression interface.
+func (*ConcatWithSeparator) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewConcatWithSeparator(children...)
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/function/connection_id.go
+++ b/sql/expression/function/connection_id.go
@@ -19,9 +19,12 @@ func (ConnectionID) Type() sql.Type { return sql.Uint32 }
 // Resolved implements the sql.Expression interface.
 func (ConnectionID) Resolved() bool { return true }
 
-// TransformUp implements the sql.Expression interface.
-func (ConnectionID) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	return f(ConnectionID{})
+// WithChildren implements the Expression interface.
+func (c ConnectionID) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 0)
+	}
+	return c, nil
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/sql/expression/function/database.go
+++ b/sql/expression/function/database.go
@@ -29,9 +29,12 @@ func (*Database) String() string {
 	return "DATABASE()"
 }
 
-// TransformUp implements the sql.Expression interface.
-func (db *Database) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	return fn(db)
+// WithChildren implements the Expression interface.
+func (d *Database) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 0)
+	}
+	return NewDatabase(d.catalog)(), nil
 }
 
 // Resolved implements the sql.Expression interface.

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -46,18 +46,9 @@ func (d *DateAdd) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (d *DateAdd) Type() sql.Type { return sql.Date }
 
-// TransformUp implements the sql.Expression interface.
-func (d *DateAdd) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	date, err := d.Date.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	interval, err := d.Interval.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DateAdd{date, interval.(*expression.Interval)}, nil
+// WithChildren implements the Expression interface.
+func (d *DateAdd) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewDateAdd(children...)
 }
 
 // Eval implements the sql.Expression interface.
@@ -130,18 +121,9 @@ func (d *DateSub) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (d *DateSub) Type() sql.Type { return sql.Date }
 
-// TransformUp implements the sql.Expression interface.
-func (d *DateSub) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	date, err := d.Date.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	interval, err := d.Interval.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DateSub{date, interval.(*expression.Interval)}, nil
+// WithChildren implements the Expression interface.
+func (d *DateSub) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewDateSub(children...)
 }
 
 // Eval implements the sql.Expression interface.

--- a/sql/expression/function/explode.go
+++ b/sql/expression/function/explode.go
@@ -40,14 +40,12 @@ func (e *Explode) String() string {
 	return fmt.Sprintf("EXPLODE(%s)", e.Child)
 }
 
-// TransformUp implements the sql.Expression interface.
-func (e *Explode) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	c, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *Explode) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-
-	return f(NewExplode(c))
+	return NewExplode(children[0]), nil
 }
 
 // Generate is a function that generates a row for each value of its child.
@@ -84,12 +82,10 @@ func (e *Generate) String() string {
 	return fmt.Sprintf("EXPLODE(%s)", e.Child)
 }
 
-// TransformUp implements the sql.Expression interface.
-func (e *Generate) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	c, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *Generate) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-
-	return f(NewGenerate(c))
+	return NewGenerate(children[0]), nil
 }

--- a/sql/expression/function/greatest_least.go
+++ b/sql/expression/function/greatest_least.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 var ErrUintOverflow = errors.NewKind(
@@ -194,23 +194,9 @@ func (f *Greatest) String() string {
 	return fmt.Sprintf("greatest(%s)", strings.Join(args, ", "))
 }
 
-// TransformUp implements the Expression interface.
-func (f *Greatest) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, len(f.Args))
-	for i, arg := range f.Args {
-		a, err := arg.TransformUp(fn)
-		if err != nil {
-			return nil, err
-		}
-		args[i] = a
-	}
-
-	expr, err := NewGreatest(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(expr)
+// WithChildren implements the Expression interface.
+func (f *Greatest) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewGreatest(children...)
 }
 
 // Resolved implements the Expression interface.
@@ -298,23 +284,9 @@ func (f *Least) String() string {
 	return fmt.Sprintf("least(%s)", strings.Join(args, ", "))
 }
 
-// TransformUp implements the Expression interface.
-func (f *Least) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, len(f.Args))
-	for i, arg := range f.Args {
-		a, err := arg.TransformUp(fn)
-		if err != nil {
-			return nil, err
-		}
-		args[i] = a
-	}
-
-	expr, err := NewLeast(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(expr)
+// WithChildren implements the Expression interface.
+func (f *Least) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewLeast(children...)
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/function/ifnull.go
+++ b/sql/expression/function/ifnull.go
@@ -65,17 +65,10 @@ func (f *IfNull) String() string {
 	return fmt.Sprintf("ifnull(%s, %s)", f.Left, f.Right)
 }
 
-// TransformUp implements the Expression interface.
-func (f *IfNull) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := f.Left.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (f *IfNull) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 2)
 	}
-
-	right, err := f.Right.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(NewIfNull(left, right))
+	return NewIfNull(children[0], children[1]), nil
 }

--- a/sql/expression/function/isbinary.go
+++ b/sql/expression/function/isbinary.go
@@ -45,13 +45,12 @@ func (ib *IsBinary) String() string {
 	return fmt.Sprintf("IS_BINARY(%s)", ib.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (ib *IsBinary) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := ib.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (ib *IsBinary) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(ib, len(children), 1)
 	}
-	return f(NewIsBinary(child))
+	return NewIsBinary(children[0]), nil
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -108,22 +108,9 @@ func (j *JSONExtract) Children() []sql.Expression {
 	return append([]sql.Expression{j.JSON}, j.Paths...)
 }
 
-// TransformUp implements the sql.Expression interface.
-func (j *JSONExtract) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	json, err := j.JSON.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	paths := make([]sql.Expression, len(j.Paths))
-	for i, p := range j.Paths {
-		paths[i], err = p.TransformUp(f)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return f(&JSONExtract{json, paths})
+// WithChildren implements the Expression interface.
+func (j *JSONExtract) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewJSONExtract(children...)
 }
 
 func (j *JSONExtract) String() string {

--- a/sql/expression/function/json_unquote.go
+++ b/sql/expression/function/json_unquote.go
@@ -33,13 +33,12 @@ func (*JSONUnquote) Type() sql.Type {
 	return sql.Text
 }
 
-// TransformUp implements the Expression interface.
-func (js *JSONUnquote) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	json, err := js.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (js *JSONUnquote) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(js, len(children), 1)
 	}
-	return f(NewJSONUnquote(json))
+	return NewJSONUnquote(children[0]), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/length.go
+++ b/sql/expression/function/length.go
@@ -35,16 +35,13 @@ func NewCharLength(e sql.Expression) sql.Expression {
 	return &Length{expression.UnaryExpression{Child: e}, NumChars}
 }
 
-// TransformUp implements the sql.Expression interface.
-func (l *Length) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := l.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (l *Length) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 1)
 	}
 
-	nl := *l
-	nl.Child = child
-	return &nl, nil
+	return &Length{expression.UnaryExpression{Child: children[0]}, l.CountType}, nil
 }
 
 // Type implements the sql.Expression interface.

--- a/sql/expression/function/logarithm.go
+++ b/sql/expression/function/logarithm.go
@@ -5,9 +5,9 @@ import (
 	"math"
 	"reflect"
 
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 // ErrInvalidArgumentForLogarithm is returned when an invalid argument value is passed to a
@@ -45,13 +45,12 @@ func (l *LogBase) String() string {
 	}
 }
 
-// TransformUp implements the Expression interface.
-func (l *LogBase) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := l.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (l *LogBase) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 1)
 	}
-	return f(NewLogBase(l.base, child))
+	return NewLogBase(l.base, children[0]), nil
 }
 
 // Type returns the resultant type of the function.
@@ -108,26 +107,9 @@ func (l *Log) String() string {
 	return fmt.Sprintf("log(%s, %s)", l.Left, l.Right)
 }
 
-// TransformUp implements the Expression interface.
-func (l *Log) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	var args = make([]sql.Expression, 2)
-	arg, err := l.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	args[0] = arg
-
-	arg, err = l.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	args[1] = arg
-	expr, err := NewLog(args...)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(expr)
+// WithChildren implements the Expression interface.
+func (l *Log) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewLog(children...)
 }
 
 // Children implements the Expression interface.

--- a/sql/expression/function/lower_upper.go
+++ b/sql/expression/function/lower_upper.go
@@ -2,9 +2,10 @@ package function
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
-	"strings"
 )
 
 // Lower is a function that returns the lowercase of the text provided.
@@ -43,13 +44,12 @@ func (l *Lower) String() string {
 	return fmt.Sprintf("LOWER(%s)", l.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (l *Lower) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := l.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (l *Lower) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 1)
 	}
-	return f(NewLower(child))
+	return NewLower(children[0]), nil
 }
 
 // Type implements the Expression interface.
@@ -93,13 +93,12 @@ func (u *Upper) String() string {
 	return fmt.Sprintf("UPPER(%s)", u.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (u *Upper) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := u.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (u *Upper) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
 	}
-	return f(NewUpper(child))
+	return NewUpper(children[0]), nil
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/nullif.go
+++ b/sql/expression/function/nullif.go
@@ -57,17 +57,10 @@ func (f *NullIf) String() string {
 	return fmt.Sprintf("nullif(%s, %s)", f.Left, f.Right)
 }
 
-// TransformUp implements the Expression interface.
-func (f *NullIf) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := f.Left.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (f *NullIf) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 2)
 	}
-
-	right, err := f.Right.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(NewNullIf(left, right))
+	return NewNullIf(children[0], children[1]), nil
 }

--- a/sql/expression/function/reverse_repeat_replace.go
+++ b/sql/expression/function/reverse_repeat_replace.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
 	"gopkg.in/src-d/go-errors.v1"
 )
 
@@ -39,7 +39,7 @@ func (r *Reverse) Eval(
 
 func reverseString(s string) string {
 	r := []rune(s)
-	for i, j := 0, len(r) - 1; i < j; i, j = i+1, j-1 {
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
 		r[i], r[j] = r[j], r[i]
 	}
 	return string(r)
@@ -49,13 +49,12 @@ func (r *Reverse) String() string {
 	return fmt.Sprintf("reverse(%s)", r.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (r *Reverse) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := r.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (r *Reverse) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), 1)
 	}
-	return f(NewReverse(child))
+	return NewReverse(children[0]), nil
 }
 
 // Type implements the Expression interface.
@@ -84,18 +83,12 @@ func (r *Repeat) Type() sql.Type {
 	return sql.Text
 }
 
-// TransformUp implements the Expression interface.
-func (r *Repeat) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := r.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (r *Repeat) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), 2)
 	}
-
-	right, err := r.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return f(NewRepeat(left, right))
+	return NewRepeat(children[0], children[1]), nil
 }
 
 // Eval implements the Expression interface.
@@ -165,23 +158,12 @@ func (r *Replace) Type() sql.Type {
 	return sql.Text
 }
 
-// TransformUp implements the Expression interface.
-func (r *Replace) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	str, err := r.str.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (r *Replace) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 3 {
+		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), 3)
 	}
-
-	fromStr, err := r.fromStr.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	toStr, err := r.toStr.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return f(NewReplace(str, fromStr, toStr))
+	return NewReplace(children[0], children[1], children[2]), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/rpad_lpad.go
+++ b/sql/expression/function/rpad_lpad.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 var ErrDivisionByZero = errors.NewKind("division by zero")
@@ -68,24 +68,9 @@ func (p *Pad) String() string {
 	return fmt.Sprintf("rpad(%s, %s, %s)", p.str, p.length, p.padStr)
 }
 
-// TransformUp implements the Expression interface.
-func (p *Pad) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	str, err := p.str.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	len, err := p.length.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	padStr, err := p.padStr.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-	padded, _ := NewPad(p.padType, str, len, padStr)
-	return f(padded)
+// WithChildren implements the Expression interface.
+func (p *Pad) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewPad(p.padType, children...)
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/sleep.go
+++ b/sql/expression/function/sleep.go
@@ -37,7 +37,7 @@ func (s *Sleep) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	time.Sleep(time.Duration(child.(float64) * 1000)  * time.Millisecond)
+	time.Sleep(time.Duration(child.(float64)*1000) * time.Millisecond)
 	return 0, nil
 }
 
@@ -51,13 +51,12 @@ func (s *Sleep) IsNullable() bool {
 	return false
 }
 
-// TransformUp implements the Expression interface.
-func (s *Sleep) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := s.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (s *Sleep) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
-	return f(NewSleep(child))
+	return NewSleep(children[0]), nil
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -87,13 +87,12 @@ func (s *Soundex) String() string {
 	return fmt.Sprintf("SOUNDEX(%s)", s.Child)
 }
 
-// TransformUp implements the Expression interface.
-func (s *Soundex) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := s.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (s *Soundex) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
-	return f(NewSoundex(child))
+	return NewSoundex(children[0]), nil
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/split.go
+++ b/sql/expression/function/split.go
@@ -76,17 +76,10 @@ func (f *Split) String() string {
 	return fmt.Sprintf("split(%s, %s)", f.Left, f.Right)
 }
 
-// TransformUp implements the Expression interface.
-func (f *Split) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := f.Left.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (f *Split) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 2)
 	}
-
-	right, err := f.Right.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(NewSplit(left, right))
+	return NewSplit(children[0], children[1]), nil
 }

--- a/sql/expression/function/sqrt_power.go
+++ b/sql/expression/function/sqrt_power.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
 )
 
 // Sqrt is a function that returns the square value of the number provided.
@@ -32,13 +32,12 @@ func (s *Sqrt) IsNullable() bool {
 	return s.Child.IsNullable()
 }
 
-// TransformUp implements the Expression interface.
-func (s *Sqrt) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := s.Child.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (s *Sqrt) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
-	return fn(NewSqrt(child))
+	return NewSqrt(children[0]), nil
 }
 
 // Eval implements the Expression interface.
@@ -86,19 +85,12 @@ func (p *Power) String() string {
 	return fmt.Sprintf("power(%s, %s)", p.Left, p.Right)
 }
 
-// TransformUp implements the Expression interface.
-func (p *Power) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := p.Left.TransformUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (p *Power) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 2)
 	}
-
-	right, err := p.Right.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(NewPower(left, right))
+	return NewPower(children[0], children[0]), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -66,14 +66,12 @@ func (y *Year) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, y.UnaryExpression, row, year)
 }
 
-// TransformUp implements the Expression interface.
-func (y *Year) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := y.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (y *Year) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(y, len(children), 1)
 	}
-
-	return f(NewYear(child))
+	return NewYear(children[0]), nil
 }
 
 // Month is a function that returns the month of a date.
@@ -96,14 +94,12 @@ func (m *Month) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, m.UnaryExpression, row, month)
 }
 
-// TransformUp implements the Expression interface.
-func (m *Month) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := m.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (m *Month) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(m, len(children), 1)
 	}
-
-	return f(NewMonth(child))
+	return NewMonth(children[0]), nil
 }
 
 // Day is a function that returns the day of a date.
@@ -126,14 +122,12 @@ func (d *Day) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, day)
 }
 
-// TransformUp implements the Expression interface.
-func (d *Day) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (d *Day) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-
-	return f(NewDay(child))
+	return NewDay(children[0]), nil
 }
 
 // Weekday is a function that returns the weekday of a date where 0 = Monday,
@@ -157,14 +151,12 @@ func (d *Weekday) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, weekday)
 }
 
-// TransformUp implements the Expression interface.
-func (d *Weekday) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (d *Weekday) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-
-	return f(NewWeekday(child))
+	return NewWeekday(children[0]), nil
 }
 
 // Hour is a function that returns the hour of a date.
@@ -187,14 +179,12 @@ func (h *Hour) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, h.UnaryExpression, row, hour)
 }
 
-// TransformUp implements the Expression interface.
-func (h *Hour) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := h.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (h *Hour) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(h, len(children), 1)
 	}
-
-	return f(NewHour(child))
+	return NewHour(children[0]), nil
 }
 
 // Minute is a function that returns the minute of a date.
@@ -217,14 +207,12 @@ func (m *Minute) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, m.UnaryExpression, row, minute)
 }
 
-// TransformUp implements the Expression interface.
-func (m *Minute) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := m.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (m *Minute) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(m, len(children), 1)
 	}
-
-	return f(NewMinute(child))
+	return NewMinute(children[0]), nil
 }
 
 // Second is a function that returns the second of a date.
@@ -247,14 +235,12 @@ func (s *Second) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, s.UnaryExpression, row, second)
 }
 
-// TransformUp implements the Expression interface.
-func (s *Second) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := s.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (s *Second) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
-
-	return f(NewSecond(child))
+	return NewSecond(children[0]), nil
 }
 
 // DayOfWeek is a function that returns the day of the week from a date where
@@ -278,14 +264,12 @@ func (d *DayOfWeek) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, dayOfWeek)
 }
 
-// TransformUp implements the Expression interface.
-func (d *DayOfWeek) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (d *DayOfWeek) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-
-	return f(NewDayOfWeek(child))
+	return NewDayOfWeek(children[0]), nil
 }
 
 // DayOfYear is a function that returns the day of the year from a date.
@@ -308,14 +292,12 @@ func (d *DayOfYear) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, dayOfYear)
 }
 
-// TransformUp implements the Expression interface.
-func (d *DayOfYear) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (d *DayOfYear) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-
-	return f(NewDayOfYear(child))
+	return NewDayOfYear(children[0]), nil
 }
 
 func datePartFunc(fn func(time.Time) int) func(interface{}) interface{} {
@@ -403,23 +385,9 @@ func (d *YearWeek) IsNullable() bool {
 	return d.date.IsNullable()
 }
 
-// TransformUp implements the Expression interface.
-func (d *YearWeek) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	date, err := d.date.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	mode, err := d.mode.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	yw, err := NewYearWeek(date, mode)
-	if err != nil {
-		return nil, err
-	}
-	return f(yw)
+// WithChildren implements the Expression interface.
+func (*YearWeek) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewYearWeek(children...)
 }
 
 // Following solution of YearWeek was taken from tidb: https://github.com/pingcap/tidb/blob/master/types/mytime.go
@@ -567,9 +535,12 @@ func (n *Now) Eval(*sql.Context, sql.Row) (interface{}, error) {
 	return n.clock(), nil
 }
 
-// TransformUp implements the sql.Expression interface.
-func (n *Now) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	return f(n)
+// WithChildren implements the Expression interface.
+func (n *Now) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 0)
+	}
+	return n, nil
 }
 
 // Date a function takes the DATE part out from a datetime expression.
@@ -598,12 +569,10 @@ func (d *Date) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	})
 }
 
-// TransformUp implements the sql.Expression interface.
-func (d *Date) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (d *Date) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-
-	return f(NewDate(child))
+	return NewDate(children[0]), nil
 }

--- a/sql/expression/function/tobase64_frombase64.go
+++ b/sql/expression/function/tobase64_frombase64.go
@@ -72,20 +72,18 @@ func (t *ToBase64) IsNullable() bool {
 	return t.Child.IsNullable()
 }
 
-// TransformUp implements the Expression interface.
-func (t *ToBase64) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := t.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (t *ToBase64) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 1)
 	}
-	return f(NewToBase64(child))
+	return NewToBase64(children[0]), nil
 }
 
 // Type implements the Expression interface.
 func (t *ToBase64) Type() sql.Type {
 	return sql.Text
 }
-
 
 // FromBase64 is a function to decode a Base64-formatted string
 // using the same dialect that MySQL's FROM_BASE64 uses
@@ -133,13 +131,12 @@ func (t *FromBase64) IsNullable() bool {
 	return t.Child.IsNullable()
 }
 
-// TransformUp implements the Expression interface.
-func (t *FromBase64) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := t.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (t *FromBase64) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 1)
 	}
-	return f(NewFromBase64(child))
+	return NewFromBase64(children[0]), nil
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/trim_ltrim_rtrim.go
+++ b/sql/expression/function/trim_ltrim_rtrim.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
 )
 
 type trimType rune
+
 const (
 	lTrimType trimType = 'l'
 	rTrimType trimType = 'r'
@@ -54,14 +55,12 @@ func (t *Trim) IsNullable() bool {
 	return t.Child.IsNullable()
 }
 
-// TransformUp implements the Expression interface.
-func (t *Trim) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	str, err := t.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (t *Trim) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 1)
 	}
-
-	return f(NewTrim(t.trimType, str))
+	return NewTrim(t.trimType, children[0]), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/version.go
+++ b/sql/expression/function/version.go
@@ -30,9 +30,12 @@ func (f Version) String() string {
 	return "VERSION()"
 }
 
-// TransformUp implements the Expression interface.
-func (f Version) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	return fn(f)
+// WithChildren implements the Expression interface.
+func (f Version) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 0)
+	}
+	return f, nil
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -3,8 +3,8 @@ package expression
 import (
 	"fmt"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // GetField is an expression to get the field of a table.
@@ -72,10 +72,12 @@ func (p *GetField) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return row[p.fieldIndex], nil
 }
 
-// TransformUp implements the Expression interface.
-func (p *GetField) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	n := *p
-	return f(&n)
+// WithChildren implements the Expression interface.
+func (p *GetField) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
+	return p, nil
 }
 
 func (p *GetField) String() string {
@@ -124,7 +126,10 @@ func (f *GetSessionField) Resolved() bool { return true }
 // String implements the sql.Expression interface.
 func (f *GetSessionField) String() string { return "@@" + f.name }
 
-// TransformUp implements the sql.Expression interface.
-func (f *GetSessionField) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	return fn(f)
+// WithChildren implements the Expression interface.
+func (f *GetSessionField) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 0)
+	}
+	return f, nil
 }

--- a/sql/expression/interval.go
+++ b/sql/expression/interval.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // Interval defines a time duration.
@@ -148,14 +148,12 @@ func (i *Interval) EvalDelta(ctx *sql.Context, row sql.Row) (*TimeDelta, error) 
 	return &td, nil
 }
 
-// TransformUp implements the sql.Expression interface.
-func (i *Interval) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := i.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (i *Interval) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(i, len(children), 1)
 	}
-
-	return NewInterval(child, i.Unit), nil
+	return NewInterval(children[0], i.Unit), nil
 }
 
 func (i *Interval) String() string {

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -36,11 +36,10 @@ func (e IsNull) String() string {
 	return e.Child.String() + " IS NULL"
 }
 
-// TransformUp implements the Expression interface.
-func (e *IsNull) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	child, err := e.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (e *IsNull) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
-	return f(NewIsNull(child))
+	return NewIsNull(children[0]), nil
 }

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -107,19 +107,12 @@ func (l *Like) String() string {
 	return fmt.Sprintf("%s LIKE %s", l.Left, l.Right)
 }
 
-// TransformUp implements the sql.Expression interface.
-func (l *Like) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := l.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (l *Like) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 2)
 	}
-
-	right, err := l.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewLike(left, right))
+	return NewLike(children[0], children[1]), nil
 }
 
 func patternToRegex(pattern string) string {

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -53,10 +53,12 @@ func (p *Literal) String() string {
 	}
 }
 
-// TransformUp implements the Expression interface.
-func (p *Literal) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	n := *p
-	return f(&n)
+// WithChildren implements the Expression interface.
+func (p *Literal) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
+	return p, nil
 }
 
 // Children implements the Expression interface.

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -68,19 +68,12 @@ func (a *And) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return true, nil
 }
 
-// TransformUp implements the Expression interface.
-func (a *And) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := a.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (a *And) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(a, len(children), 2)
 	}
-
-	right, err := a.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewAnd(left, right))
+	return NewAnd(children[0], children[1]), nil
 }
 
 // Or checks whether one of the two given expressions is true.
@@ -125,17 +118,10 @@ func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return rval == true, nil
 }
 
-// TransformUp implements the Expression interface.
-func (o *Or) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	left, err := o.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Expression interface.
+func (o *Or) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(o, len(children), 2)
 	}
-
-	right, err := o.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewOr(left, right))
+	return NewOr(children[0], children[1]), nil
 }

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -55,8 +55,10 @@ func (*Star) Eval(ctx *sql.Context, r sql.Row) (interface{}, error) {
 	panic("star is just a placeholder node, but Eval was called")
 }
 
-// TransformUp implements the Expression interface.
-func (s *Star) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	n := *s
-	return f(&n)
+// WithChildren implements the Expression interface.
+func (s *Star) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 0)
+	}
+	return s, nil
 }

--- a/sql/expression/transform.go
+++ b/sql/expression/transform.go
@@ -1,0 +1,28 @@
+package expression
+
+import "github.com/src-d/go-mysql-server/sql"
+
+// TransformUp applies a transformation function to the given expression from the
+// bottom up.
+func TransformUp(e sql.Expression, f sql.TransformExprFunc) (sql.Expression, error) {
+	children := e.Children()
+	if len(children) == 0 {
+		return f(e)
+	}
+
+	newChildren := make([]sql.Expression, len(children))
+	for i, c := range children {
+		c, err := TransformUp(c, f)
+		if err != nil {
+			return nil, err
+		}
+		newChildren[i] = c
+	}
+
+	e, err := e.WithChildren(newChildren...)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(e)
+}

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -77,18 +77,12 @@ func (t Tuple) Type() sql.Type {
 	return sql.Tuple(types...)
 }
 
-// TransformUp implements the Expression interface.
-func (t Tuple) TransformUp(f sql.TransformExprFunc) (sql.Expression, error) {
-	var exprs = make([]sql.Expression, len(t))
-	for i, e := range t {
-		var err error
-		exprs[i], err = f(e)
-		if err != nil {
-			return nil, err
-		}
+// WithChildren implements the Expression interface.
+func (t Tuple) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != len(t) {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), len(t))
 	}
-
-	return f(Tuple(exprs))
+	return NewTuple(children...), nil
 }
 
 // Children implements the Expression interface.

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -401,8 +401,8 @@ var _ Expression = (*dummyExpr)(nil)
 
 func (dummyExpr) Children() []Expression                  { return nil }
 func (dummyExpr) Eval(*Context, Row) (interface{}, error) { panic("not implemented") }
-func (e dummyExpr) TransformUp(fn TransformExprFunc) (Expression, error) {
-	return fn(e)
+func (e dummyExpr) WithChildren(children ...Expression) (Expression, error) {
+	return e, nil
 }
 func (e dummyExpr) String() string { return fmt.Sprintf("dummyExpr{%d, %s}", e.index, e.colName) }
 func (dummyExpr) IsNullable() bool { return false }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -168,7 +168,7 @@ func convertSet(ctx *sql.Context, n *sqlparser.Set) (sql.Node, error) {
 		}
 
 		name := strings.TrimSpace(e.Name.Lowered())
-		if expr, err = expr.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		if expr, err = expression.TransformUp(expr, func(e sql.Expression) (sql.Expression, error) {
 			if _, ok := e.(*expression.DefaultColumn); ok {
 				return e, nil
 			}

--- a/sql/plan/common.go
+++ b/sql/plan/common.go
@@ -57,20 +57,3 @@ func expressionsResolved(exprs ...sql.Expression) bool {
 
 	return true
 }
-
-func transformExpressionsUp(
-	f sql.TransformExprFunc,
-	exprs []sql.Expression,
-) ([]sql.Expression, error) {
-
-	var es []sql.Expression
-	for _, e := range exprs {
-		te, err := e.TransformUp(f)
-		if err != nil {
-			return nil, err
-		}
-		es = append(es, te)
-	}
-
-	return es, nil
-}

--- a/sql/plan/cross_join.go
+++ b/sql/plan/cross_join.go
@@ -66,34 +66,13 @@ func (p *CrossJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (p *CrossJoin) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := p.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (p *CrossJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 2)
 	}
 
-	right, err := p.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewCrossJoin(left, right))
-}
-
-// TransformExpressionsUp implements the Transformable interface.
-func (p *CrossJoin) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := p.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	right, err := p.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewCrossJoin(left, right), nil
+	return NewCrossJoin(children[0], children[1]), nil
 }
 
 func (p *CrossJoin) String() string {

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -1,8 +1,8 @@
 package plan
 
 import (
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 // ErrCreateTable is thrown when the database doesn't support table creation
@@ -64,13 +64,11 @@ func (c *CreateTable) Schema() sql.Schema { return nil }
 // Children implements the Node interface.
 func (c *CreateTable) Children() []sql.Node { return nil }
 
-// TransformUp implements the Transformable interface.
-func (c *CreateTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewCreateTable(c.db, c.name, c.schema))
-}
-
-// TransformExpressionsUp implements the Transformable interface.
-func (c *CreateTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+// WithChildren implements the Node interface.
+func (c *CreateTable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 0)
+	}
 	return c, nil
 }
 

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -33,22 +33,13 @@ func (d *Describe) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return &describeIter{schema: d.Child.Schema()}, nil
 }
 
-// TransformUp implements the Transformable interface.
-func (d *Describe) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (d *Describe) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-	return f(NewDescribe(child))
-}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (d *Describe) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := d.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return NewDescribe(child), nil
+	return NewDescribe(children[0]), nil
 }
 
 func (d Describe) String() string {
@@ -116,22 +107,11 @@ func (d *DescribeQuery) String() string {
 	return pr.String()
 }
 
-// TransformUp implements the Node interface.
-func (d *DescribeQuery) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (d *DescribeQuery) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
 
-	return f(NewDescribeQuery(d.Format, child))
-}
-
-// TransformExpressionsUp implements the Node interface.
-func (d *DescribeQuery) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := d.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewDescribeQuery(d.Format, child), nil
+	return NewDescribeQuery(d.Format, children[0]), nil
 }

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -37,22 +37,13 @@ func (d *Distinct) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, newDistinctIter(it)), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (d *Distinct) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (d *Distinct) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-	return f(NewDistinct(child))
-}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (d *Distinct) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := d.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return NewDistinct(child), nil
+	return NewDistinct(children[0]), nil
 }
 
 func (d Distinct) String() string {
@@ -135,22 +126,13 @@ func (d *OrderedDistinct) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, newOrderedDistinctIter(it, d.Child.Schema())), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (d *OrderedDistinct) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := d.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (d *OrderedDistinct) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-	return f(NewOrderedDistinct(child))
-}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (d *OrderedDistinct) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := d.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return NewOrderedDistinct(child), nil
+	return NewOrderedDistinct(children[0]), nil
 }
 
 func (d OrderedDistinct) String() string {

--- a/sql/plan/drop_index.go
+++ b/sql/plan/drop_index.go
@@ -1,9 +1,9 @@
 package plan
 
 import (
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/internal/similartext"
 	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 var (
@@ -104,26 +104,13 @@ func (d *DropIndex) String() string {
 	return pr.String()
 }
 
-// TransformExpressionsUp implements the Node interface.
-func (d *DropIndex) TransformExpressionsUp(fn sql.TransformExprFunc) (sql.Node, error) {
-	t, err := d.Table.TransformExpressionsUp(fn)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (d *DropIndex) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
 
-	nc := *d
-	nc.Table = t
-	return &nc, nil
-}
-
-// TransformUp implements the Node interface.
-func (d *DropIndex) TransformUp(fn sql.TransformNodeFunc) (sql.Node, error) {
-	t, err := d.Table.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	nc := *d
-	nc.Table = t
-	return fn(&nc)
+	nd := *d
+	nd.Table = children[0]
+	return &nd, nil
 }

--- a/sql/plan/empty_table.go
+++ b/sql/plan/empty_table.go
@@ -16,12 +16,11 @@ func (emptyTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (e *emptyTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(e)
-}
+// WithChildren implements the Node interface.
+func (e *emptyTable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(e, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (e *emptyTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return e, nil
 }

--- a/sql/plan/exchange_test.go
+++ b/sql/plan/exchange_test.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExchange(t *testing.T) {
@@ -106,11 +106,12 @@ type partitionable struct {
 	rowsPerPartition int
 }
 
-func (p *partitionable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(p)
-}
+// WithChildren implements the Node interface.
+func (p *partitionable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
 
-func (p *partitionable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return p, nil
 }
 

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -36,28 +36,22 @@ func (p *Filter) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, NewFilterIter(ctx, p.Expression, i)), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (p *Filter) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := p.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (p *Filter) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 1)
 	}
-	return f(NewFilter(p.Expression, child))
+
+	return NewFilter(p.Expression, children[0]), nil
 }
 
-// TransformExpressionsUp implements the Transformable interface.
-func (p *Filter) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	expr, err := p.Expression.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithExpressions implements the Expressioner interface.
+func (p *Filter) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(exprs), 1)
 	}
 
-	child, err := p.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewFilter(expr, child), nil
+	return NewFilter(exprs[0], p.Child), nil
 }
 
 func (p *Filter) String() string {
@@ -70,16 +64,6 @@ func (p *Filter) String() string {
 // Expressions implements the Expressioner interface.
 func (p *Filter) Expressions() []sql.Expression {
 	return []sql.Expression{p.Expression}
-}
-
-// TransformExpressions implements the Expressioner interface.
-func (p *Filter) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
-	e, err := p.Expression.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewFilter(e, p.Child), nil
 }
 
 // FilterIter is an iterator that filters another iterator and skips rows that

--- a/sql/plan/generate_test.go
+++ b/sql/plan/generate_test.go
@@ -3,9 +3,9 @@ package plan
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRowIter(t *testing.T) {
@@ -80,9 +80,6 @@ func (n *fakeNode) Resolved() bool                            { return true }
 func (n *fakeNode) Schema() sql.Schema                        { return n.schema }
 func (n *fakeNode) RowIter(*sql.Context) (sql.RowIter, error) { return n.iter, nil }
 func (n *fakeNode) String() string                            { return "fakeNode" }
-func (n *fakeNode) TransformUp(sql.TransformNodeFunc) (sql.Node, error) {
-	panic("placeholder")
-}
-func (n *fakeNode) TransformExpressionsUp(sql.TransformExprFunc) (sql.Node, error) {
+func (*fakeNode) WithChildren(children ...sql.Node) (sql.Node, error) {
 	panic("placeholder")
 }

--- a/sql/plan/having.go
+++ b/sql/plan/having.go
@@ -24,39 +24,22 @@ func (h *Having) Resolved() bool { return h.Cond.Resolved() && h.Child.Resolved(
 // Expressions implements the sql.Expressioner interface.
 func (h *Having) Expressions() []sql.Expression { return []sql.Expression{h.Cond} }
 
-// TransformExpressions implements the sql.Expressioner interface.
-func (h *Having) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
-	e, err := h.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (h *Having) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(h, len(children), 1)
 	}
 
-	return &Having{h.UnaryNode, e}, nil
+	return NewHaving(h.Cond, children[0]), nil
 }
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (h *Having) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := h.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
+// WithExpressions implements the Expressioner interface.
+func (h *Having) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(h, len(exprs), 1)
 	}
 
-	e, err := h.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Having{UnaryNode{child}, e}, nil
-}
-
-// TransformUp implements the sql.Node interface.
-func (h *Having) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := h.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(&Having{UnaryNode{child}, h.Cond})
+	return NewHaving(exprs[0], h.Child), nil
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -4,9 +4,9 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 // ErrInsertIntoNotSupported is thrown when a table doesn't support inserts
@@ -123,34 +123,13 @@ func (p *InsertInto) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(sql.NewRow(int64(n))), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (p *InsertInto) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := p.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (p *InsertInto) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 2)
 	}
 
-	right, err := p.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewInsertInto(left, right, p.Columns))
-}
-
-// TransformExpressionsUp implements the Transformable interface.
-func (p *InsertInto) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := p.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	right, err := p.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewInsertInto(left, right, p.Columns), nil
+	return NewInsertInto(children[0], children[1], p.Columns), nil
 }
 
 func (p InsertInto) String() string {

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -83,39 +83,22 @@ func (j *InnerJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return joinRowIter(ctx, innerJoin, j.Left, j.Right, j.Cond)
 }
 
-// TransformUp implements the Transformable interface.
-func (j *InnerJoin) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := j.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (j *InnerJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(children), 2)
 	}
 
-	right, err := j.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewInnerJoin(left, right, j.Cond))
+	return NewInnerJoin(children[0], children[1], j.Cond), nil
 }
 
-// TransformExpressionsUp implements the Transformable interface.
-func (j *InnerJoin) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := j.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
+// WithExpressions implements the Expressioner interface.
+func (j *InnerJoin) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(exprs), 1)
 	}
 
-	right, err := j.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewInnerJoin(left, right, cond), nil
+	return NewInnerJoin(j.Left, j.Right, exprs[0]), nil
 }
 
 func (j *InnerJoin) String() string {
@@ -128,16 +111,6 @@ func (j *InnerJoin) String() string {
 // Expressions implements the Expressioner interface.
 func (j *InnerJoin) Expressions() []sql.Expression {
 	return []sql.Expression{j.Cond}
-}
-
-// TransformExpressions implements the Expressioner interface.
-func (j *InnerJoin) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewInnerJoin(j.Left, j.Right, cond), nil
 }
 
 // LeftJoin is a left join between two tables.
@@ -172,39 +145,22 @@ func (j *LeftJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return joinRowIter(ctx, leftJoin, j.Left, j.Right, j.Cond)
 }
 
-// TransformUp implements the Transformable interface.
-func (j *LeftJoin) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := j.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (j *LeftJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(children), 1)
 	}
 
-	right, err := j.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewLeftJoin(left, right, j.Cond))
+	return NewLeftJoin(children[0], children[1], j.Cond), nil
 }
 
-// TransformExpressionsUp implements the Transformable interface.
-func (j *LeftJoin) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := j.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
+// WithExpressions implements the Expressioner interface.
+func (j *LeftJoin) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(exprs), 1)
 	}
 
-	right, err := j.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewLeftJoin(left, right, cond), nil
+	return NewLeftJoin(j.Left, j.Right, exprs[0]), nil
 }
 
 func (j *LeftJoin) String() string {
@@ -217,16 +173,6 @@ func (j *LeftJoin) String() string {
 // Expressions implements the Expressioner interface.
 func (j *LeftJoin) Expressions() []sql.Expression {
 	return []sql.Expression{j.Cond}
-}
-
-// TransformExpressions implements the Expressioner interface.
-func (j *LeftJoin) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewLeftJoin(j.Left, j.Right, cond), nil
 }
 
 // RightJoin is a left join between two tables.
@@ -261,39 +207,22 @@ func (j *RightJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return joinRowIter(ctx, rightJoin, j.Left, j.Right, j.Cond)
 }
 
-// TransformUp implements the Transformable interface.
-func (j *RightJoin) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := j.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (j *RightJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(children), 2)
 	}
 
-	right, err := j.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewRightJoin(left, right, j.Cond))
+	return NewRightJoin(children[0], children[1], j.Cond), nil
 }
 
-// TransformExpressionsUp implements the Transformable interface.
-func (j *RightJoin) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := j.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
+// WithExpressions implements the Expressioner interface.
+func (j *RightJoin) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(exprs), 1)
 	}
 
-	right, err := j.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewRightJoin(left, right, cond), nil
+	return NewRightJoin(j.Left, j.Right, exprs[0]), nil
 }
 
 func (j *RightJoin) String() string {
@@ -306,16 +235,6 @@ func (j *RightJoin) String() string {
 // Expressions implements the Expressioner interface.
 func (j *RightJoin) Expressions() []sql.Expression {
 	return []sql.Expression{j.Cond}
-}
-
-// TransformExpressions implements the Expressioner interface.
-func (j *RightJoin) TransformExpressions(f sql.TransformExprFunc) (sql.Node, error) {
-	cond, err := j.Cond.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewRightJoin(j.Left, j.Right, cond), nil
 }
 
 type joinType byte

--- a/sql/plan/naturaljoin.go
+++ b/sql/plan/naturaljoin.go
@@ -35,32 +35,11 @@ func (j NaturalJoin) String() string {
 	return pr.String()
 }
 
-// TransformUp implements the Node interface.
-func (j *NaturalJoin) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	left, err := j.Left.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (j *NaturalJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(j, len(children), 2)
 	}
 
-	right, err := j.Right.TransformUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(NewNaturalJoin(left, right))
-}
-
-// TransformExpressionsUp implements the Node interface.
-func (j *NaturalJoin) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	left, err := j.Left.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	right, err := j.Right.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewNaturalJoin(left, right), nil
+	return NewNaturalJoin(children[0], children[1]), nil
 }

--- a/sql/plan/nothing.go
+++ b/sql/plan/nothing.go
@@ -7,8 +7,6 @@ var Nothing nothing
 
 type nothing struct{}
 
-var _ sql.Node = nothing{}
-
 func (nothing) String() string       { return "NOTHING" }
 func (nothing) Resolved() bool       { return true }
 func (nothing) Schema() sql.Schema   { return nil }
@@ -16,9 +14,12 @@ func (nothing) Children() []sql.Node { return nil }
 func (nothing) RowIter(*sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(), nil
 }
-func (nothing) TransformUp(sql.TransformNodeFunc) (sql.Node, error) {
-	return Nothing, nil
-}
-func (nothing) TransformExpressionsUp(sql.TransformExprFunc) (sql.Node, error) {
+
+// WithChildren implements the Node interface.
+func (n nothing) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 0)
+	}
+
 	return Nothing, nil
 }

--- a/sql/plan/offset.go
+++ b/sql/plan/offset.go
@@ -36,22 +36,12 @@ func (o *Offset) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, &offsetIter{o.Offset, it}), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (o *Offset) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := o.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (o *Offset) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(o, len(children), 1)
 	}
-	return f(NewOffset(o.Offset, child))
-}
-
-// TransformExpressionsUp implements the Transformable interface.
-func (o *Offset) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := o.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return NewOffset(o.Offset, child), nil
+	return NewOffset(o.Offset, children[0]), nil
 }
 
 func (o Offset) String() string {

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -21,28 +21,13 @@ func NewQueryProcess(node sql.Node, notify NotifyFunc) *QueryProcess {
 	return &QueryProcess{UnaryNode{Child: node}, notify}
 }
 
-// TransformUp implements the sql.Node interface.
-func (p *QueryProcess) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	n, err := p.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (p *QueryProcess) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 1)
 	}
 
-	np := *p
-	np.Child = n
-	return &np, nil
-}
-
-// TransformExpressionsUp implements the sql.Node interface.
-func (p *QueryProcess) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	n, err := p.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	np := *p
-	np.Child = n
-	return &np, nil
+	return NewQueryProcess(children[0], p.Notify), nil
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -58,13 +58,12 @@ func (p *ShowProcessList) Children() []sql.Node { return nil }
 // Resolved implements the Node interface.
 func (p *ShowProcessList) Resolved() bool { return true }
 
-// TransformUp implements the Node interface.
-func (p *ShowProcessList) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(p)
-}
+// WithChildren implements the Node interface.
+func (p *ShowProcessList) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Node interface.
-func (p *ShowProcessList) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return p, nil
 }
 

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -44,13 +44,12 @@ func (t *ResolvedTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (t *ResolvedTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewResolvedTable(t.Table))
-}
+// WithChildren implements the Node interface.
+func (t *ResolvedTable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (t *ResolvedTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return t, nil
 }
 

--- a/sql/plan/show_collation.go
+++ b/sql/plan/show_collation.go
@@ -42,12 +42,11 @@ func (ShowCollation) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 // Schema implements the sql.Node interface.
 func (ShowCollation) Schema() sql.Schema { return collationSchema }
 
-// TransformUp implements the sql.Node interface.
-func (ShowCollation) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(ShowCollation{})
-}
+// WithChildren implements the Node interface.
+func (s ShowCollation) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (ShowCollation) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	return ShowCollation{}, nil
+	return s, nil
 }

--- a/sql/plan/show_create_database.go
+++ b/sql/plan/show_create_database.go
@@ -82,12 +82,11 @@ func (s *ShowCreateDatabase) Resolved() bool {
 	return !ok
 }
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (s *ShowCreateDatabase) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	return s, nil
-}
+// WithChildren implements the Node interface.
+func (s *ShowCreateDatabase) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 0)
+	}
 
-// TransformUp implements the sql.Node interface.
-func (s *ShowCreateDatabase) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(s)
+	return s, nil
 }

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -25,14 +25,13 @@ func (n *ShowCreateTable) Schema() sql.Schema {
 	}
 }
 
-// TransformExpressionsUp implements the Transformable interface.
-func (n *ShowCreateTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	return n, nil
-}
+// WithChildren implements the Node interface.
+func (n *ShowCreateTable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 0)
+	}
 
-// TransformUp implements the Transformable interface.
-func (n *ShowCreateTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewShowCreateTable(n.CurrentDatabase, n.Catalog, n.Table))
+	return n, nil
 }
 
 // RowIter implements the Node interface

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -39,13 +39,12 @@ func (n *ShowIndexes) Resolved() bool {
 	return !ok
 }
 
-// TransformUp implements the Transformable interface.
-func (n *ShowIndexes) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewShowIndexes(n.db, n.Table, n.Registry))
-}
+// WithChildren implements the Node interface.
+func (n *ShowIndexes) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (n *ShowIndexes) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return n, nil
 }
 

--- a/sql/plan/show_tables.go
+++ b/sql/plan/show_tables.go
@@ -84,13 +84,12 @@ func (p *ShowTables) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(rows...), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (p *ShowTables) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewShowTables(p.db, p.Full))
-}
+// WithChildren implements the Node interface.
+func (p *ShowTables) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (p *ShowTables) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return p, nil
 }
 

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -104,24 +104,13 @@ func (s *ShowColumns) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, sql.RowsToRowIter(rows...)), nil
 }
 
-// TransformUp creates a new ShowColumns node.
-func (s *ShowColumns) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := s.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (s *ShowColumns) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
 
-	return f(NewShowColumns(s.Full, child))
-}
-
-// TransformExpressionsUp creates a new ShowColumns node.
-func (s *ShowColumns) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := s.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewShowColumns(s.Full, child), nil
+	return NewShowColumns(s.Full, children[0]), nil
 }
 
 func (s *ShowColumns) String() string {

--- a/sql/plan/showdatabases.go
+++ b/sql/plan/showdatabases.go
@@ -53,16 +53,15 @@ func (p *ShowDatabases) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(rows...), nil
 }
 
-// TransformUp implements the Transformable interface.
-func (p *ShowDatabases) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	np := *p
-	return f(&np)
-}
+// WithChildren implements the Node interface.
+func (p *ShowDatabases) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (p *ShowDatabases) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return p, nil
 }
+
 func (p ShowDatabases) String() string {
 	return "ShowDatabases"
 }

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -86,13 +86,12 @@ func (s *ShowTableStatus) String() string {
 	return fmt.Sprintf("ShowTableStatus(%s)", strings.Join(s.Databases, ", "))
 }
 
-// TransformUp implements the sql.Node interface.
-func (s *ShowTableStatus) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(s)
-}
+// WithChildren implements the Node interface.
+func (s *ShowTableStatus) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (s *ShowTableStatus) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return s, nil
 }
 

--- a/sql/plan/showvariables.go
+++ b/sql/plan/showvariables.go
@@ -28,13 +28,12 @@ func (sv *ShowVariables) Resolved() bool {
 	return true
 }
 
-// TransformUp implements the sq.Transformable interface.
-func (sv *ShowVariables) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewShowVariables(sv.config, sv.pattern))
-}
+// WithChildren implements the Node interface.
+func (sv *ShowVariables) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(sv, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the sql.Transformable interface.
-func (sv *ShowVariables) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return sv, nil
 }
 

--- a/sql/plan/showwarnings.go
+++ b/sql/plan/showwarnings.go
@@ -12,13 +12,12 @@ func (ShowWarnings) Resolved() bool {
 	return true
 }
 
-// TransformUp implements the sq.Transformable interface.
-func (sw ShowWarnings) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(sw)
-}
+// WithChildren implements the Node interface.
+func (sw ShowWarnings) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(sw, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the sql.Transformable interface.
-func (sw ShowWarnings) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return sw, nil
 }
 

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -45,14 +45,20 @@ func (n *SubqueryAlias) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewSpanIter(span, iter), nil
 }
 
-// TransformUp implements the Node interface.
-func (n *SubqueryAlias) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(n)
+// WithChildren implements the Node interface.
+func (n *SubqueryAlias) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 1)
+	}
+
+	nn := *n
+	nn.Child = children[0]
+	return n, nil
 }
 
-// TransformExpressionsUp implements the Node interface.
-func (n *SubqueryAlias) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	return n, nil
+// Opaque implements the OpaqueNode interface.
+func (n *SubqueryAlias) Opaque() bool {
+	return true
 }
 
 func (n SubqueryAlias) String() string {

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -23,22 +23,13 @@ func (t *TableAlias) Name() string {
 	return t.name
 }
 
-// TransformUp implements the Transformable interface.
-func (t *TableAlias) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	child, err := t.Child.TransformUp(f)
-	if err != nil {
-		return nil, err
+// WithChildren implements the Node interface.
+func (t *TableAlias) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 1)
 	}
-	return f(NewTableAlias(t.name, child))
-}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (t *TableAlias) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
-	child, err := t.Child.TransformExpressionsUp(f)
-	if err != nil {
-		return nil, err
-	}
-	return NewTableAlias(t.name, child), nil
+	return NewTableAlias(t.name, children[0]), nil
 }
 
 // RowIter implements the Node interface.

--- a/sql/plan/transaction.go
+++ b/sql/plan/transaction.go
@@ -15,13 +15,12 @@ func (*Rollback) RowIter(*sql.Context) (sql.RowIter, error) {
 
 func (*Rollback) String() string { return "ROLLBACK" }
 
-// TransformUp implements the sql.Node interface.
-func (r *Rollback) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(r)
-}
+// WithChildren implements the Node interface.
+func (r *Rollback) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (r *Rollback) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return r, nil
 }
 

--- a/sql/plan/transform.go
+++ b/sql/plan/transform.go
@@ -1,0 +1,89 @@
+package plan
+
+import (
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+)
+
+// TransformUp applies a transformation function to the given tree from the
+// bottom up.
+func TransformUp(node sql.Node, f sql.TransformNodeFunc) (sql.Node, error) {
+	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
+		return f(node)
+	}
+
+	children := node.Children()
+	if len(children) == 0 {
+		return f(node)
+	}
+
+	newChildren := make([]sql.Node, len(children))
+	for i, c := range children {
+		c, err := TransformUp(c, f)
+		if err != nil {
+			return nil, err
+		}
+		newChildren[i] = c
+	}
+
+	node, err := node.WithChildren(newChildren...)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(node)
+}
+
+// TransformExpressionsUp applies a transformation function to all expressions
+// on the given tree from the bottom up.
+func TransformExpressionsUp(node sql.Node, f sql.TransformExprFunc) (sql.Node, error) {
+	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
+		return TransformExpressions(node, f)
+	}
+
+	children := node.Children()
+	if len(children) == 0 {
+		return TransformExpressions(node, f)
+	}
+
+	newChildren := make([]sql.Node, len(children))
+	for i, c := range children {
+		c, err := TransformExpressionsUp(c, f)
+		if err != nil {
+			return nil, err
+		}
+		newChildren[i] = c
+	}
+
+	node, err := node.WithChildren(newChildren...)
+	if err != nil {
+		return nil, err
+	}
+
+	return TransformExpressions(node, f)
+}
+
+// TransformExpressions applies a transformation function to all expressions
+// on the given node.
+func TransformExpressions(node sql.Node, f sql.TransformExprFunc) (sql.Node, error) {
+	e, ok := node.(sql.Expressioner)
+	if !ok {
+		return node, nil
+	}
+
+	exprs := e.Expressions()
+	if len(exprs) == 0 {
+		return node, nil
+	}
+
+	newExprs := make([]sql.Expression, len(exprs))
+	for i, e := range exprs {
+		e, err := expression.TransformUp(e, f)
+		if err != nil {
+			return nil, err
+		}
+		newExprs[i] = e
+	}
+
+	return e.WithExpressions(newExprs...)
+}

--- a/sql/plan/transform_test.go
+++ b/sql/plan/transform_test.go
@@ -24,7 +24,7 @@ func TestTransformUp(t *testing.T) {
 	}
 	table := mem.NewTable("resolved", schema)
 
-	pt, err := p.TransformUp(func(n sql.Node) (sql.Node, error) {
+	pt, err := TransformUp(p, func(n sql.Node) (sql.Node, error) {
 		switch n.(type) {
 		case *UnresolvedTable:
 			return NewResolvedTable(table), nil

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -3,8 +3,8 @@ package plan
 import (
 	"fmt"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // ErrUnresolvedTable is thrown when a table cannot be resolved
@@ -42,13 +42,12 @@ func (*UnresolvedTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return nil, ErrUnresolvedTable.New()
 }
 
-// TransformUp implements the Transformable interface.
-func (t *UnresolvedTable) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(NewUnresolvedTable(t.name, t.Database))
-}
+// WithChildren implements the Node interface.
+func (t *UnresolvedTable) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 0)
+	}
 
-// TransformExpressionsUp implements the Transformable interface.
-func (t *UnresolvedTable) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return t, nil
 }
 

--- a/sql/plan/use.go
+++ b/sql/plan/use.go
@@ -50,13 +50,12 @@ func (u *Use) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(), nil
 }
 
-// TransformUp implements the sql.Node interface.
-func (u *Use) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
-	return f(u)
-}
+// WithChildren implements the Node interface.
+func (u *Use) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
+	}
 
-// TransformExpressionsUp implements the sql.Node interface.
-func (u *Use) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
 	return u, nil
 }
 

--- a/sql/session_test.go
+++ b/sql/session_test.go
@@ -51,27 +51,22 @@ func TestHasDefaultValue(t *testing.T) {
 
 type testNode struct{}
 
-func (t *testNode) Resolved() bool {
+func (*testNode) Resolved() bool {
+	panic("not implemented")
+}
+func (*testNode) WithChildren(...Node) (Node, error) {
 	panic("not implemented")
 }
 
-func (t *testNode) TransformUp(func(Node) Node) Node {
+func (*testNode) Schema() Schema {
 	panic("not implemented")
 }
 
-func (t *testNode) TransformExpressionsUp(func(Expression) Expression) Node {
+func (*testNode) Children() []Node {
 	panic("not implemented")
 }
 
-func (t *testNode) Schema() Schema {
-	panic("not implemented")
-}
-
-func (t *testNode) Children() []Node {
-	panic("not implemented")
-}
-
-func (t *testNode) RowIter(ctx *Context) (RowIter, error) {
+func (*testNode) RowIter(ctx *Context) (RowIter, error) {
 	return newTestNodeIterator(ctx), nil
 }
 


### PR DESCRIPTION
Close #772 

Instead of having TransformUp and TransformExpressionsUp in each
node, which was really error prone, now we have a different API.

Each node will have a WithChildren method that will receive
the children from which a new node of the same type will be created.
These nodes must come in the same number and order as the ones
returned by the Children method.

Expressioner nodes will also have WithExpressions method, which is
the same, except it will create a new node with its expressions
changed, instead of the children nodes.

The plan package will expose 3 new helpers:

- TransformUp: which transforms a node from the bottom-up.
- TransformExpressionsUp: which transforms expressions of a node from
  the bottom up.
- TransformExpressions: which transforms the expressions of just the
  given node.

Just like with nodes, expressions will also have a new WithChildren
method that does the exact same thing as it does in the nodes.

The expression package will expose a new helper:

- TransformUp: which transforms an expression from the bottom up.

The sql package now has one interface more: `OpaqueNode`. An opaque node is a node that acts as a black box and their children will not be transformed using the aforementioned helpers. SubqueryAlias node, for example, requires being opaque.

Caveats and limitations:

One thing that may seem odd is the limitation that WithChildren and
WithExpressions must receive the children in the exact same order and
number as they were returned from Expressions or Children.

This is because without this limitation there is no way to build
certain nodes. If we force this limitation on one, it would feel odd
not to have it elsewhere.

For example, take Case expression into account. It may or may not have
Expr, it has a list of branches (each having 2 expressions) and it
may or may not have an Else expression. If WithChildren receives N
children, how do we know where to put all these expressions?
This limitation allows us to build the node beacause we know the shape
of children must match the current shape.