### PR TITLE
analyzer: do not erase sort node when pushing it down

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -2536,6 +2536,12 @@ func TestOrderByGroupBy(t *testing.T) {
 	require.NoError(err)
 
 	require.Equal(expected, rows)
+
+	_, _, err = e.Query(
+		newCtx(),
+		"SELECT team, COUNT(*) FROM members GROUP BY team ORDER BY columndoesnotexist",
+	)
+	require.Error(err)
 }
 
 func TestTracing(t *testing.T) {

--- a/sql/analyzer/resolve_orderby.go
+++ b/sql/analyzer/resolve_orderby.go
@@ -164,7 +164,7 @@ func pushSortDown(sort *plan.Sort) (sql.Node, error) {
 			plan.NewSort(sort.SortFields, child.Child),
 		), nil
 	case *plan.ResolvedTable:
-		return child, nil
+		return sort, nil
 	default:
 		children := child.Children()
 		if len(children) == 1 {


### PR DESCRIPTION
Fixes #813 

It turns out there was a case in which a sort node could be removed