### PR TITLE
sql: fix how nulls are sent to clients

### DIFF
--- a/_integration/go/mysql_test.go
+++ b/_integration/go/mysql_test.go
@@ -74,7 +74,7 @@ func TestGrafana(t *testing.T) {
 		},
 		{
 			`select @@version_comment limit 1`,
-			[][]string{{"NULL"}},
+			[][]string{{""}},
 		},
 		{
 			`describe table mytable`,

--- a/engine_test.go
+++ b/engine_test.go
@@ -634,6 +634,8 @@ var queries = []struct {
 			{"ndbinfo_version", ""},
 			{"sql_select_limit", math.MaxInt32},
 			{"transaction_isolation", "READ UNCOMMITTED"},
+			{"version", ""},
+			{"version_comment", ""},
 		},
 	},
 	{
@@ -1237,8 +1239,8 @@ var queries = []struct {
 	{
 		`SELECT ARRAY_LENGTH("foo")`,
 		[]sql.Row{{nil}},
-  },
-  {
+	},
+	{
 		`SELECT * FROM mytable WHERE NULL AND i = 3`,
 		[]sql.Row{},
 	},

--- a/server/handler.go
+++ b/server/handler.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	errors "gopkg.in/src-d/go-errors.v1"
 	sqle "github.com/src-d/go-mysql-server"
 	"github.com/src-d/go-mysql-server/auth"
 	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/sirupsen/logrus"
 	"vitess.io/vitess/go/mysql"

--- a/sql/session.go
+++ b/sql/session.go
@@ -175,6 +175,8 @@ func DefaultSessionConfig() map[string]TypedValue {
 		"ndbinfo_version":          TypedValue{Text, ""},
 		"sql_select_limit":         TypedValue{Int32, math.MaxInt32},
 		"transaction_isolation":    TypedValue{Text, "READ UNCOMMITTED"},
+		"version":                  TypedValue{Text, ""},
+		"version_comment":          TypedValue{Text, ""},
 	}
 }
 

--- a/sql/type.go
+++ b/sql/type.go
@@ -303,7 +303,7 @@ func (t numberT) Type() query.Type {
 // SQL implements Type interface.
 func (t numberT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(t.t, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	switch t.t {
@@ -429,7 +429,7 @@ var TimestampLayouts = []string{
 // SQL implements Type interface.
 func (t timestampT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.Timestamp, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)
@@ -505,7 +505,7 @@ func (t dateT) Type() query.Type {
 
 func (t dateT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.Timestamp, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)
@@ -562,7 +562,7 @@ func (t textT) Type() query.Type {
 // SQL implements Type interface.
 func (t textT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.Text, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)
@@ -599,7 +599,7 @@ func (t booleanT) Type() query.Type {
 // SQL implements Type interface.
 func (t booleanT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.Bit, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	b := []byte{'0'}
@@ -659,7 +659,7 @@ func (t blobT) Type() query.Type {
 // SQL implements Type interface.
 func (t blobT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.Blob, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)
@@ -703,7 +703,7 @@ func (t jsonT) Type() query.Type {
 // SQL implements Type interface.
 func (t jsonT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.TypeJSON, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)
@@ -810,7 +810,7 @@ func (t arrayT) Type() query.Type {
 
 func (t arrayT) SQL(v interface{}) (sqltypes.Value, error) {
 	if v == nil {
-		return sqltypes.MakeTrusted(sqltypes.TypeJSON, nil), nil
+		return sqltypes.NULL, nil
 	}
 
 	v, err := t.Convert(v)

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -13,7 +13,7 @@ func TestIsNull(t *testing.T) {
 	require.True(t, IsNull(nil))
 
 	n := numberT{sqltypes.Uint64}
-	require.Equal(t, sqltypes.MakeTrusted(sqltypes.Uint64, nil), mustSQL(n.SQL(nil)))
+	require.Equal(t, sqltypes.NULL, mustSQL(n.SQL(nil)))
 	require.Equal(t, sqltypes.NewUint64(0), mustSQL(n.SQL(uint64(0))))
 }
 


### PR DESCRIPTION
Fixes #779 

Fixing this, connecting from MySQL client broke. After much debugging, turns out it was because `@@version` and `@@version_comment` didn't exist (and thus, they were null), but the client was expecting something there. I just added both, but left them empty and the problem goes away.