### PR TITLE
plan: return types in lowercase in SHOW CREATE TABLE

### DIFF
--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -91,7 +91,7 @@ func produceCreateStatement(table sql.Table) string {
 
 	// Statement creation parts for each column
 	for i, col := range schema {
-		stmt := fmt.Sprintf("  `%s` %s", col.Name, sql.MySQLTypeName(col.Type))
+		stmt := fmt.Sprintf("  `%s` %s", col.Name, strings.ToLower(sql.MySQLTypeName(col.Type)))
 
 		if !col.Nullable {
 			stmt = fmt.Sprintf("%s NOT NULL", stmt)

--- a/sql/plan/show_create_table_test.go
+++ b/sql/plan/show_create_table_test.go
@@ -37,9 +37,9 @@ func TestShowCreateTable(t *testing.T) {
 
 	expected := sql.NewRow(
 		table.Name(),
-		"CREATE TABLE `test-table` (\n  `baz` TEXT NOT NULL,\n"+
-			"  `zab` INTEGER DEFAULT 0,\n"+
-			"  `bza` BIGINT UNSIGNED DEFAULT 0\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+		"CREATE TABLE `test-table` (\n  `baz` text NOT NULL,\n"+
+			"  `zab` integer DEFAULT 0,\n"+
+			"  `bza` bigint unsigned DEFAULT 0\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 	)
 
 	require.Equal(expected, row)


### PR DESCRIPTION
Fixes https://github.com/src-d/gitbase/issues/962

It solves a compatibility issue with SQLAlchemy, as it did not return
the types the same way MySQL does.