### PR TITLE
Also check sockets bind to tcp6 and fail on all closed sockets

### DIFF
--- a/internal/sockstate/netstat_darwin.go
+++ b/internal/sockstate/netstat_darwin.go
@@ -12,8 +12,8 @@ import (
 // elements that satisfy the accept function
 func tcpSocks(accept AcceptFn) ([]sockTabEntry, error) {
 	// (juanjux) TODO: not implemented
-	logrus.Info("Connection checking not implemented for Darwin")
-	return []sockTabEntry{}, nil
+	logrus.Info("Connection checking not implemented for Windows")
+	return nil, ErrSocketCheckNotImplemented.New()
 }
 
 func GetConnInode(c *net.TCPConn) (n uint64, err error) {

--- a/internal/sockstate/netstat_darwin.go
+++ b/internal/sockstate/netstat_darwin.go
@@ -12,7 +12,7 @@ import (
 // elements that satisfy the accept function
 func tcpSocks(accept AcceptFn) ([]sockTabEntry, error) {
 	// (juanjux) TODO: not implemented
-	logrus.Info("Connection checking not implemented for Windows")
+	logrus.Warn("Connection checking not implemented for Darwin")
 	return nil, ErrSocketCheckNotImplemented.New()
 }
 

--- a/internal/sockstate/netstat_windows.go
+++ b/internal/sockstate/netstat_windows.go
@@ -12,7 +12,7 @@ import (
 // elements that satisfy the accept function
 func tcpSocks(accept AcceptFn) ([]sockTabEntry, error) {
 	// (juanjux) TODO: not implemented
-	logrus.Info("Connection checking not implemented for Windows")
+	logrus.Warn("Connection checking not implemented for Windows")
 	return nil, ErrSocketCheckNotImplemented.New()
 }
 

--- a/internal/sockstate/netstat_windows.go
+++ b/internal/sockstate/netstat_windows.go
@@ -13,7 +13,7 @@ import (
 func tcpSocks(accept AcceptFn) ([]sockTabEntry, error) {
 	// (juanjux) TODO: not implemented
 	logrus.Info("Connection checking not implemented for Windows")
-	return []sockTabEntry{}, nil
+	return nil, ErrSocketCheckNotImplemented.New()
 }
 
 func GetConnInode(c *net.TCPConn) (n uint64, err error) {

--- a/internal/sockstate/sockstate.go
+++ b/internal/sockstate/sockstate.go
@@ -36,7 +36,7 @@ func GetInodeSockState(port int, inode uint64) (SockState, error) {
 
 	switch len(socks) {
 	case 0:
-		fallthrough
+		return Broken, nil
 	case 1:
 		switch socks[0].State {
 		case CloseWait:

--- a/internal/sockstate/sockstate.go
+++ b/internal/sockstate/sockstate.go
@@ -8,8 +8,7 @@ import (
 type SockState uint8
 
 const (
-	Finished = iota
-	Broken
+	Broken = iota
 	Other
 	Error
 )
@@ -37,12 +36,24 @@ func GetInodeSockState(port int, inode uint64) (SockState, error) {
 
 	switch len(socks) {
 	case 0:
-		return Finished, nil
+		fallthrough
 	case 1:
-		if socks[0].State == CloseWait {
+		switch socks[0].State {
+		case CloseWait:
+			fallthrough
+		case TimeWait:
+			fallthrough
+		case FinWait1:
+			fallthrough
+		case FinWait2:
+			fallthrough
+		case Close:
+			fallthrough
+		case Closing:
 			return Broken, nil
+		default:
+			return Other, nil
 		}
-		return Other, nil
 	default: // more than one sock for inode, impossible?
 		return Error, ErrMultipleSocketsForInode.New()
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -239,6 +239,7 @@ rowLoop:
 
 		if r.RowsAffected == rowsBatch {
 			if err := callback(r); err != nil {
+				close(quit)
 				return err
 			}
 
@@ -272,12 +273,11 @@ rowLoop:
 		}
 		timer.Reset(waitTime)
 	}
+	close(quit)
 
 	if err := rows.Close(); err != nil {
 		return err
 	}
-
-	close(quit)
 
 	// Even if r.RowsAffected = 0, the callback must be
 	// called to update the state in the go-vitess' listener

--- a/server/handler.go
+++ b/server/handler.go
@@ -211,16 +211,12 @@ func (h *Handler) ComQuery(
 		for {
 			select {
 			case <-quit:
-				// timeout or other errors detected by the calling routine
 				return
 			default:
 			}
 
 			st, err := sockstate.GetInodeSockState(t.Port, inode)
 			switch st {
-			case sockstate.Finished:
-				// Not Linux OSs will also exit here
-				return
 			case sockstate.Broken:
 				errChan <- ErrConnectionWasClosed.New()
 				return

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -255,6 +255,7 @@ func TestHandlerTimeout(t *testing.T) {
 	})
 	require.NoError(err)
 }
+
 func TestOkClosedConnection(t *testing.T) {
 	require := require.New(t)
 	e := setupMemDB(require)
@@ -281,11 +282,11 @@ func TestOkClosedConnection(t *testing.T) {
 		0,
 	)
 	h.AddNetConnection(&conn)
-	c2 := newConn(2)
-	h.NewConnection(c2)
+	c := newConn(1)
+	h.NewConnection(c)
 
 	q := fmt.Sprintf("SELECT SLEEP(%d)", tcpCheckerSleepTime*4)
-	err = h.ComQuery(c2, q, func(res *sqltypes.Result) error {
+	err = h.ComQuery(c, q, func(res *sqltypes.Result) error {
 		return nil
 	})
 	require.NoError(err)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -165,7 +165,6 @@ func TestHandlerKill(t *testing.T) {
 	require.Len(handler.c, 2)
 	require.Equal(conntainer1, handler.c[1])
 	require.Equal(conntainer2, handler.c[2])
-
 	assertNoConnProcesses(t, e, conn2.ConnectionID)
 
 	ctx1 := handler.sm.NewContextWithQuery(conn1, "SELECT 1")


### PR DESCRIPTION
- Also parse `/proc/net/tcp6` because go will bind to it (too) on `Listen()`  if TCP v6 is enabled on the system, and then the socket will only show on `/proc/net/tcp6`. This fixes #821.

- Fail on all kinds of closed sockets, even if they were closed correctly, before the query completion, thus ensuring that the query is cancelled.

- Two explicit channel closings to ensure the goroutines exit ASAP.