### PR TITLE
Fixed INSERT bugs, added UINT64 support, and added tests

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -1908,11 +1908,21 @@ func TestInsertIntoErrors(t *testing.T) {
 			"too many values no columns specified",
 			"INSERT INTO mytable VALUES (999, 'x', 'y');",
 		},
+		{
+			"non-existent column",
+			"INSERT INTO mytable (i, s, z) VALUES (999, 'x', 999);",
+		},
+		{
+			"duplicate column",
+			"INSERT INTO mytable (i, s, s) VALUES (999, 'x', 'x');",
+		},
 	}
 
 	for _, expectedFailure := range expectedFailures {
-		_, _, err := newEngine(t).Query(newCtx(), expectedFailure.query)
-		require.Error(t, err)
+		t.Run(expectedFailure.name, func(t *testing.T) {
+			_, _, err := newEngine(t).Query(newCtx(), expectedFailure.query)
+			require.Error(t, err)
+		})
 	}
 }
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/expression/function"
@@ -903,7 +903,12 @@ func convertVal(v *sqlparser.SQLVal) (sql.Expression, error) {
 		//TODO: Use smallest integer representation and widen later.
 		val, err := strconv.ParseInt(string(v.Val), 10, 64)
 		if err != nil {
-			return nil, err
+			// Might be a uint64 value that is greater than int64 max
+			val, checkErr := strconv.ParseUint(string(v.Val), 10, 64)
+			if checkErr != nil {
+				return nil, err
+			}
+			return expression.NewLiteral(val, sql.Uint64), nil
 		}
 		return expression.NewLiteral(val, sql.Int64), nil
 	case sqlparser.FloatVal:

--- a/sql/type.go
+++ b/sql/type.go
@@ -343,10 +343,18 @@ func (t numberT) Convert(v interface{}) (interface{}, error) {
 	}
 
 	switch t.t {
+	case sqltypes.Int8:
+		return cast.ToInt8E(v)
+	case sqltypes.Int16:
+		return cast.ToInt16E(v)
 	case sqltypes.Int32:
 		return cast.ToInt32E(v)
 	case sqltypes.Int64:
 		return cast.ToInt64E(v)
+	case sqltypes.Uint8:
+		return cast.ToUint8E(v)
+	case sqltypes.Uint16:
+		return cast.ToUint16E(v)
 	case sqltypes.Uint32:
 		return cast.ToUint32E(v)
 	case sqltypes.Uint64:


### PR DESCRIPTION
I found some bugs for INSERT statements, and implemented a few tests as well (some specific to the bug fixes, others for general INSERT testing).

One bug dealt with integer values greater than an INT64. By default, all numbers are parsed to INT64, meaning that a column with type `sql.Uint64` cannot actually hold the entire range. I added another check that only attempts to parse as a UINT64 in the event that the INT64 parsing fails.

Another bug dealt with the absence of columns in an INSERT statement. For example: `INSERT INTO tablename VALUES ...` would parse as an empty column list, rather than the entire column list. This behavior has been fixed.

Another bug dealt with a mismatch between the number of columns supplied and the number of values supplied for an INSERT statement. This has also been fixed.

The last bug dealt with the smallest integer types. The `Convert` function was missing entries for those types, and causing inserts on those columns to fail that should otherwise be valid. This has also been fixed.