### PR TITLE
Add CHAR and DATETIME types support

### DIFF
--- a/_integration/go/mysql_test.go
+++ b/_integration/go/mysql_test.go
@@ -82,7 +82,7 @@ func TestGrafana(t *testing.T) {
 				{"name", "TEXT"},
 				{"email", "TEXT"},
 				{"phone_numbers", "JSON"},
-				{"created_at", "DATETIME"},
+				{"created_at", "TIMESTAMP"},
 			},
 		},
 		{

--- a/engine_test.go
+++ b/engine_test.go
@@ -1994,7 +1994,7 @@ func TestDDL(t *testing.T) {
 	testQuery(t, e,
 		"CREATE TABLE t1(a INTEGER, b TEXT, c DATE, "+
 			"d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, "+
-			"b1 BOOL, b2 BOOLEAN NOT NULL)",
+			"b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME",
 		[]sql.Row(nil),
 	)
 
@@ -2013,6 +2013,7 @@ func TestDDL(t *testing.T) {
 		{Name: "f", Type: sql.Blob, Source: "t1"},
 		{Name: "b1", Type: sql.Uint8, Nullable: true, Source: "t1"},
 		{Name: "b2", Type: sql.Uint8, Source: "t1"},
+		{Name: "g", Type: sql.Datetime, Nullable: true, Source: "t1"},
 	}
 
 	require.Equal(s, testTable.Schema())

--- a/engine_test.go
+++ b/engine_test.go
@@ -1994,7 +1994,7 @@ func TestDDL(t *testing.T) {
 	testQuery(t, e,
 		"CREATE TABLE t1(a INTEGER, b TEXT, c DATE, "+
 			"d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, "+
-			"b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME",
+			"b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME, h CHAR(40))",
 		[]sql.Row(nil),
 	)
 
@@ -2014,6 +2014,7 @@ func TestDDL(t *testing.T) {
 		{Name: "b1", Type: sql.Uint8, Nullable: true, Source: "t1"},
 		{Name: "b2", Type: sql.Uint8, Source: "t1"},
 		{Name: "g", Type: sql.Datetime, Nullable: true, Source: "t1"},
+		{Name: "h", Type: sql.Text, Nullable: true, Source: "t1"},
 	}
 
 	require.Equal(s, testTable.Schema())

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var fixtures = map[string]sql.Node{
-	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL)`: plan.NewCreateTable(
+	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME)`: plan.NewCreateTable(
 		sql.UnresolvedDatabase(""),
 		"t1",
 		sql.Schema{{
@@ -40,6 +40,10 @@ var fixtures = map[string]sql.Node{
 			Name:     "f",
 			Type:     sql.Blob,
 			Nullable: false,
+		}, {
+			Name:     "g",
+			Type:     sql.Datetime,
+			Nullable: true,
 		}},
 	),
 	`DESCRIBE TABLE foo;`: plan.NewDescribe(

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var fixtures = map[string]sql.Node{
-	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME)`: plan.NewCreateTable(
+	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`: plan.NewCreateTable(
 		sql.UnresolvedDatabase(""),
 		"t1",
 		sql.Schema{{
@@ -43,6 +43,10 @@ var fixtures = map[string]sql.Node{
 		}, {
 			Name:     "g",
 			Type:     sql.Datetime,
+			Nullable: true,
+		}, {
+			Name:     "h",
+			Type:     sql.Text,
 			Nullable: true,
 		}},
 	),

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -236,40 +236,57 @@ func TestExtraTimestamps(t *testing.T) {
 	}
 }
 
-func TestDate(t *testing.T) {
+// Generic tests for Date and Datetime.
+// typ should be Date or Datetime
+func commonTestsDatesTypes(typ Type, layout string, t *testing.T) {
 	require := require.New(t)
 	now := time.Now().UTC()
-	v, err := Date.Convert(now)
+	v, err := typ.Convert(now)
 	require.NoError(err)
-	require.Equal(now.Format(DateLayout), v.(time.Time).Format(DateLayout))
+	require.Equal(now.Format(layout), v.(time.Time).Format(layout))
 
-	v, err = Date.Convert(now.Format(DateLayout))
-	require.NoError(err)
-	require.Equal(
-		now.Format(DateLayout),
-		v.(time.Time).Format(DateLayout),
-	)
-
-	v, err = Date.Convert(now.Unix())
+	v, err = typ.Convert(now.Format(layout))
 	require.NoError(err)
 	require.Equal(
-		now.Format(DateLayout),
-		v.(time.Time).Format(DateLayout),
+		now.Format(layout),
+		v.(time.Time).Format(layout),
 	)
 
-	sql, err := Date.SQL(now)
+	v, err = typ.Convert(now.Unix())
 	require.NoError(err)
-	require.Equal([]byte(now.Format(DateLayout)), sql.Raw())
+	require.Equal(
+		now.Format(layout),
+		v.(time.Time).Format(layout),
+	)
 
+	sql, err := typ.SQL(now)
+	require.NoError(err)
+	require.Equal([]byte(now.Format(layout)), sql.Raw())
+
+	after := now.Add(26 * time.Hour)
+	lt(t, typ, now, after)
+	eq(t, typ, now, now)
+	gt(t, typ, after, now)
+}
+
+func TestDate(t *testing.T) {
+	commonTestsDatesTypes(Date, DateLayout, t)
+
+	now := time.Now().UTC()
 	after := now.Add(time.Second)
 	eq(t, Date, now, after)
 	eq(t, Date, now, now)
 	eq(t, Date, after, now)
+}
 
-	after = now.Add(26 * time.Hour)
-	lt(t, Date, now, after)
-	eq(t, Date, now, now)
-	gt(t, Date, after, now)
+func TestDatetime(t *testing.T) {
+	commonTestsDatesTypes(Datetime, DatetimeLayout, t)
+
+	now := time.Now().UTC()
+	after := now.Add(time.Millisecond)
+	lt(t, Datetime, now, after)
+	eq(t, Datetime, now, now)
+	gt(t, Datetime, after, now)
 }
 
 func TestBlob(t *testing.T) {

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -342,20 +342,22 @@ func TestTuple(t *testing.T) {
 	gt(t, typ, []interface{}{1, 2, 4}, []interface{}{1, 2, 3})
 }
 
-func TestVarChar(t *testing.T) {
-	typ := VarChar(3)
-	require.True(t, IsVarChar(typ))
+// Generic test for Char and VarChar types.
+// genType should be sql.Char or sql.VarChar
+func testCharTypes(genType func(int) Type, checkType func(Type) bool, t *testing.T) {
+	typ := genType(3)
+	require.True(t, checkType(typ))
 	require.True(t, IsText(typ))
 	convert(t, typ, "foo", "foo")
 	fooByte := []byte{'f', 'o', 'o'}
 	convert(t, typ, fooByte, "foo")
 
-	typ = VarChar(1)
+	typ = genType(1)
 	convertErr(t, typ, "foo")
 	convertErr(t, typ, fooByte)
 	convertErr(t, typ, 123)
 
-	typ = VarChar(10)
+	typ = genType(10)
 	convert(t, typ, 123, "123")
 	convertErr(t, typ, 1234567890123)
 
@@ -370,8 +372,16 @@ func TestVarChar(t *testing.T) {
 	require.NoError(t, err)
 
 	convert(t, typ, text, "abc")
-	typ1 := VarChar(1)
+	typ1 := genType(1)
 	convertErr(t, typ1, text)
+}
+
+func TestChar(t *testing.T) {
+	testCharTypes(Char, IsChar, t)
+}
+
+func TestVarChar(t *testing.T) {
+	testCharTypes(VarChar, IsVarChar, t)
 }
 
 func TestArray(t *testing.T) {


### PR DESCRIPTION
This PR adds support for two MySQL types: CHAR and DATETIME.

The former shares much of its behaviour with VARCHAR, whereas the latter is similar to DATE, so I have refactored the tests for the older types to test also the new ones.

Fixes #807.