### PR TITLE
Varchar type

### DIFF
--- a/sql/expression/function/nullif_test.go
+++ b/sql/expression/function/nullif_test.go
@@ -28,6 +28,13 @@ func TestNullIf(t *testing.T) {
 	)
 	require.Equal(t, sql.Text, f.Type())
 
+	var3 := sql.VarChar(3)
+	f = NewNullIf(
+		expression.NewGetField(0, var3, "ex1", true),
+		expression.NewGetField(1, var3, "ex2", true),
+	)
+	require.Equal(t, var3, f.Type())
+
 	for _, tc := range testCases {
 		v, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(tc.ex1, tc.ex2))
 		require.NoError(t, err)

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -14,6 +14,8 @@ type Literal struct {
 
 // NewLiteral creates a new Literal expression.
 func NewLiteral(value interface{}, fieldType sql.Type) *Literal {
+	// TODO(juanjux): we should probably check here if the type is sql.VarChar and the
+	// Capacity of the Type and the length of the value, but this can't return an error
 	return &Literal{
 		value:     value,
 		fieldType: fieldType,

--- a/sql/expression/tuple_test.go
+++ b/sql/expression/tuple_test.go
@@ -3,8 +3,8 @@ package expression
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTuple(t *testing.T) {

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -24,6 +24,10 @@ func TestText(t *testing.T) {
 	lt(t, Text, "a", "b")
 	eq(t, Text, "a", "a")
 	gt(t, Text, "b", "a")
+
+	var3, err := VarChar(3).Convert("abc")
+	require.NoError(t, err)
+	convert(t, Text, var3, "abc")
 }
 
 func TestInt32(t *testing.T) {
@@ -235,6 +239,38 @@ func TestTuple(t *testing.T) {
 	gt(t, typ, []interface{}{2, 2, 3}, []interface{}{1, 2, 3})
 	gt(t, typ, []interface{}{1, 3, 3}, []interface{}{1, 2, 3})
 	gt(t, typ, []interface{}{1, 2, 4}, []interface{}{1, 2, 3})
+}
+
+func TestVarChar(t *testing.T) {
+	typ := VarChar(3)
+	require.True(t, IsVarChar(typ))
+	require.True(t, IsText(typ))
+	convert(t, typ, "foo", "foo")
+	fooByte := []byte{'f', 'o', 'o'}
+	convert(t, typ, fooByte, "foo")
+
+	typ = VarChar(1)
+	convertErr(t, typ, "foo")
+	convertErr(t, typ, fooByte)
+	convertErr(t, typ, 123)
+
+	typ = VarChar(10)
+	convert(t, typ, 123, "123")
+	convertErr(t, typ, 1234567890123)
+
+	convert(t, typ, "", "")
+	convert(t, typ, 1, "1")
+
+	lt(t, typ, "a", "b")
+	eq(t, typ, "a", "a")
+	gt(t, typ, "b", "a")
+
+	text, err := Text.Convert("abc")
+	require.NoError(t, err)
+
+	convert(t, typ, text, "abc")
+	typ1 := VarChar(1)
+	convertErr(t, typ1, text)
 }
 
 func TestArray(t *testing.T) {


### PR DESCRIPTION
Part of the fix for: src-d/gitbase/issues/824 (the missing part is using it on the columns / types of gitbase where superset expects varchars).

This adds `VarChar` as an specific type. As happens with `Array`, it's a parametrized type that will be returned by a function with a specific length. It is convertible from and to `Text` and `string` and will return true for `IsText` so it should work for all functions using `Text`.

There is a "TO-DO" comment I added in the `NewLiteral` function, any suggestion is welcomed:

```go
	// TODO(juanjux): we should probably check here if the type is sql.VarChar and the
	// Capacity of the Type and the length of the value, but this can't return an error
```