### PR TITLE
sql: fix SQL method for arrays of JSON

### DIFF
--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -401,6 +401,22 @@ func TestUnderlyingType(t *testing.T) {
 	require.Equal(t, Text, UnderlyingType(Text))
 }
 
+type testJSONStruct struct {
+	A int
+	B string
+}
+
+func TestJSONArraySQL(t *testing.T) {
+	require := require.New(t)
+	val, err := Array(JSON).SQL([]interface{}{
+		testJSONStruct{1, "foo"},
+		testJSONStruct{2, "bar"},
+	})
+	require.NoError(err)
+	expected := `[{"A":1,"B":"foo"},{"A":2,"B":"bar"}]`
+	require.Equal(expected, string(val.Raw()))
+}
+
 func eq(t *testing.T, typ Type, a, b interface{}) {
 	t.Helper()
 	cmp, err := typ.Compare(a, b)


### PR DESCRIPTION
Using `SQL` method of a value of type `Array(JSON)` produces the following:

```
[chunk of bytes, chunk of bytes, ...]
```

With this fix, it produces:

```
[proper json, proper json]
```

This bug is blocking the pushdown of `commit_file_stats` on https://github.com/src-d/gitbase-spark-connector-enterprise/issues/86