### PR TITLE
Implemented REPLACE

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -120,7 +120,7 @@ func (e *Engine) Query(
 	case *plan.CreateIndex:
 		typ = sql.CreateIndexProcess
 		perm = auth.ReadPerm | auth.WritePerm
-	case *plan.InsertInto, *plan.DropIndex, *plan.UnlockTables, *plan.LockTables:
+	case *plan.InsertInto, *plan.DeleteFrom, *plan.DropIndex, *plan.UnlockTables, *plan.LockTables:
 		perm = auth.ReadPerm | auth.WritePerm
 	}
 

--- a/memory/table.go
+++ b/memory/table.go
@@ -263,8 +263,8 @@ func (t *Table) Delete(ctx *sql.Context, row sql.Row) error {
 		return err
 	}
 
+	matches := false
 	for partitionIndex, partition := range t.partitions {
-		matches := false
 		for partitionRowIndex, partitionRow := range partition {
 			matches = true
 			for rIndex, val := range row {
@@ -281,6 +281,10 @@ func (t *Table) Delete(ctx *sql.Context, row sql.Row) error {
 		if matches {
 			break
 		}
+	}
+
+	if !matches {
+		return sql.ErrDeleteRowNotFound
 	}
 
 	return nil

--- a/memory/table.go
+++ b/memory/table.go
@@ -257,6 +257,35 @@ func (t *Table) Insert(ctx *sql.Context, row sql.Row) error {
 	return nil
 }
 
+// Delete the given row from the table.
+func (t *Table) Delete(ctx *sql.Context, row sql.Row) error {
+	if err := checkRow(t.schema, row); err != nil {
+		return err
+	}
+
+	for partitionIndex, partition := range t.partitions {
+		matches := false
+		for partitionRowIndex, partitionRow := range partition {
+			matches = true
+			for rIndex, val := range row {
+				if val != partitionRow[rIndex] {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				t.partitions[partitionIndex] = append(partition[:partitionRowIndex], partition[partitionRowIndex+1:]...)
+				break
+			}
+		}
+		if matches {
+			break
+		}
+	}
+
+	return nil
+}
+
 func checkRow(schema sql.Schema, row sql.Row) error {
 	if len(row) != len(schema) {
 		return sql.ErrUnexpectedRowLength.New(len(schema), len(row))

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -20,7 +20,7 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 
 	// don't do pushdown on certain queries
 	switch n.(type) {
-	case *plan.InsertInto, *plan.CreateIndex:
+	case *plan.InsertInto, *plan.DeleteFrom, *plan.CreateIndex:
 		return n, nil
 	}
 

--- a/sql/core.go
+++ b/sql/core.go
@@ -29,6 +29,9 @@ var (
 	// ErrInvalidChildrenNumber is returned when the WithChildren method of a
 	// node or expression is called with an invalid number of arguments.
 	ErrInvalidChildrenNumber = errors.NewKind("%T: invalid children number, got %d, expected %d")
+
+	// ErrDeleteRowNotFound
+	ErrDeleteRowNotFound = errors.NewKind("row was not found when attempting to delete").New()
 )
 
 // Nameable is something that has a name.
@@ -204,8 +207,14 @@ type Inserter interface {
 
 // Deleter allow rows to be deleted from them.
 type Deleter interface {
-	// Delete the given row.
+	// Delete the given row. Returns ErrDeleteRowNotFound if the row was not found.
 	Delete(*Context, Row) error
+}
+
+// Replacer allows rows to be replaced through a Delete (if applicable) then Insert.
+type Replacer interface {
+	Deleter
+	Inserter
 }
 
 // Database represents the database.

--- a/sql/core.go
+++ b/sql/core.go
@@ -202,6 +202,12 @@ type Inserter interface {
 	Insert(*Context, Row) error
 }
 
+// Deleter allow rows to be deleted from them.
+type Deleter interface {
+	// Delete the given row.
+	Delete(*Context, Row) error
+}
+
 // Database represents the database.
 type Database interface {
 	Nameable

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -373,10 +373,7 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 		return nil, ErrUnsupportedSyntax.New(i)
 	}
 
-	isReplace := false
-	if i.Action == sqlparser.ReplaceStr {
-		isReplace = true
-	}
+	isReplace := i.Action == sqlparser.ReplaceStr
 
 	src, err := insertRowsToNode(ctx, i.Rows)
 	if err != nil {

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -373,6 +373,11 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 		return nil, ErrUnsupportedSyntax.New(i)
 	}
 
+	isReplace := false
+	if i.Action == sqlparser.ReplaceStr {
+		isReplace = true
+	}
+
 	src, err := insertRowsToNode(ctx, i.Rows)
 	if err != nil {
 		return nil, err
@@ -381,6 +386,7 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 	return plan.NewInsertInto(
 		plan.NewUnresolvedTable(i.Table.Name.String(), i.Table.Qualifier.String()),
 		src,
+		isReplace,
 		columnsToStrings(i.Columns),
 	), nil
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -252,6 +252,16 @@ var fixtures = map[string]sql.Node{
 			expression.NewLiteral("a", sql.Text),
 			expression.NewLiteral(int64(1), sql.Int64),
 		}}),
+		false,
+		[]string{"col1", "col2"},
+	),
+	`REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(
+		plan.NewUnresolvedTable("t1", ""),
+		plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.Text),
+			expression.NewLiteral(int64(1), sql.Int64),
+		}}),
+		true,
 		[]string{"col1", "col2"},
 	),
 	`SHOW TABLES`:               plan.NewShowTables(sql.UnresolvedDatabase(""), false),

--- a/sql/plan/delete.go
+++ b/sql/plan/delete.go
@@ -1,0 +1,125 @@
+package plan
+
+import (
+	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
+	"io"
+)
+
+var ErrDeleteFromNotSupported = errors.NewKind("table doesn't support DELETE FROM")
+
+// DeleteFrom is a node describing a deletion from some table.
+type DeleteFrom struct {
+	sql.Node
+}
+
+// NewDeleteFrom creates a DeleteFrom node.
+func NewDeleteFrom(n sql.Node) *DeleteFrom {
+	return &DeleteFrom{n}
+}
+
+// Schema implements the Node interface.
+func (p *DeleteFrom) Schema() sql.Schema {
+	return sql.Schema{{
+		Name:     "updated",
+		Type:     sql.Int64,
+		Default:  int64(0),
+		Nullable: false,
+	}}
+}
+
+// Resolved implements the Resolvable interface.
+func (p *DeleteFrom) Resolved() bool {
+	return p.Node.Resolved()
+}
+
+func (p *DeleteFrom) Children() []sql.Node {
+	return []sql.Node{p.Node}
+}
+
+func getDeletable(node sql.Node) (sql.Deleter, error) {
+	switch node := node.(type) {
+	case sql.Deleter:
+		return node, nil
+	case *ResolvedTable:
+		return getDeletableTable(node.Table)
+	}
+	for _, child := range node.Children() {
+		deleter, _ := getDeletable(child)
+		if deleter != nil {
+			return deleter, nil
+		}
+	}
+	return nil, ErrDeleteFromNotSupported.New()
+}
+
+func getDeletableTable(t sql.Table) (sql.Deleter, error) {
+	switch t := t.(type) {
+	case sql.Deleter:
+		return t, nil
+	case sql.TableWrapper:
+		return getDeletableTable(t.Underlying())
+	default:
+		return nil, ErrDeleteFromNotSupported.New()
+	}
+}
+
+// Execute inserts the rows in the database.
+func (p *DeleteFrom) Execute(ctx *sql.Context) (int, error) {
+	deletable, err := getDeletable(p.Node)
+	if err != nil {
+		return 0, err
+	}
+
+	iter, err := p.Node.RowIter(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	i := 0
+	for {
+		row, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			_ = iter.Close()
+			return i, err
+		}
+
+		if err := deletable.Delete(ctx, row); err != nil {
+			_ = iter.Close()
+			return i, err
+		}
+
+		i++
+	}
+
+	return i, nil
+}
+
+// RowIter implements the Node interface.
+func (p *DeleteFrom) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	n, err := p.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.RowsToRowIter(sql.NewRow(int64(n))), nil
+}
+
+// WithChildren implements the Node interface.
+func (p *DeleteFrom) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 1)
+	}
+	return NewDeleteFrom(children[0]), nil
+}
+
+func (p DeleteFrom) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("Delete")
+	_ = pr.WriteChildren(p.Node.String())
+	return pr.String()
+}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/src-d/go-mysql-server/pull/822 and includes that commit's changes as well.

Looking over the [MySQL REPLACE documentation](https://dev.mysql.com/doc/refman/8.0/en/replace.html), I see that it mentions a REPLACE being either a DELETE then INSERT, or just an INSERT. I figured that there were two ways to implement this: as another interface with a unique function (`Replacer` with a `Replace` function for example), or by leveraging the already-included `Insert` and `Delete` functions from their respective interfaces. I decided to go with the latter option for the below reasons.

One point is in the reduction of code needed for someone wanting to implement the library. The more that the framework handles (without appreciable loss of freedom), the better. Then there is also the consideration of triggers. If DELETE and INSERT calls should make use of triggers (which are probably already built into the implementing `Delete` and `Insert` functions), then simply calling those _as normal_ will allow for correct behavior by default.

The biggest downside that I could see is that `Delete` is now forced to check if the given row exists, and return the appropriate error if not. For some implementations, this will not make an impact on the written code nor performance, but for others it definitely will. I felt that the trade off was worth it, but I'm interesting in hearing your opinions as well.

A third potential option is to allow for a custom `Replace` function if provided, otherwise defaulting to DELETE + INSERT from earlier. For example:
```go
type Replacer interface {
	Deleter
	Inserter
}

type CustomReplacer interface {
	Replace(*Context, Row) error
}
```
This would solve both of the problems as far as I can tell, but would not follow in the pattern established for every other keyword, and thus I decided against this.