### PR TITLE
sql/analyzer: fix having resolution

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1237,10 +1237,33 @@ var queries = []struct {
 	{
 		`SELECT ARRAY_LENGTH("foo")`,
 		[]sql.Row{{nil}},
-  },
-  {
+	},
+	{
 		`SELECT * FROM mytable WHERE NULL AND i = 3`,
 		[]sql.Row{},
+	},
+	{
+		`SELECT 1 FROM mytable GROUP BY i HAVING i > 1`,
+		[]sql.Row{{int64(1)}, {int64(1)}},
+	},
+	{
+		`SELECT avg(i) FROM mytable GROUP BY i HAVING avg(i) > 1`,
+		[]sql.Row{{float64(2)}, {float64(3)}},
+	},
+	{
+		`SELECT s AS s, COUNT(*) AS count,  AVG(i) AS ` + "`AVG(i)`" + `
+		FROM  (
+			SELECT * FROM mytable
+		) AS expr_qry
+		GROUP BY s
+		HAVING ((AVG(i) > 0))
+		ORDER BY count DESC
+		LIMIT 10000`,
+		[]sql.Row{
+			{"first row", int64(1), float64(1)},
+			{"second row", int64(1), float64(2)},
+			{"third row", int64(1), float64(3)},
+		},
 	},
 }
 

--- a/sql/analyzer/resolve_having.go
+++ b/sql/analyzer/resolve_having.go
@@ -2,12 +2,13 @@ package analyzer
 
 import (
 	"reflect"
+	"strings"
 
-	"gopkg.in/src-d/go-errors.v1"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 func resolveHaving(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, error) {
@@ -17,98 +18,380 @@ func resolveHaving(ctx *sql.Context, a *Analyzer, node sql.Node) (sql.Node, erro
 			return node, nil
 		}
 
-		if !having.Resolved() {
+		if !having.Child.Resolved() {
 			return node, nil
 		}
 
-		// If there are no aggregations there is no need to check anything else
-		// and we can just leave the node as it is.
-		if !hasAggregations(having.Cond) {
-			return node, nil
+		originalSchema := having.Schema()
+
+		var requiresProjection bool
+		if containsAggregation(having.Cond) {
+			var err error
+			having, requiresProjection, err = replaceAggregations(having)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		groupBy, ok := having.Child.(*plan.GroupBy)
-		if !ok {
-			return nil, errHavingNeedsGroupBy.New()
+		missingCols := findMissingColumns(having, having.Cond)
+		// If all the columns required by the having are available, do nothing about it.
+		if len(missingCols) > 0 {
+			var err error
+			having, err = pushMissingColumnsUp(having, missingCols)
+			if err != nil {
+				return nil, err
+			}
+			requiresProjection = true
 		}
 
-		var aggregate = make([]sql.Expression, len(groupBy.Aggregate))
-		copy(aggregate, groupBy.Aggregate)
+		if !requiresProjection {
+			return having, nil
+		}
 
-		// We need to find all the aggregations in the having that are already present in
-		// the group by and replace them with a GetField. If the aggregation is not
-		// present, we need to move it to the GroupBy and reference it with a GetField.
-		cond, err := having.Cond.TransformUp(func(e sql.Expression) (sql.Expression, error) {
-			agg, ok := e.(sql.Aggregation)
-			if !ok {
-				return e, nil
+		return projectOriginalAggregation(having, originalSchema), nil
+	})
+}
+
+func findMissingColumns(node sql.Node, expr sql.Expression) []string {
+	var schemaCols []string
+	for _, col := range node.Schema() {
+		schemaCols = append(schemaCols, strings.ToLower(col.Name))
+	}
+
+	var missingCols []string
+	for _, n := range findExprNameables(expr) {
+		name := strings.ToLower(n.Name())
+		if !stringContains(schemaCols, name) {
+			missingCols = append(missingCols, n.Name())
+		}
+	}
+
+	return missingCols
+}
+
+func projectOriginalAggregation(having *plan.Having, schema sql.Schema) *plan.Project {
+	var projection []sql.Expression
+	for i, col := range schema {
+		projection = append(
+			projection,
+			expression.NewGetFieldWithTable(i, col.Type, col.Source, col.Name, col.Nullable),
+		)
+	}
+
+	return plan.NewProject(projection, having)
+}
+
+var errHavingChildMissingRef = errors.NewKind("cannot find column %s referenced in HAVING clause in either GROUP BY or its child")
+
+func pushMissingColumnsUp(
+	having *plan.Having,
+	missingCols []string,
+) (*plan.Having, error) {
+	groupBy, err := findGroupBy(having)
+	if err != nil {
+		return nil, err
+	}
+
+	schema := groupBy.Child.Schema()
+	var newAggregate []sql.Expression
+	for _, c := range missingCols {
+		idx := -1
+		for i, col := range schema {
+			if strings.ToLower(c) == strings.ToLower(col.Name) {
+				idx = i
+				break
 			}
+		}
+		if idx < 0 {
+			return nil, errHavingChildMissingRef.New(c)
+		}
+		col := schema[idx]
+		newAggregate = append(
+			newAggregate,
+			expression.NewGetFieldWithTable(idx, col.Type, col.Source, col.Name, col.Nullable),
+		)
+	}
 
-			for i, expr := range aggregate {
-				if aggregationEquals(agg, expr) {
-					var name string
-					if n, ok := expr.(sql.Nameable); ok {
-						name = n.Name()
-					} else {
-						name = expr.String()
-					}
+	node, err := addColumnsToGroupBy(having, newAggregate)
+	if err != nil {
+		return nil, err
+	}
 
-					return expression.NewGetField(
-						i,
-						expr.Type(),
-						name,
-						expr.IsNullable(),
-					), nil
-				}
-			}
+	return node.(*plan.Having), nil
+}
 
-			aggregate = append(aggregate, agg)
-			return expression.NewGetField(
-				len(aggregate)-1,
-				agg.Type(),
-				agg.String(),
-				agg.IsNullable(),
-			), nil
-		})
+func findGroupBy(n sql.Node) (*plan.GroupBy, error) {
+	children := n.Children()
+	if len(children) != 1 {
+		return nil, errHavingNeedsGroupBy.New()
+	}
+
+	if g, ok := children[0].(*plan.GroupBy); ok {
+		return g, nil
+	}
+
+	return findGroupBy(children[0])
+}
+
+func addColumnsToGroupBy(node sql.Node, columns []sql.Expression) (sql.Node, error) {
+	switch node := node.(type) {
+	case *plan.Project:
+		child, err := addColumnsToGroupBy(node.Child, columns)
 		if err != nil {
 			return nil, err
 		}
 
-		var result sql.Node = plan.NewHaving(
-			cond,
-			plan.NewGroupBy(aggregate, groupBy.Grouping, groupBy.Child),
-		)
-
-		// If any aggregation was sent to the GroupBy aggregate, we will need
-		// to wrap the new Having in a project that will get rid of all those
-		// extra columns we added.
-		if len(aggregate) != len(groupBy.Aggregate) {
-			var projection = make([]sql.Expression, len(groupBy.Aggregate))
-			for i, e := range groupBy.Aggregate {
-				var table, name string
-				if t, ok := e.(sql.Tableable); ok {
-					table = t.Table()
-				}
-
-				if n, ok := e.(sql.Nameable); ok {
-					name = n.Name()
-				} else {
-					name = e.String()
-				}
-
-				projection[i] = expression.NewGetFieldWithTable(
-					i,
-					e.Type(),
-					table,
-					name,
-					e.IsNullable(),
-				)
+		var newProjections = make([]sql.Expression, len(columns))
+		for i, col := range columns {
+			var name = col.String()
+			var table string
+			if n, ok := col.(sql.Nameable); ok {
+				name = n.Name()
 			}
-			result = plan.NewProject(projection, result)
+
+			if t, ok := col.(sql.Tableable); ok {
+				table = t.Table()
+			}
+
+			newProjections[i] = expression.NewGetFieldWithTable(
+				len(child.Schema())-len(columns)+i,
+				col.Type(),
+				table,
+				name,
+				col.IsNullable(),
+			)
 		}
 
-		return result, nil
+		return plan.NewProject(append(node.Projections, newProjections...), child), nil
+	case *plan.Filter:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewFilter(node.Expression, child), nil
+	case *plan.Sort:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewSort(node.SortFields, child), nil
+	case *plan.Limit:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewLimit(node.Limit, child), nil
+	case *plan.Offset:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewOffset(node.Offset, child), nil
+	case *plan.Distinct:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewDistinct(child), nil
+	case *plan.GroupBy:
+		return plan.NewGroupBy(append(node.Aggregate, columns...), node.Grouping, node.Child), nil
+	case *plan.Having:
+		child, err := addColumnsToGroupBy(node.Child, columns)
+		if err != nil {
+			return nil, err
+		}
+		return plan.NewHaving(node.Cond, child), nil
+	default:
+		return nil, errHavingNeedsGroupBy.New()
+	}
+}
+
+// pushColumnsUp pushes up the group by columns with the given indexes.
+// It returns the resultant node, the indexes of those pushed up columns in the
+// resultant node and an error, if any.
+func pushColumnsUp(node sql.Node, columns []int) (sql.Node, []int, error) {
+	switch node := node.(type) {
+	case *plan.Project:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var seen = make(map[int]int)
+		for i, col := range node.Projections {
+			switch col := col.(type) {
+			case *expression.Alias:
+				if f, ok := col.Child.(*expression.GetField); ok {
+					seen[f.Index()] = i
+				}
+			case *expression.GetField:
+				seen[col.Index()] = i
+			}
+		}
+
+		var newProjections = make([]sql.Expression, len(node.Projections))
+		copy(newProjections, node.Projections)
+		schema := child.Schema()
+		var newColumns []int
+
+		for _, idx := range columns {
+			if newIdx, ok := seen[idx]; ok {
+				newColumns = append(newColumns, newIdx)
+				continue
+			}
+
+			col := schema[idx]
+			newIdx := len(newProjections)
+			newProjections = append(newProjections, expression.NewGetFieldWithTable(
+				newIdx,
+				col.Type,
+				col.Source,
+				col.Name,
+				col.Nullable,
+			))
+			newColumns = append(newColumns, newIdx)
+		}
+
+		return plan.NewProject(newProjections, child), newColumns, nil
+	case *plan.Filter:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewFilter(node.Expression, child), columns, nil
+	case *plan.Sort:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewSort(node.SortFields, child), columns, nil
+	case *plan.Limit:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewLimit(node.Limit, child), columns, nil
+	case *plan.Offset:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewOffset(node.Offset, child), columns, nil
+	case *plan.Distinct:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewDistinct(child), columns, nil
+	case *plan.GroupBy:
+		return node, columns, nil
+	case *plan.Having:
+		child, columns, err := pushColumnsUp(node.Child, columns)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan.NewHaving(node.Cond, child), columns, nil
+	default:
+		return nil, nil, errHavingNeedsGroupBy.New()
+	}
+}
+
+func replaceAggregations(having *plan.Having) (*plan.Having, bool, error) {
+	groupBy, err := findGroupBy(having)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var newAggregate []sql.Expression
+
+	var pushUp []int
+	var tokenToIdx = make(map[int]int)
+	var pushUpToken = -1
+
+	// We need to find all aggregations inside the having condition. The ones
+	// that are already present in the group by will be pushed up and the ones
+	// that are not, will be added to the group by and pushed up.
+	//
+	// To push up already existing aggregations we need to change all possible
+	// projections between the having and the group by, so we will need to
+	// assign some fake token indexes to replace later with the actual column
+	// indexes after they have been pushed up. This is because some of these
+	// may have already been projected in some projection and we cannot ensure
+	// from here what the final index will be.
+	cond, err := having.Cond.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		agg, ok := e.(sql.Aggregation)
+		if !ok {
+			return e, nil
+		}
+
+		for i, expr := range groupBy.Aggregate {
+			if aggregationEquals(agg, expr) {
+				token := pushUpToken
+				pushUpToken--
+				pushUp = append(pushUp, i)
+				tokenToIdx[token] = len(pushUp) - 1
+				return expression.NewGetField(
+					token,
+					expr.Type(),
+					expr.String(),
+					expr.IsNullable(),
+				), nil
+			}
+		}
+
+		newAggregate = append(newAggregate, agg)
+		return expression.NewGetField(
+			len(having.Child.Schema())+len(newAggregate)-1,
+			agg.Type(),
+			agg.String(),
+			agg.IsNullable(),
+		), nil
 	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	// The new aggregations will be added to the group by and pushed up until
+	// the topmost node.
+	having = plan.NewHaving(cond, having.Child)
+	node, err := addColumnsToGroupBy(having, newAggregate)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Then, the ones that already existed are pushed up and we get the final
+	// indexes at the topmost node (the having) in the same order.
+	node, pushedUpColumns, err := pushColumnsUp(node, pushUp)
+	if err != nil {
+		return nil, false, err
+	}
+
+	newSchema := node.Schema()
+	requiresProjection := len(newSchema) != len(having.Schema())
+	having = node.(*plan.Having)
+
+	// Now, the tokens are replaced with the actual columns, now that we know
+	// what the indexes are.
+	cond, err = having.Cond.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		f, ok := e.(*expression.GetField)
+		if !ok {
+			return e, nil
+		}
+
+		idx, ok := tokenToIdx[f.Index()]
+		if !ok {
+			return e, nil
+		}
+
+		idx = pushedUpColumns[idx]
+		col := newSchema[idx]
+		return expression.NewGetFieldWithTable(idx, col.Type, col.Source, col.Name, col.Nullable), nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return plan.NewHaving(cond, having.Child), requiresProjection, nil
 }
 
 func aggregationEquals(a, b sql.Expression) bool {
@@ -125,14 +408,88 @@ func aggregationEquals(a, b sql.Expression) bool {
 		// the same.
 		_, ok := b.(*aggregation.Count)
 		return ok
-	case *aggregation.Sum,
-		*aggregation.Avg,
-		*aggregation.Min,
-		*aggregation.Max:
-		return reflect.DeepEqual(a, b)
+	case *aggregation.Sum:
+		b, ok := b.(*aggregation.Sum)
+		if !ok {
+			return false
+		}
+
+		return aggregationChildEquals(a.Child, b.Child)
+	case *aggregation.Avg:
+		b, ok := b.(*aggregation.Avg)
+		if !ok {
+			return false
+		}
+
+		return aggregationChildEquals(a.Child, b.Child)
+	case *aggregation.Min:
+		b, ok := b.(*aggregation.Min)
+		if !ok {
+			return false
+		}
+
+		return aggregationChildEquals(a.Child, b.Child)
+	case *aggregation.Max:
+		b, ok := b.(*aggregation.Max)
+		if !ok {
+			return false
+		}
+
+		return aggregationChildEquals(a.Child, b.Child)
 	default:
 		return false
 	}
+}
+
+// aggregationChildEquals checks if expression a coming from the having
+// matches expression b coming from the group by. To do that, columns in
+// a need to be replaced to match the ones in b if their name or table and
+// name match.
+func aggregationChildEquals(a, b sql.Expression) bool {
+	var fieldsByName = make(map[string]sql.Expression)
+	var fieldsByTableCol = make(map[tableCol]sql.Expression)
+	expression.Inspect(b, func(e sql.Expression) bool {
+		gf, ok := e.(*expression.GetField)
+		if ok {
+			fieldsByTableCol[tableCol{
+				strings.ToLower(gf.Table()),
+				strings.ToLower(gf.Name()),
+			}] = e
+			fieldsByName[strings.ToLower(gf.Name())] = e
+		}
+		return true
+	})
+
+	a, err := a.TransformUp(func(e sql.Expression) (sql.Expression, error) {
+		var table, name string
+		switch e := e.(type) {
+		case *expression.UnresolvedColumn:
+			table = strings.ToLower(e.Table())
+			name = strings.ToLower(e.Name())
+		case *expression.GetField:
+			table = strings.ToLower(e.Table())
+			name = strings.ToLower(e.Name())
+		}
+
+		if table == "" {
+			f, ok := fieldsByName[name]
+			if !ok {
+				return e, nil
+			}
+			return f, nil
+		}
+
+		f, ok := fieldsByTableCol[tableCol{table, name}]
+		if !ok {
+			return e, nil
+		}
+		return f, nil
+	})
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(a, b)
 }
 
 var errHavingNeedsGroupBy = errors.NewKind("found HAVING clause with no GROUP BY")

--- a/sql/analyzer/resolve_having_test.go
+++ b/sql/analyzer/resolve_having_test.go
@@ -3,101 +3,309 @@ package analyzer
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/src-d/go-mysql-server/mem"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/src-d/go-mysql-server/sql/plan"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 func TestResolveHaving(t *testing.T) {
-	require := require.New(t)
-
-	var node sql.Node = plan.NewHaving(
-		expression.NewGreaterThan(
-			aggregation.NewCount(expression.NewStar()),
-			expression.NewLiteral(int64(5), sql.Int64),
-		),
-		plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias(aggregation.NewCount(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
-				expression.NewGetField(0, sql.Int64, "foo", false),
-			},
-			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
-			plan.NewResolvedTable(mem.NewTable("t", nil)),
-		),
-	)
-
-	var expected sql.Node = plan.NewHaving(
-		expression.NewGreaterThan(
-			expression.NewGetField(0, sql.Int64, "x", false),
-			expression.NewLiteral(int64(5), sql.Int64),
-		),
-		plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias(aggregation.NewCount(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
-				expression.NewGetField(0, sql.Int64, "foo", false),
-			},
-			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
-			plan.NewResolvedTable(mem.NewTable("t", nil)),
-		),
-	)
-
-	result, err := resolveHaving(sql.NewEmptyContext(), nil, node)
-	require.NoError(err)
-	require.Equal(expected, result)
-
-	node = plan.NewHaving(
-		expression.NewGreaterThan(
-			aggregation.NewCount(expression.NewStar()),
-			expression.NewLiteral(int64(5), sql.Int64),
-		),
-		plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
-				expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
-			},
-			[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
-			plan.NewResolvedTable(mem.NewTable("t", nil)),
-		),
-	)
-
-	expected = plan.NewProject(
-		[]sql.Expression{
-			expression.NewGetField(0, sql.Float64, "x", true),
-			expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
-		},
-		plan.NewHaving(
-			expression.NewGreaterThan(
-				expression.NewGetField(2, sql.Int64, "COUNT(*)", false),
-				expression.NewLiteral(int64(5), sql.Int64),
+	testCases := []struct {
+		name     string
+		input    sql.Node
+		expected sql.Node
+		err      *errors.Kind
+	}{
+		{
+			"replace existing aggregation in group by",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					aggregation.NewAvg(expression.NewUnresolvedColumn("foo")),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewAlias(aggregation.NewAvg(expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false)), "x"),
+						expression.NewGetField(0, sql.Int64, "foo", false),
+					},
+					[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+					plan.NewResolvedTable(mem.NewTable("t", nil)),
+				),
 			),
-			plan.NewGroupBy(
-				[]sql.Expression{
-					expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
-					expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewGetField(0, sql.Float64, "x", true),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewAlias(aggregation.NewAvg(expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false)), "x"),
+						expression.NewGetField(0, sql.Int64, "foo", false),
+					},
+					[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+					plan.NewResolvedTable(mem.NewTable("t", nil)),
+				),
+			),
+			nil,
+		},
+		{
+			"push down aggregation to group by",
+			plan.NewHaving(
+				expression.NewGreaterThan(
 					aggregation.NewCount(expression.NewStar()),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+						expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+					},
+					[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+					plan.NewResolvedTable(mem.NewTable("t", nil)),
+				),
+			),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Float64, "x", true),
+					expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
 				},
-				[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+				plan.NewHaving(
+					expression.NewGreaterThan(
+						expression.NewGetField(2, sql.Int64, "COUNT(*)", false),
+						expression.NewLiteral(int64(5), sql.Int64),
+					),
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewAlias(aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)), "x"),
+							expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+							aggregation.NewCount(expression.NewStar()),
+						},
+						[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", nil)),
+					),
+				),
+			),
+			nil,
+		},
+		{
+			"push up missing column",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewUnresolvedColumn("i"),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+					},
+					[]sql.Expression{expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false)},
+					plan.NewResolvedTable(mem.NewTable("t", sql.Schema{
+						{Type: sql.Int64, Name: "i", Source: "t"},
+						{Type: sql.Int64, Name: "i", Source: "foo"},
+					})),
+				),
+			),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+				},
+				plan.NewHaving(
+					expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("i"),
+						expression.NewLiteral(int64(5), sql.Int64),
+					),
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+							expression.NewGetFieldWithTable(0, sql.Int64, "t", "i", false),
+						},
+						[]sql.Expression{expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", sql.Schema{
+							{Type: sql.Int64, Name: "i", Source: "t"},
+							{Type: sql.Int64, Name: "i", Source: "foo"},
+						})),
+					),
+				),
+			),
+			nil,
+		},
+		{
+			"push up missing column with nodes in between",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewUnresolvedColumn("i"),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+					},
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+						},
+						[]sql.Expression{expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", sql.Schema{
+							{Type: sql.Int64, Name: "i", Source: "t"},
+							{Type: sql.Int64, Name: "i", Source: "foo"},
+						})),
+					),
+				),
+			),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+				},
+				plan.NewHaving(
+					expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("i"),
+						expression.NewLiteral(int64(5), sql.Int64),
+					),
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+							expression.NewGetFieldWithTable(1, sql.Int64, "t", "i", false),
+						},
+						plan.NewGroupBy(
+							[]sql.Expression{
+								expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+								expression.NewGetFieldWithTable(0, sql.Int64, "t", "i", false),
+							},
+							[]sql.Expression{expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false)},
+							plan.NewResolvedTable(mem.NewTable("t", sql.Schema{
+								{Type: sql.Int64, Name: "i", Source: "t"},
+								{Type: sql.Int64, Name: "i", Source: "foo"},
+							})),
+						),
+					),
+				),
+			),
+			nil,
+		},
+		{
+			"push down aggregations with nodes in between",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					aggregation.NewCount(expression.NewStar()),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewAlias(expression.NewGetField(0, sql.Float64, "avg(foo)", false), "x"),
+						expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+					},
+					plan.NewGroupBy(
+						[]sql.Expression{
+							aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)),
+							expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+						},
+						[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", nil)),
+					),
+				),
+			),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Float64, "x", false),
+					expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+				},
+				plan.NewHaving(
+					expression.NewGreaterThan(
+						expression.NewGetField(2, sql.Int64, "COUNT(*)", false),
+						expression.NewLiteral(int64(5), sql.Int64),
+					),
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewAlias(expression.NewGetField(0, sql.Float64, "avg(foo)", false), "x"),
+							expression.NewGetFieldWithTable(1, sql.Int64, "t", "foo", false),
+							expression.NewGetField(2, sql.Int64, "COUNT(*)", false),
+						},
+						plan.NewGroupBy(
+							[]sql.Expression{
+								aggregation.NewAvg(expression.NewGetField(0, sql.Int64, "foo", false)),
+								expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false),
+								aggregation.NewCount(expression.NewStar()),
+							},
+							[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+							plan.NewResolvedTable(mem.NewTable("t", nil)),
+						),
+					),
+				),
+			),
+			nil,
+		},
+		{
+			"replace existing aggregation in group by with nodes in between",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					aggregation.NewAvg(expression.NewUnresolvedColumn("foo")),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Float64, "x", false),
+						expression.NewGetField(1, sql.Int64, "foo", false),
+					},
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewAlias(aggregation.NewAvg(expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false)), "x"),
+							expression.NewGetField(0, sql.Int64, "foo", false),
+						},
+						[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", nil)),
+					),
+				),
+			),
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewGetField(0, sql.Float64, "x", false),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Float64, "x", false),
+						expression.NewGetField(1, sql.Int64, "foo", false),
+					},
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewAlias(aggregation.NewAvg(expression.NewGetFieldWithTable(0, sql.Int64, "t", "foo", false)), "x"),
+							expression.NewGetField(0, sql.Int64, "foo", false),
+						},
+						[]sql.Expression{expression.NewGetField(0, sql.Int64, "foo", false)},
+						plan.NewResolvedTable(mem.NewTable("t", nil)),
+					),
+				),
+			),
+			nil,
+		},
+		{
+			"missing groupby",
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					aggregation.NewCount(expression.NewStar()),
+					expression.NewLiteral(int64(5), sql.Int64),
+				),
 				plan.NewResolvedTable(mem.NewTable("t", nil)),
 			),
-		),
-	)
+			nil,
+			errHavingNeedsGroupBy,
+		},
+	}
 
-	result, err = resolveHaving(sql.NewEmptyContext(), nil, node)
-	require.NoError(err)
-	require.Equal(expected, result)
-
-	node = plan.NewHaving(
-		expression.NewGreaterThan(
-			aggregation.NewCount(expression.NewStar()),
-			expression.NewLiteral(int64(5), sql.Int64),
-		),
-		plan.NewResolvedTable(mem.NewTable("t", nil)),
-	)
-
-	_, err = resolveHaving(sql.NewEmptyContext(), nil, node)
-	require.Error(err)
-	require.True(errHavingNeedsGroupBy.Is(err))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			result, err := resolveHaving(sql.NewEmptyContext(), nil, tt.input)
+			if tt.err != nil {
+				require.Error(err)
+				require.True(tt.err.Is(err))
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, result)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #764

This one solves all the cases I could come up with. Now having group by immediately under the having is not necessary and there can be any number of nodes in between them.