### PR TITLE
README.md -> fix build status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-mysql-server
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-<a href="https://travis-ci.org/src-d/go-mysql-server"><img alt="Build Status" src="https://travis-ci.org/src-d/go-mysql-server.svg?branch=master" /></a>
+<a href="https://travis-ci.com/src-d/go-mysql-server"><img alt="Build Status" src="https://travis-ci.com/src-d/go-mysql-server.svg?branch=master" /></a>
 <a href="https://codecov.io/gh/src-d/go-mysql-server"><img alt="codecov" src="https://codecov.io/gh/src-d/go-mysql-server/branch/master/graph/badge.svg" /></a>
 <a href="https://godoc.org/github.com/src-d/go-mysql-server"><img alt="GoDoc" src="https://godoc.org/github.com/src-d/go-mysql-server?status.svg" /></a>
 [![Issues](http://img.shields.io/github/issues/src-d/go-mysql-server.svg)](https://github.com/src-d/go-mysql-server/issues)


### PR DESCRIPTION
<img width="965" alt="Screen Shot 2019-07-22 at 2 57 19 PM" src="https://user-images.githubusercontent.com/10910699/61631472-21dfdd00-ac93-11e9-8e05-fd10dcc26d29.png">
fix build status link inside the README.md: travis-ci.org -> travis-ci.com

Signed-off-by: lwsanty <lwsanty@gmail.com>