### PR TITLE
Add progress for each partition in SHOW PROCESSLIST

### DIFF
--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -83,7 +83,7 @@ func (t *ProcessIndexableTable) PartitionRows(ctx *sql.Context, p sql.Partition)
 		return nil, err
 	}
 
-	partitionName := string(p.Key())
+	partitionName := partitionName(p)
 	if t.OnPartitionStart != nil {
 		t.OnPartitionStart(partitionName)
 	}
@@ -137,7 +137,7 @@ func (t *ProcessTable) PartitionRows(ctx *sql.Context, p sql.Partition) (sql.Row
 		return nil, err
 	}
 
-	partitionName := string(p.Key())
+	partitionName := partitionName(p)
 	if t.OnPartitionStart != nil {
 		t.OnPartitionStart(partitionName)
 	}
@@ -206,7 +206,7 @@ func (i *trackedPartitionIndexKeyValueIter) Next() (sql.Partition, sql.IndexKeyV
 		return nil, nil, err
 	}
 
-	partitionName := string(p.Key())
+	partitionName := partitionName(p)
 	if i.OnPartitionStart != nil {
 		i.OnPartitionStart(partitionName)
 	}
@@ -263,4 +263,11 @@ func (i *trackedIndexKeyValueIter) Next() ([]interface{}, []byte, error) {
 	}
 
 	return v, k, nil
+}
+
+func partitionName(p sql.Partition) string {
+	if n, ok := p.(sql.Nameable); ok {
+		return n.Name()
+	}
+	return string(p.Key())
 }

--- a/sql/plan/process_test.go
+++ b/sql/plan/process_test.go
@@ -61,7 +61,9 @@ func TestProcessTable(t *testing.T) {
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(3)))
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(4)))
 
-	var notifications int
+	var partitionDoneNotifications int
+	var partitionStartNotifications int
+	var rowNextNotifications int
 
 	node := NewProject(
 		[]sql.Expression{
@@ -70,8 +72,14 @@ func TestProcessTable(t *testing.T) {
 		NewResolvedTable(
 			NewProcessTable(
 				table,
-				func() {
-					notifications++
+				func(partitionName string) {
+					partitionDoneNotifications++
+				},
+				func(partitionName string) {
+					partitionStartNotifications++
+				},
+				func(partitionName string) {
+					rowNextNotifications++
 				},
 			),
 		),
@@ -91,7 +99,9 @@ func TestProcessTable(t *testing.T) {
 	}
 
 	require.ElementsMatch(expected, rows)
-	require.Equal(2, notifications)
+	require.Equal(2, partitionDoneNotifications)
+	require.Equal(2, partitionStartNotifications)
+	require.Equal(4, rowNextNotifications)
 }
 
 func TestProcessIndexableTable(t *testing.T) {
@@ -106,12 +116,20 @@ func TestProcessIndexableTable(t *testing.T) {
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(3)))
 	table.Insert(sql.NewEmptyContext(), sql.NewRow(int64(4)))
 
-	var notifications int
+	var partitionDoneNotifications int
+	var partitionStartNotifications int
+	var rowNextNotifications int
 
 	pt := NewProcessIndexableTable(
 		table,
-		func() {
-			notifications++
+		func(partitionName string) {
+			partitionDoneNotifications++
+		},
+		func(partitionName string) {
+			partitionStartNotifications++
+		},
+		func(partitionName string) {
+			rowNextNotifications++
 		},
 	)
 
@@ -144,5 +162,7 @@ func TestProcessIndexableTable(t *testing.T) {
 	}
 
 	require.ElementsMatch(expectedValues, values)
-	require.Equal(2, notifications)
+	require.Equal(2, partitionDoneNotifications)
+	require.Equal(2, partitionStartNotifications)
+	require.Equal(4, rowNextNotifications)
 }

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -156,6 +156,20 @@ func (pl *ProcessList) AddProgressItem(pid uint64, name string, total int64) {
 	}
 }
 
+// RemoveProgressItem removes an existing item tracking progress from the
+// process with the given pid, if it exists.
+func (pl *ProcessList) RemoveProgressItem(pid uint64, name string) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+
+	p, ok := pl.procs[pid]
+	if !ok {
+		return
+	}
+
+	delete(p.Progress, name)
+}
+
 // Kill terminates all queries for a given connection id.
 func (pl *ProcessList) Kill(connID uint32) {
 	pl.mu.Lock()


### PR DESCRIPTION
This is a proposal to add some more information to the `SHOW PROCESSLIST` output.
It adds a counter for each active partition. A partition gets removed from the list when it finishes.

This is how it looks:
```
$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "show processlist"
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------+-----------------------+
| Id   | User | Host            | db      | Command | Time | State                                                            | Info                  |
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------+-----------------------+
|  395 | root | 127.0.0.1:35250 | gitbase | query   |    2 | cangallo(45/?), commits(0/3), octoprint-tft(45/?), upsilon(45/?) | select * from commits |
|  396 | root | 127.0.0.1:35250 | gitbase | query   |    0 | running                                                          | show processlist      |
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------+-----------------------+

$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "show processlist"
+------+------+-----------------+---------+---------+------+------------------------------+-----------------------+
| Id   | User | Host            | db      | Command | Time | State                        | Info                  |
+------+------+-----------------+---------+---------+------+------------------------------+-----------------------+
|  395 | root | 127.0.0.1:35256 | gitbase | query   |   11 | commits(2/3), upsilon(229/?) | select * from commits |
|  398 | root | 127.0.0.1:35256 | gitbase | query   |    0 | running                      | show processlist      |
+------+------+-----------------+---------+---------+------+------------------------------+-----------------------+
```
```
$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "show processlist"
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------+
| Id   | User | Host            | db      | Command | Time | State                                                                                                      | Info                                                               |
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------+
|  173 | root | 127.0.0.1:35236 | gitbase | query   |   65 | SquashedTable(commits, commit_blobs, blobs)(0/3), cangallo(1289/?), octoprint-tft(1280/?), upsilon(1281/?) | select * from commits natural join commit_blobs natural join blobs |
|  393 | root | 127.0.0.1:35236 | gitbase | query   |    0 | running                                                                                                    | show processlist                                                   |
+------+------+-----------------+---------+---------+------+------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------+
```
```
$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "show processlist"
+------+------+-----------------+---------+--------------+------+------------------------------+---------------------------------------------------------------------------------------------------------+
| Id   | User | Host            | db      | Command      | Time | State                        | Info                                                                                                    |
+------+------+-----------------+---------+--------------+------+------------------------------+---------------------------------------------------------------------------------------------------------+
|  395 | root | 127.0.0.1:35270 | gitbase | create_index |    8 | commits(2/3), upsilon(160/?) | CREATE INDEX commits_hash_idx ON commits USING pilosa (repository_id, commit_hash) WITH (async = false) |
|  402 | root | 127.0.0.1:35270 | gitbase | query        |    0 | running                      | show processlist                                                                                        |
+------+------+-----------------+---------+--------------+------+------------------------------+---------------------------------------------------------------------------------------------------------+
```

The new output can be used to notice when for some reason a repository takes more time than others to finish.

Because there aren't totals, the counter of each partition cannot be used to get an estimate of the progress made. Right now its only function is to let the user know that the iterator is working.

I am concerned with the `onNext` function, because I'm not sure if updating the progress for every row will have an impact on performance. I'm working on testing this, but so far `gitbase-regression` has been giving me unreliable times.

If we removed `onNext` we could still benefit from having the name of the active partitions, maybe with a `(?/?)` progress.

Another generic improvement would be to have a way to get the total number of rows for a table. Maybe implementing a new interface. I didn't explore this possibility because as far as I know in gitbase we won't be able to use this. But it may be an interesting generic addition later for go-mysql-server itself.