### PR TITLE
Fixed a few typos for the DELETE implementation

### DIFF
--- a/sql/core.go
+++ b/sql/core.go
@@ -205,7 +205,7 @@ type Inserter interface {
 	Insert(*Context, Row) error
 }
 
-// Deleter allow rows to be deleted from them.
+// Deleter allow rows to be deleted from tables.
 type Deleter interface {
 	// Delete the given row. Returns ErrDeleteRowNotFound if the row was not found.
 	Delete(*Context, Row) error

--- a/sql/plan/delete.go
+++ b/sql/plan/delete.go
@@ -64,7 +64,7 @@ func getDeletableTable(t sql.Table) (sql.Deleter, error) {
 	}
 }
 
-// Execute inserts the rows in the database.
+// Execute deletes the rows in the database.
 func (p *DeleteFrom) Execute(ctx *sql.Context) (int, error) {
 	deletable, err := getDeletable(p.Node)
 	if err != nil {


### PR DESCRIPTION
I had thought that I rebased the typo changes into the [REPLACE PR](https://github.com/src-d/go-mysql-server/pull/825) from the [DELETE PR](https://github.com/src-d/go-mysql-server/pull/822) and that those were included in the merge, but apparently I did not! I apologize for the lack of diligence on my part.