### PR TITLE
Convert LIKE patterns to specific Go regexes

### DIFF
--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -68,11 +68,11 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		right = patternToRegex(v.(string))
+		right = patternToGoRegex(v.(string))
 	}
 	// for non-cached regex every time create a new matcher
 	if !l.cached {
-		matcher, disposer, err = regex.New(regex.Default(), right)
+		matcher, disposer, err = regex.New("go", right)
 	} else {
 		if l.pool == nil {
 			l.pool = &sync.Pool{
@@ -115,8 +115,9 @@ func (l *Like) WithChildren(children ...sql.Expression) (sql.Expression, error) 
 	return NewLike(children[0], children[1]), nil
 }
 
-func patternToRegex(pattern string) string {
+func patternToGoRegex(pattern string) string {
 	var buf bytes.Buffer
+	buf.WriteString("(?s)")
 	buf.WriteRune('^')
 	var escaped bool
 	for _, r := range strings.Replace(regexp.QuoteMeta(pattern), `\\`, `\`, -1) {

--- a/sql/expression/like_test.go
+++ b/sql/expression/like_test.go
@@ -12,23 +12,23 @@ func TestPatternToRegex(t *testing.T) {
 	testCases := []struct {
 		in, out string
 	}{
-		{`__`, `^..$`},
-		{`_%_`, `^..*.$`},
-		{`%_`, `^.*.$`},
-		{`_%`, `^..*$`},
-		{`a_b`, `^a.b$`},
-		{`a%b`, `^a.*b$`},
-		{`a.%b`, `^a\..*b$`},
-		{`a\%b`, `^a%b$`},
-		{`a\_b`, `^a_b$`},
-		{`a\\b`, `^a\\b$`},
-		{`a\\\_b`, `^a\\_b$`},
-		{`(ab)`, `^\(ab\)$`},
+		{`__`, `(?s)^..$`},
+		{`_%_`, `(?s)^..*.$`},
+		{`%_`, `(?s)^.*.$`},
+		{`_%`, `(?s)^..*$`},
+		{`a_b`, `(?s)^a.b$`},
+		{`a%b`, `(?s)^a.*b$`},
+		{`a.%b`, `(?s)^a\..*b$`},
+		{`a\%b`, `(?s)^a%b$`},
+		{`a\_b`, `(?s)^a_b$`},
+		{`a\\b`, `(?s)^a\\b$`},
+		{`a\\\_b`, `(?s)^a\\_b$`},
+		{`(ab)`, `(?s)^\(ab\)$`},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.in, func(t *testing.T) {
-			require.Equal(t, tt.out, patternToRegex(tt.in))
+			require.Equal(t, tt.out, patternToGoRegex(tt.in))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #814

The problem here was that we converted [the `LIKE` pattern into a regex](https://github.com/src-d/go-mysql-server/blob/128924aa3c/sql/expression/like.go#L118-L153) and used one of the regex engines (the standard go regexp package, or oniguruma) to try to match the string from the input row. The regex was built by enclosing the `LIKE` pattern between `^` and `$` (so if the pattern was `text`, the regexp would be `^text$`). But, at least in the standard go regexp package, `^` and `$` match the beginning and the end of the text, not of the line, and the dot `.` matches any character that is not a new line character. That is, if the `LIKE` pattern is `%text%`, then the resulting regex, `^.*text.*$`, will match anything that contains the substring text and that does not contain any new line characters. I considered several solutions to fix this:
- to modify the default behaviour of our go regexp manager `internal/regex_go.go`, either by:
   - adding the flag `(?s)`, which makes `.` match also newline characters
   - adding the flag `(?m)`, which makes `^` and `$` match beginning and end, respectively, of a new line, not of the whole text.
- to refactor the `patternToRegex` function in `sql/expression/like.go` so it depends on the regex engine being used.
- to make the `patternToRegex` specific to the go engine, always adding the `(?s)` flag.

I finally implemented the last solution, as it was the least intrusive. The other ones are not generic or mix two different problems in one single place.

**Note**: We should block the merge of this PR until @Hydrocharged opens one with the tests.