### PR TITLE
Add VIEWs support

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -120,7 +120,7 @@ func (e *Engine) Query(
 	case *plan.CreateIndex:
 		typ = sql.CreateIndexProcess
 		perm = auth.ReadPerm | auth.WritePerm
-	case *plan.InsertInto, *plan.DeleteFrom, *plan.Update, *plan.DropIndex, *plan.UnlockTables, *plan.LockTables:
+	case *plan.InsertInto, *plan.DeleteFrom, *plan.Update, *plan.DropIndex, *plan.UnlockTables, *plan.LockTables, *plan.CreateView:
 		perm = auth.ReadPerm | auth.WritePerm
 	}
 

--- a/sql/analyzer/assign_catalog.go
+++ b/sql/analyzer/assign_catalog.go
@@ -60,6 +60,10 @@ func assignCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 			nc := *node
 			nc.Catalog = a.Catalog
 			return &nc, nil
+		case *plan.CreateView:
+			nc := *node
+			nc.Catalog = a.Catalog
+			return &nc, nil
 		default:
 			return n, nil
 		}

--- a/sql/analyzer/assign_catalog_test.go
+++ b/sql/analyzer/assign_catalog_test.go
@@ -73,4 +73,12 @@ func TestAssignCatalog(t *testing.T) {
 	ut, ok := node.(*plan.UnlockTables)
 	require.True(ok)
 	require.Equal(c, ut.Catalog)
+
+	mockSubquery := plan.NewSubqueryAlias("mock", plan.NewResolvedTable(tbl))
+	mockView := plan.NewCreateView(db, "", nil, mockSubquery, false)
+	node, err = f.Apply(sql.NewEmptyContext(), a, mockView)
+	require.NoError(err)
+	cv, ok := node.(*plan.CreateView)
+	require.True(ok)
+	require.Equal(c, cv.Catalog)
 }

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -55,7 +55,7 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 
 			if view, err := a.Catalog.ViewRegistry.View(db, name); err == nil {
 				a.Log("table %q is a view: replacing plans", t.Name())
-				return view.Definition, nil
+				return view.Definition(), nil
 			}
 		}
 

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -39,17 +39,26 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 		}
 
 		rt, err := a.Catalog.Table(db, name)
-		if err != nil {
-			if sql.ErrTableNotFound.Is(err) && name == dualTableName {
+		if err == nil {
+			a.Log("table resolved: %q", t.Name())
+			return plan.NewResolvedTable(rt), nil
+		}
+
+		if sql.ErrTableNotFound.Is(err) {
+			if name == dualTableName {
 				rt = dualTable
 				name = dualTableName
-			} else {
-				return nil, err
+
+				a.Log("table resolved: %q", t.Name())
+				return plan.NewResolvedTable(rt), nil
+			}
+
+			if view, err := a.Catalog.ViewRegistry.View(db, name); err == nil {
+				a.Log("table %q is a view: replacing plans", t.Name())
+				return view.Definition, nil
 			}
 		}
 
-		a.Log("table resolved: %q", t.Name())
-
-		return plan.NewResolvedTable(rt), nil
+		return nil, err
 	})
 }

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -92,9 +92,6 @@ func TestResolveTablesNested(t *testing.T) {
 	require.Equal(expected, analyzed)
 }
 
-// Tests the resolution of views (ensuring it is case-insensitive), that should
-// result in the replacement of the UnresolvedTable with the SubqueryAlias that
-// represents the view
 func TestResolveViews(t *testing.T) {
 	require := require.New(t)
 

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -118,7 +118,8 @@ func TestResolveViews(t *testing.T) {
 	// Register the view in the catalog
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(db)
-	catalog.ViewRegistry.Register(db.Name(), view)
+	err := catalog.ViewRegistry.Register(db.Name(), view)
+	require.NoError(err)
 
 	a := NewBuilder(catalog).AddPostAnalyzeRule(f.Name, f.Apply).Build()
 

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -115,7 +115,6 @@ func TestResolveViews(t *testing.T) {
 	subqueryAlias := plan.NewSubqueryAlias("myview", subquery)
 	view := sql.NewView("myview", subqueryAlias)
 
-	// Register the view in the catalog
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(db)
 	err := catalog.ViewRegistry.Register(db.Name(), view)
@@ -123,19 +122,16 @@ func TestResolveViews(t *testing.T) {
 
 	a := NewBuilder(catalog).AddPostAnalyzeRule(f.Name, f.Apply).Build()
 
-	// Check whether the view is resolved and replaced with the subquery
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("myview", "")
 	analyzed, err := f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.NoError(err)
 	require.Equal(subqueryAlias, analyzed)
 
-	// Ensures that the resolution is case-insensitive
 	notAnalyzed = plan.NewUnresolvedTable("MyVieW", "")
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.NoError(err)
 	require.Equal(subqueryAlias, analyzed)
 
-	// Ensures that the resolution is idempotent
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, subqueryAlias)
 	require.NoError(err)
 	require.Equal(subqueryAlias, analyzed)

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -110,7 +110,7 @@ func TestResolveViews(t *testing.T) {
 		plan.NewResolvedTable(table),
 	)
 	subqueryAlias := plan.NewSubqueryAlias("myview", subquery)
-	view := sql.View{"myview", subqueryAlias}
+	view := sql.NewView("myview", subqueryAlias)
 
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(db)

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -91,3 +91,44 @@ func TestResolveTablesNested(t *testing.T) {
 	)
 	require.Equal(expected, analyzed)
 }
+
+func TestResolveViews(t *testing.T) {
+	require := require.New(t)
+
+	f := getRule("resolve_tables")
+
+	table := memory.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})
+	db := memory.NewDatabase("mydb")
+	db.AddTable("mytable", table)
+
+	// Resolved plan that corresponds to query "SELECT i FROM mytable"
+	subquery := plan.NewProject(
+		[]sql.Expression{
+			expression.NewGetFieldWithTable(
+				1, sql.Int32, table.Name(), "i", true),
+		},
+		plan.NewResolvedTable(table),
+	)
+	subqueryAlias := plan.NewSubqueryAlias("myview", subquery)
+	view := sql.View{"myview", subqueryAlias}
+
+	catalog := sql.NewCatalog()
+	catalog.AddDatabase(db)
+	catalog.ViewRegistry.Register(db.Name(), view)
+
+	a := NewBuilder(catalog).AddPostAnalyzeRule(f.Name, f.Apply).Build()
+
+	var notAnalyzed sql.Node = plan.NewUnresolvedTable("myview", "")
+	analyzed, err := f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
+	require.NoError(err)
+	require.Equal(subqueryAlias, analyzed)
+
+	notAnalyzed = plan.NewUnresolvedTable("MyVieW", "")
+	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
+	require.NoError(err)
+	require.Equal(subqueryAlias, analyzed)
+
+	analyzed, err = f.Apply(sql.NewEmptyContext(), a, subqueryAlias)
+	require.NoError(err)
+	require.Equal(subqueryAlias, analyzed)
+}

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -17,6 +17,7 @@ var ErrDatabaseNotFound = errors.NewKind("database not found: %s")
 type Catalog struct {
 	FunctionRegistry
 	*IndexRegistry
+	*ViewRegistry
 	*ProcessList
 	*MemoryManager
 
@@ -37,6 +38,7 @@ func NewCatalog() *Catalog {
 	return &Catalog{
 		FunctionRegistry: NewFunctionRegistry(),
 		IndexRegistry:    NewIndexRegistry(),
+		ViewRegistry:     NewViewRegistry(),
 		MemoryManager:    NewMemoryManager(ProcessMemory),
 		ProcessList:      NewProcessList(),
 		locks:            make(sessionLocks),

--- a/sql/index.go
+++ b/sql/index.go
@@ -512,7 +512,7 @@ func exprListsEqual(a, b []string) bool {
 // marked as creating, so nobody can't register two indexes with the same
 // expression or id while the other is still being created.
 // When something is sent through the returned channel, it means the index has
-// finished it's creation and will be marked as ready.
+// finished its creation and will be marked as ready.
 // Another channel is returned to notify the user when the index is ready.
 func (r *IndexRegistry) AddIndex(
 	idx Index,

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -36,7 +36,7 @@ var (
 var (
 	describeTablesRegex  = regexp.MustCompile(`^(describe|desc)\s+table\s+(.*)`)
 	createIndexRegex     = regexp.MustCompile(`^create\s+index\s+`)
-	createViewRegex     = regexp.MustCompile(`^create\s+(or\s+replace\s+)?view\s+`)
+	createViewRegex      = regexp.MustCompile(`^create\s+(or\s+replace\s+)?view\s+`)
 	dropIndexRegex       = regexp.MustCompile(`^drop\s+index\s+`)
 	showIndexRegex       = regexp.MustCompile(`^show\s+(index|indexes|keys)\s+(from|in)\s+\S+\s*`)
 	showCreateRegex      = regexp.MustCompile(`^show create\s+\S+\s*`)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -36,6 +36,7 @@ var (
 var (
 	describeTablesRegex  = regexp.MustCompile(`^(describe|desc)\s+table\s+(.*)`)
 	createIndexRegex     = regexp.MustCompile(`^create\s+index\s+`)
+	createViewRegex     = regexp.MustCompile(`^create\s+(or\s+replace\s+)?view\s+`)
 	dropIndexRegex       = regexp.MustCompile(`^drop\s+index\s+`)
 	showIndexRegex       = regexp.MustCompile(`^show\s+(index|indexes|keys)\s+(from|in)\s+\S+\s*`)
 	showCreateRegex      = regexp.MustCompile(`^show create\s+\S+\s*`)
@@ -47,7 +48,6 @@ var (
 	unlockTablesRegex    = regexp.MustCompile(`^unlock\s+tables$`)
 	lockTablesRegex      = regexp.MustCompile(`^lock\s+tables\s`)
 	setRegex             = regexp.MustCompile(`^set\s+`)
-	createViewRegex      = regexp.MustCompile(`^create\s+view\s+`)
 )
 
 // These constants aren't exported from vitess for some reason. This could be removed if we changed this.
@@ -82,6 +82,8 @@ func Parse(ctx *sql.Context, query string) (sql.Node, error) {
 		return parseDescribeTables(lowerQuery)
 	case createIndexRegex.MatchString(lowerQuery):
 		return parseCreateIndex(ctx, s)
+	case createViewRegex.MatchString(lowerQuery):
+		return parseCreateView(ctx, s)
 	case dropIndexRegex.MatchString(lowerQuery):
 		return parseDropIndex(s)
 	case showIndexRegex.MatchString(lowerQuery):
@@ -104,9 +106,6 @@ func Parse(ctx *sql.Context, query string) (sql.Node, error) {
 		return parseLockTables(ctx, s)
 	case setRegex.MatchString(lowerQuery):
 		s = fixSetQuery(s)
-	case createViewRegex.MatchString(lowerQuery):
-		// CREATE VIEW parses as a CREATE DDL statement with an empty table spec
-		return nil, ErrUnsupportedFeature.New("CREATE VIEW")
 	}
 
 	stmt, err := sqlparser.Parse(s)

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1,8 +1,8 @@
 package parse
 
 import (
-	"testing"
 	"math"
+	"testing"
 
 	"github.com/src-d/go-mysql-server/sql/expression"
 	"github.com/src-d/go-mysql-server/sql/expression/function/aggregation"
@@ -55,14 +55,14 @@ var fixtures = map[string]sql.Node{
 		sql.UnresolvedDatabase(""),
 		"t1",
 		sql.Schema{{
-			Name:     "a",
-			Type:     sql.Int32,
-			Nullable: false,
+			Name:       "a",
+			Type:       sql.Int32,
+			Nullable:   false,
 			PrimaryKey: true,
 		}, {
-			Name:     "b",
-			Type:     sql.Text,
-			Nullable: true,
+			Name:       "b",
+			Type:       sql.Text,
+			Nullable:   true,
 			PrimaryKey: false,
 		}},
 	),
@@ -70,14 +70,14 @@ var fixtures = map[string]sql.Node{
 		sql.UnresolvedDatabase(""),
 		"t1",
 		sql.Schema{{
-			Name:     "a",
-			Type:     sql.Int32,
-			Nullable: true,
+			Name:       "a",
+			Type:       sql.Int32,
+			Nullable:   true,
 			PrimaryKey: true,
 		}, {
-			Name:     "b",
-			Type:     sql.Text,
-			Nullable: true,
+			Name:       "b",
+			Type:       sql.Text,
+			Nullable:   true,
 			PrimaryKey: false,
 		}},
 	),
@@ -85,14 +85,14 @@ var fixtures = map[string]sql.Node{
 		sql.UnresolvedDatabase(""),
 		"t1",
 		sql.Schema{{
-			Name:     "a",
-			Type:     sql.Int32,
-			Nullable: true,
+			Name:       "a",
+			Type:       sql.Int32,
+			Nullable:   true,
 			PrimaryKey: true,
 		}, {
-			Name:     "b",
-			Type:     sql.Text,
-			Nullable: true,
+			Name:       "b",
+			Type:       sql.Text,
+			Nullable:   true,
 			PrimaryKey: true,
 		}},
 	),
@@ -1263,42 +1263,6 @@ var fixtures = map[string]sql.Node{
 		},
 		plan.NewUnresolvedTable("dual", ""),
 	),
-	`CREATE VIEW myview AS SELECT 1`: plan.NewCreateView(
-		sql.UnresolvedDatabase(""),
-		"myview",
-		nil,
-		plan.NewSubqueryAlias("myview",
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
-				plan.NewUnresolvedTable("dual", ""),
-			),
-		),
-		false,
-	),
-	`CREATE VIEW mydb.myview AS SELECT 1`: plan.NewCreateView(
-		sql.UnresolvedDatabase("mydb"),
-		"myview",
-		nil,
-		plan.NewSubqueryAlias("myview",
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
-				plan.NewUnresolvedTable("dual", ""),
-			),
-		),
-		false,
-	),
-	`CREATE OR REPLACE VIEW mydb.myview AS SELECT 1`: plan.NewCreateView(
-		sql.UnresolvedDatabase("mydb"),
-		"myview",
-		nil,
-		plan.NewSubqueryAlias(	"myview",
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
-				plan.NewUnresolvedTable("dual", ""),
-			),
-		),
-		true,
-	),
 }
 
 func TestParse(t *testing.T) {
@@ -1332,7 +1296,7 @@ var fixturesErrors = map[string]*errors.Kind{
 	`SELECT INTERVAL 1 DAY + INTERVAL 1 DAY`:                  ErrUnsupportedSyntax,
 	`SELECT '2018-05-01' + (INTERVAL 1 DAY + INTERVAL 1 DAY)`: ErrUnsupportedSyntax,
 	`SELECT AVG(DISTINCT foo) FROM b`:                         ErrUnsupportedSyntax,
-	`CREATE VIEW myview (col1) AS SELECT 1`:                         ErrUnsupportedSyntax,
+	`CREATE VIEW myview (col1) AS SELECT 1`:                   ErrUnsupportedSyntax,
 }
 
 func TestParseErrors(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1296,7 +1296,6 @@ var fixturesErrors = map[string]*errors.Kind{
 	`SELECT INTERVAL 1 DAY + INTERVAL 1 DAY`:                  ErrUnsupportedSyntax,
 	`SELECT '2018-05-01' + (INTERVAL 1 DAY + INTERVAL 1 DAY)`: ErrUnsupportedSyntax,
 	`SELECT AVG(DISTINCT foo) FROM b`:                         ErrUnsupportedSyntax,
-	`CREATE VIEW view1 AS SELECT x FROM t1 WHERE x>0`:         ErrUnsupportedFeature,
 }
 
 func TestParseErrors(t *testing.T) {

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -262,14 +262,14 @@ func readIdent(ident *string) parseFunc {
 	}
 }
 
-// Reads a scoped identifier, populating the specified slice with the different
-// parts of the identifier if it is correctly formed.
+// readIdentList reads a scoped identifier, populating the specified slice
+// with the different parts of the identifier if it is correctly formed.
 // A scoped identifier is a sequence of identifiers separated by the specified
 // rune in separator. An identifier is a string of runes whose first character
 // is a letter and the following ones are either letters, digits or underscores.
 // An example of a correctly formed scoped identifier is "dbName.tableName",
 // that would populate the slice with the values ["dbName", "tableName"]
-func readScopedIdent(separator rune, idents *[]string) parseFunc {
+func readIdentList(separator rune, idents *[]string) parseFunc {
 	return func(r *bufio.Reader) error {
 		var buf bytes.Buffer
 		if err := readLetter(r, &buf); err != nil {

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -64,20 +64,8 @@ func expect(expected string) parseFunc {
 }
 
 func skipSpaces(r *bufio.Reader) error {
-	for {
-		ru, _, err := r.ReadRune()
-		if err == io.EOF {
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		if !unicode.IsSpace(ru) {
-			return r.UnreadRune()
-		}
-	}
+	var unusedCount int
+	return readSpaces(r, &unusedCount)
 }
 
 // readSpaces reads every contiguous space from the reader, populating

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -483,8 +483,7 @@ func maybeList(opening, separator, closing rune, list *[]string) parseFunc {
 		}
 
 		if r != opening {
-			rd.UnreadRune()
-			return nil
+			return rd.UnreadRune()
 		}
 
 		for {

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -127,6 +127,8 @@ func readLetter(r *bufio.Reader, buf *bytes.Buffer) error {
 	return nil
 }
 
+// Parses a single rune from the reader and consumes it, copying it to the
+// buffer, if it is either a letter or a point
 func readLetterOrPoint(r *bufio.Reader, buf *bytes.Buffer) error {
 	ru, _, err := r.ReadRune()
 	if err != nil {
@@ -165,6 +167,8 @@ func readValidIdentRune(r *bufio.Reader, buf *bytes.Buffer) error {
 	return nil
 }
 
+// Parses a single rune from the reader and consumes it, copying it to the
+// buffer, if is a letter, a digit, an underscore or the specified separator.
 func readValidScopedIdentRune(r *bufio.Reader, separator rune, buf *bytes.Buffer) error {
 	ru, _, err := r.ReadRune()
 	if err != nil {
@@ -237,6 +241,14 @@ func readIdent(ident *string) parseFunc {
 	}
 }
 
+
+// Reads a scoped identifier, populating the specified slice with the different
+// parts of the identifier if it is correctly formed.
+// A scoped identifier is a sequence of identifiers separated by the specified
+// rune in separator. An identifier is a string of runes whose first character
+// is a letter and the following ones are either letters, digits or underscores.
+// An example of a correctly formed scoped identifier is "dbName.tableName",
+// that would populate the slice with the values ["dbName", "tableName"]
 func readScopedIdent(separator rune, idents *[]string) parseFunc {
 	return func(r *bufio.Reader) error {
 		var buf bytes.Buffer
@@ -370,6 +382,8 @@ func expectQuote(r *bufio.Reader) error {
 	return nil
 }
 
+// Tries to read the specified string, consuming the reader if the string is
+// found. The `matched` boolean is set to true if the string is found
 func maybe(matched *bool, str string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		*matched = false
@@ -400,6 +414,9 @@ func maybe(matched *bool, str string) parseFunc {
 	}
 }
 
+// Tries to read the specified strings, one after the other, separeted by an
+// arbitrary number of spaces. It consumes the reader if and only all the
+// strings are found.
 func multiMaybe(matched *bool, strings ...string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		*matched = false
@@ -429,11 +446,11 @@ func multiMaybe(matched *bool, strings ...string) parseFunc {
 	}
 }
 
-// Read a list of strings separated by the specified separator, with a rune
+// Reads a list of strings separated by the specified separator, with a rune
 // indicating the opening of the list and another one specifying its closing.
 // For example, readList('(', ',', ')', list) parses "(uno,  dos,tres)" and
 // populates list with the array of strings ["uno", "dos", "tres"]
-// If the opening is not found, do not advance the reader
+// If the opening is not found, this does not consumes any rune from the reader.
 func maybeList(opening, separator, closing rune, list *[]string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		r, _, err := rd.ReadRune()

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -80,8 +80,8 @@ func skipSpaces(r *bufio.Reader) error {
 	}
 }
 
-// Reads every contiguous space from the reader, populating numSpacesRead with
-// the number of spaces read.
+// readSpaces reads every contiguous space from the reader, populating
+// numSpacesRead with the number of spaces read.
 func readSpaces(r *bufio.Reader, numSpacesRead *int) error {
 	*numSpacesRead = 0
 	for {
@@ -148,8 +148,8 @@ func readLetter(r *bufio.Reader, buf *bytes.Buffer) error {
 	return nil
 }
 
-// Parses a single rune from the reader and consumes it, copying it to the
-// buffer, if it is either a letter or a point
+// readLetterOrPoint parses a single rune from the reader and consumes it,
+// copying it to the buffer, if it is either a letter or a point
 func readLetterOrPoint(r *bufio.Reader, buf *bytes.Buffer) error {
 	ru, _, err := r.ReadRune()
 	if err != nil {
@@ -188,8 +188,9 @@ func readValidIdentRune(r *bufio.Reader, buf *bytes.Buffer) error {
 	return nil
 }
 
-// Parses a single rune from the reader and consumes it, copying it to the
-// buffer, if is a letter, a digit, an underscore or the specified separator.
+// readValidScopedIdentRune parses a single rune from the reader and consumes
+// it, copying it to the buffer, if is a letter, a digit, an underscore or the
+// specified separator.
 func readValidScopedIdentRune(r *bufio.Reader, separator rune, buf *bytes.Buffer) error {
 	ru, _, err := r.ReadRune()
 	if err != nil {
@@ -404,8 +405,8 @@ func expectQuote(r *bufio.Reader) error {
 	return nil
 }
 
-// Tries to read the specified string, consuming the reader if the string is
-// found. The `matched` boolean is set to true if the string is found
+// maybe tries to read the specified string, consuming the reader if the string
+// is found. The `matched` boolean is set to true if the string is found
 func maybe(matched *bool, str string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		*matched = false
@@ -436,9 +437,9 @@ func maybe(matched *bool, str string) parseFunc {
 	}
 }
 
-// Tries to read the specified strings, one after the other, separated by an
-// arbitrary number of spaces. It consumes the reader if and only if all the
-// strings are found.
+// multiMaybe tries to read the specified strings, one after the other,
+// separated by an arbitrary number of spaces. It consumes the reader if and
+// only if all the strings are found.
 func multiMaybe(matched *bool, strings ...string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		*matched = false
@@ -468,8 +469,9 @@ func multiMaybe(matched *bool, strings ...string) parseFunc {
 	}
 }
 
-// Reads a list of strings separated by the specified separator, with a rune
-// indicating the opening of the list and another one specifying its closing.
+// maybeList reads a list of strings separated by the specified separator, with
+// a rune indicating the opening of the list and another one specifying its
+// closing.
 // For example, readList('(', ',', ')', list) parses "(uno,  dos,tres)" and
 // populates list with the array of strings ["uno", "dos", "tres"]
 // If the opening is not found, this does not consumes any rune from the

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -310,7 +310,7 @@ func expectQuote(r *bufio.Reader) error {
 }
 
 func maybe(matched *bool, str string) parseFunc {
-	return func (rd *bufio.Reader) error {
+	return func(rd *bufio.Reader) error {
 		*matched = false
 		strLength := len(str)
 
@@ -340,7 +340,7 @@ func maybe(matched *bool, str string) parseFunc {
 }
 
 func multiMaybe(matched *bool, strings ...string) parseFunc {
-	return func (rd *bufio.Reader) error {
+	return func(rd *bufio.Reader) error {
 		*matched = false
 		first := true
 		for _, str := range strings {

--- a/sql/parse/util.go
+++ b/sql/parse/util.go
@@ -373,7 +373,7 @@ func multiMaybe(matched *bool, strings ...string) parseFunc {
 // For example, readList('(', ',', ')', list) parses "(uno,  dos,tres)" and
 // populates list with the array of strings ["uno", "dos", "tres"]
 // If the opening is not found, do not advance the reader
-func maybeList(opening, separator, closing rune, list []string) parseFunc {
+func maybeList(opening, separator, closing rune, list *[]string) parseFunc {
 	return func(rd *bufio.Reader) error {
 		r, _, err := rd.ReadRune()
 		if err != nil {
@@ -404,10 +404,10 @@ func maybeList(opening, separator, closing rune, list []string) parseFunc {
 
 			switch r {
 			case closing:
-				list = append(list, newItem)
+				*list = append(*list, newItem)
 				return nil
 			case separator:
-				list = append(list, newItem)
+				*list = append(*list, newItem)
 				continue
 			default:
 				return errUnexpectedSyntax.New(

--- a/sql/parse/util_test.go
+++ b/sql/parse/util_test.go
@@ -2,42 +2,57 @@ package parse
 
 import (
 	"bufio"
+	"bytes"
 	"strings"
 	"testing"
-	"bytes"
 
 	"github.com/stretchr/testify/require"
 )
 
+// Tests that readLetterOrPoint reads only letters and points, not consuming
+// the reader when the rune is not of those kinds
 func TestReadLetterOrPoint(t *testing.T) {
+	require := require.New(t)
+
 	testFixtures := []struct {
-		string  string
-		expectedBuffer string
+		string            string
+		expectedBuffer    string
 		expectedRemaining string
 	}{
-		{ "asd.ASD.ñu",
+		{
+			"asd.ASD.ñu",
 			"asd.ASD.ñu",
 			"",
 		},
-		{ "5anytext",
+		{
+			"5anytext",
 			"",
 			"5anytext",
 		},
-		{ "",
+		{
+			"",
 			"",
 			"",
 		},
-		{ "as df",
+		{
+			"as df",
 			"as",
 			" df",
 		},
-		{ "a.s df",
+		{
+			"a.s df",
 			"a.s",
 			" df",
 		},
-		{ "a.s-",
+		{
+			"a.s-",
 			"a.s",
 			"-",
+		},
+		{
+			"a.s_",
+			"a.s",
+			"_",
 		},
 	}
 
@@ -50,23 +65,384 @@ func TestReadLetterOrPoint(t *testing.T) {
 		}
 
 		remaining, _ := reader.ReadString('\n')
-		require.Equal(t, remaining, fixture.expectedRemaining)
+		require.Equal(remaining, fixture.expectedRemaining)
 
-		require.Equal(t, buffer.String(), fixture.expectedBuffer)
+		require.Equal(buffer.String(), fixture.expectedBuffer)
 	}
 }
 
+// Tests that readValidScopedIdentRune reads a single rune that is either part
+// of an identifier or the specified separator. It checks that the function
+// does not consume the reader when it encounters any other rune
 func TestReadValidScopedIdentRune(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		string            string
+		separator         rune
+		expectedBuffer    string
+		expectedRemaining string
+	}{
+		{
+			"ident_1.ident_2",
+			'.',
+			"ident_1.ident_2",
+			"",
+		},
+		{
+			"$ident_1.ident_2",
+			'.',
+			"",
+			"$ident_1.ident_2",
+		},
+		{
+			"",
+			'.',
+			"",
+			"",
+		},
+		{
+			"ident_1 ident_2",
+			'.',
+			"ident_1",
+			" ident_2",
+		},
+		{
+			"ident_1 ident_2",
+			' ',
+			"ident_1 ident_2",
+			"",
+		},
+		{
+			"ident_1.ident_2 ident_3",
+			'.',
+			"ident_1.ident_2",
+			" ident_3",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.string))
+		var buffer bytes.Buffer
+
+		for i := 0; i < len(fixture.string); i++ {
+			readValidScopedIdentRune(reader, fixture.separator, &buffer)
+		}
+
+		remaining, _ := reader.ReadString('\n')
+		require.Equal(remaining, fixture.expectedRemaining)
+
+		require.Equal(buffer.String(), fixture.expectedBuffer)
+	}
 }
 
+// Tests that readScopedIdent reads a list of identifiers separated by a user-
+// specified rune, populating the passed slice with the identifiers found.
 func TestReadScopedIdent(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		string            string
+		separator         rune
+		expectedIdents    []string
+		expectedRemaining string
+	}{
+		{
+			"ident_1.ident_2",
+			'.',
+			[]string{"ident_1", "ident_2"},
+			"",
+		},
+		{
+			"$ident_1.ident_2",
+			'.',
+			nil,
+			"$ident_1.ident_2",
+		},
+		{
+			"",
+			'.',
+			nil,
+			"",
+		},
+		{
+			"ident_1 ident_2",
+			'.',
+			[]string{"ident_1"},
+			" ident_2",
+		},
+		{
+			"ident_1 ident_2",
+			' ',
+			[]string{"ident_1", "ident_2"},
+			"",
+		},
+		{
+			"ident_1.ident_2 ident_3",
+			'.',
+			[]string{"ident_1", "ident_2"},
+			" ident_3",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.string))
+		var actualIdents []string
+
+		err := readScopedIdent(fixture.separator, &actualIdents)(reader)
+		require.NoError(err)
+
+		remaining, _ := reader.ReadString('\n')
+		require.Equal(fixture.expectedRemaining, remaining)
+
+		require.Equal(fixture.expectedIdents, actualIdents)
+	}
 }
 
+// Tests that maybe reads, and consumes, the specified string, if and only if
+// it is there, reporting the result in the boolean passed.
 func TestMaybe(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		input             string
+		maybeString       string
+		expectedMatched   bool
+		expectedRemaining string
+	}{
+		{
+			"ident_1.ident_2",
+			"ident_1",
+			true,
+			".ident_2",
+		},
+		{
+			"ident_1.ident_2",
+			"random",
+			false,
+			"ident_1.ident_2",
+		},
+		{
+			"ident_1.ident_2",
+			"ident_1.ident_2",
+			true,
+			"",
+		},
+		{
+			"ident_1",
+			"ident_1butlonger",
+			false,
+			"ident_1",
+		},
+		{
+			"ident_1",
+			"",
+			true,
+			"ident_1",
+		},
+		{
+			"",
+			"",
+			true,
+			"",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.input))
+		var actualMatched bool
+
+		err := maybe(&actualMatched, fixture.maybeString)(reader)
+		require.NoError(err)
+
+		remaining, _ := reader.ReadString('\n')
+		require.Equal(fixture.expectedRemaining, remaining)
+
+		require.Equal(fixture.expectedMatched, actualMatched)
+	}
 }
 
+// Tests that multiMaybe reads, and consumes, the list of strings passed if all
+// of them are in the reader, reporting the result in the boolean passed.
 func TestMultiMaybe(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		input             string
+		maybeStrings      []string
+		expectedMatched   bool
+		expectedRemaining string
+	}{
+		{
+			"unodostres",
+			[]string{"uno", "dos", "tres"},
+			true,
+			"",
+		},
+		{
+			"uno dos tres",
+			[]string{"uno", "dos", "tres"},
+			true,
+			"",
+		},
+		{
+			"uno      dos tres",
+			[]string{"uno", "dos", "tres"},
+			true,
+			"",
+		},
+		{
+			"uno dos tres",
+			[]string{"random"},
+			false,
+			"uno dos tres",
+		},
+		{
+			"uno dos tres",
+			[]string{"uno", "random"},
+			false,
+			"uno dos tres",
+		},
+		{
+			"uno dos tres",
+			[]string{"uno", "dos", "tres", "cuatro"},
+			false,
+			"uno dos tres",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.input))
+		var actualMatched bool
+
+		err := multiMaybe(&actualMatched, fixture.maybeStrings...)(reader)
+		require.NoError(err)
+
+		remaining, _ := reader.ReadString('\n')
+		require.Equal(fixture.expectedRemaining, remaining)
+
+		require.Equal(fixture.expectedMatched, actualMatched)
+	}
 }
 
+// Tests that maybeList reads the specified list of strings separated by the
+// user-specified separator, not consuming the reader if the opening rune is
+// not found. It checks that the function populates the list with the found
+// strings even if there is an error in the middle of the parsing.
 func TestMaybeList(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		stringWithList string
+		openingRune    rune
+		separatorRune  rune
+		closingRune    rune
+		expectedList   []string
+		expectedError  bool
+	}{
+		{
+			"(uno, dos, tres)",
+			'(', ',', ')',
+			[]string{"uno", "dos", "tres"},
+			false,
+		},
+		{
+			"-uno&dos & tres-",
+			'-', '&', '-',
+			[]string{"uno", "dos", "tres"},
+			false,
+		},
+		{
+			"-(uno, dos, tres)",
+			'(', ',', ')',
+			nil,
+			false,
+		},
+		{
+			"(uno, dos,( tres)",
+			'(', ',', ')',
+			[]string{"uno", "dos"},
+			true,
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.stringWithList))
+		var actualList []string
+
+		err := maybeList(fixture.openingRune, fixture.separatorRune, fixture.closingRune, &actualList)(reader)
+
+		if fixture.expectedError {
+			require.Error(err)
+		} else {
+			require.NoError(err)
+		}
+
+		require.Equal(fixture.expectedList, actualList)
+	}
+}
+
+// Tests that readSpaces consumes all the spaces it ecounters in the reader,
+// reporting the number of spaces read to the user through the integer passed.
+func TestReadSpaces(t *testing.T) {
+	require := require.New(t)
+
+	testFixtures := []struct {
+		stringWithSpaces  string
+		runesBeforeSpaces int
+		expectedNumSpaces int
+		expectedRemaining string
+	}{
+		{
+			"one",
+			3, 0,
+			"",
+		},
+		{
+			"two",
+			0, 0,
+			"two",
+		},
+		{
+			"   three",
+			0, 3,
+			"three",
+		},
+		{
+			"four    four ",
+			4, 4,
+			"four ",
+		},
+		{
+			"five     ",
+			4, 5,
+			"",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.stringWithSpaces))
+		var actualNumSpaces int
+
+		// Check that readSpaces does not read spaces when there are none
+		if fixture.runesBeforeSpaces > 0 {
+			err := readSpaces(reader, &actualNumSpaces)
+			require.NoError(err)
+			require.Equal(0, actualNumSpaces)
+		}
+
+		// Read all the runes before the spaces
+		for i := 0; i < fixture.runesBeforeSpaces; i++ {
+			_, _, err := reader.ReadRune()
+			require.NoError(err)
+		}
+
+		// Read all the spaces
+		err := readSpaces(reader, &actualNumSpaces)
+		require.NoError(err)
+		require.Equal(fixture.expectedNumSpaces, actualNumSpaces)
+
+		actualRemaining, _ := reader.ReadString('\n')
+		require.Equal(fixture.expectedRemaining, actualRemaining)
+	}
 }

--- a/sql/parse/util_test.go
+++ b/sql/parse/util_test.go
@@ -150,9 +150,9 @@ func TestReadValidScopedIdentRune(t *testing.T) {
 	}
 }
 
-// Tests that readScopedIdent reads a list of identifiers separated by a user-
+// Tests that readIdentList reads a list of identifiers separated by a user-
 // specified rune, populating the passed slice with the identifiers found.
-func TestReadScopedIdent(t *testing.T) {
+func TestReadIdentList(t *testing.T) {
 	require := require.New(t)
 
 	testFixtures := []struct {
@@ -203,7 +203,7 @@ func TestReadScopedIdent(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader(fixture.string))
 		var actualIdents []string
 
-		err := readScopedIdent(fixture.separator, &actualIdents)(reader)
+		err := readIdentList(fixture.separator, &actualIdents)(reader)
 		require.NoError(err)
 
 		remaining, _ := reader.ReadString('\n')

--- a/sql/parse/util_test.go
+++ b/sql/parse/util_test.go
@@ -133,9 +133,14 @@ func TestReadValidScopedIdentRune(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader(fixture.string))
 		var buffer bytes.Buffer
 
+		var rune rune
 		var err error
 		for i := 0; i < len(fixture.string); i++ {
-			err = readValidScopedIdentRune(reader, fixture.separator, &buffer)
+			if rune, err = readValidScopedIdentRune(reader, fixture.separator); err != nil {
+				break
+			}
+
+			buffer.WriteRune(rune)
 		}
 		if fixture.expectedError {
 			require.Error(err)
@@ -146,7 +151,7 @@ func TestReadValidScopedIdentRune(t *testing.T) {
 		remaining, _ := reader.ReadString('\n')
 		require.Equal(remaining, fixture.expectedRemaining)
 
-		require.Equal(buffer.String(), fixture.expectedBuffer)
+		require.Equal(fixture.expectedBuffer, buffer.String())
 	}
 }
 

--- a/sql/parse/util_test.go
+++ b/sql/parse/util_test.go
@@ -61,7 +61,8 @@ func TestReadLetterOrPoint(t *testing.T) {
 		var buffer bytes.Buffer
 
 		for i := 0; i < len(fixture.string); i++ {
-			readLetterOrPoint(reader, &buffer)
+			err := readLetterOrPoint(reader, &buffer)
+			require.NoError(err)
 		}
 
 		remaining, _ := reader.ReadString('\n')
@@ -82,42 +83,49 @@ func TestReadValidScopedIdentRune(t *testing.T) {
 		separator         rune
 		expectedBuffer    string
 		expectedRemaining string
+		expectedError     bool
 	}{
 		{
 			"ident_1.ident_2",
 			'.',
 			"ident_1.ident_2",
 			"",
+			false,
 		},
 		{
 			"$ident_1.ident_2",
 			'.',
 			"",
 			"$ident_1.ident_2",
+			true,
 		},
 		{
 			"",
 			'.',
 			"",
 			"",
+			false,
 		},
 		{
 			"ident_1 ident_2",
 			'.',
 			"ident_1",
 			" ident_2",
+			true,
 		},
 		{
 			"ident_1 ident_2",
 			' ',
 			"ident_1 ident_2",
 			"",
+			false,
 		},
 		{
 			"ident_1.ident_2 ident_3",
 			'.',
 			"ident_1.ident_2",
 			" ident_3",
+			true,
 		},
 	}
 
@@ -125,8 +133,14 @@ func TestReadValidScopedIdentRune(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader(fixture.string))
 		var buffer bytes.Buffer
 
+		var err error
 		for i := 0; i < len(fixture.string); i++ {
-			readValidScopedIdentRune(reader, fixture.separator, &buffer)
+			err = readValidScopedIdentRune(reader, fixture.separator, &buffer)
+		}
+		if fixture.expectedError {
+			require.Error(err)
+		} else {
+			require.NoError(err)
 		}
 
 		remaining, _ := reader.ReadString('\n')

--- a/sql/parse/util_test.go
+++ b/sql/parse/util_test.go
@@ -1,0 +1,72 @@
+package parse
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+	"bytes"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadLetterOrPoint(t *testing.T) {
+	testFixtures := []struct {
+		string  string
+		expectedBuffer string
+		expectedRemaining string
+	}{
+		{ "asd.ASD.ñu",
+			"asd.ASD.ñu",
+			"",
+		},
+		{ "5anytext",
+			"",
+			"5anytext",
+		},
+		{ "",
+			"",
+			"",
+		},
+		{ "as df",
+			"as",
+			" df",
+		},
+		{ "a.s df",
+			"a.s",
+			" df",
+		},
+		{ "a.s-",
+			"a.s",
+			"-",
+		},
+	}
+
+	for _, fixture := range testFixtures {
+		reader := bufio.NewReader(strings.NewReader(fixture.string))
+		var buffer bytes.Buffer
+
+		for i := 0; i < len(fixture.string); i++ {
+			readLetterOrPoint(reader, &buffer)
+		}
+
+		remaining, _ := reader.ReadString('\n')
+		require.Equal(t, remaining, fixture.expectedRemaining)
+
+		require.Equal(t, buffer.String(), fixture.expectedBuffer)
+	}
+}
+
+func TestReadValidScopedIdentRune(t *testing.T) {
+}
+
+func TestReadScopedIdent(t *testing.T) {
+}
+
+func TestMaybe(t *testing.T) {
+}
+
+func TestMultiMaybe(t *testing.T) {
+}
+
+func TestMaybeList(t *testing.T) {
+}

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -35,7 +35,7 @@ func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 		skipSpaces,
 		readIdent(&viewName),
 		skipSpaces,
-		maybeList('(', ',', ')', columns),
+		maybeList('(', ',', ')', &columns),
 		skipSpaces,
 		expect("as"),
 		skipSpaces,

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -1,0 +1,71 @@
+package parse
+
+import (
+	"bufio"
+	"strings"
+	// "io"
+
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/plan"
+
+	"gopkg.in/src-d/go-errors.v1"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+var ErrMalformedCreateView = errors.NewKind("view definition %#v is not a SELECT query")
+
+// Parses
+// CREATE [OR REPLACE] VIEW view_name [(col1, col2, ...)] AS select_statement
+// and returns a NewCreateView node in case of success
+func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
+	r := bufio.NewReader(strings.NewReader(s))
+
+
+	var (
+		viewName, subquery string
+		columns []string
+		isReplace bool
+	)
+
+	err := parseFuncs{
+		expect("create"),
+		skipSpaces,
+		multiMaybe(&isReplace, "or", "replace"),
+		skipSpaces,
+		expect("view"),
+		skipSpaces,
+		readIdent(&viewName),
+		skipSpaces,
+		maybeList('(', ',', ')', columns),
+		skipSpaces,
+		expect("as"),
+		skipSpaces,
+		readRemaining(&subquery),
+		checkEOF,
+	}.exec(r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	subqueryStatement, err := sqlparser.Parse(subquery)
+	if err != nil {
+		return nil, err
+	}
+
+	selectStatement, ok := subqueryStatement.(*sqlparser.Select)
+	if !ok {
+		return nil, ErrMalformedCreateView.New(subqueryStatement)
+	}
+
+	subqueryNode, err := convertSelect(ctx, selectStatement)
+	if err != nil {
+		return nil, err
+	}
+
+	subqueryAlias := plan.NewSubqueryAlias(viewName, subqueryNode)
+
+	return plan.NewCreateView(
+		sql.UnresolvedDatabase(""), viewName, columns, subqueryAlias,
+	), nil
+}

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -20,11 +20,10 @@ var ErrMalformedCreateView = errors.NewKind("view definition %#v is not a SELECT
 func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 	r := bufio.NewReader(strings.NewReader(s))
 
-
 	var (
 		viewName, subquery string
-		columns []string
-		isReplace bool
+		columns            []string
+		isReplace          bool
 	)
 
 	err := parseFuncs{

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -3,7 +3,6 @@ package parse
 import (
 	"bufio"
 	"strings"
-	// "io"
 
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/plan"

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -14,7 +14,7 @@ import (
 var ErrMalformedViewName = errors.NewKind("the view name '%s' is not correct")
 var ErrMalformedCreateView = errors.NewKind("view definition %#v is not a SELECT query")
 
-// Parses
+// parseCreateView parses
 // CREATE [OR REPLACE] VIEW [db_name.]view_name AS select_statement
 // and returns a NewCreateView node in case of success
 func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -15,7 +15,7 @@ var ErrMalformedViewName = errors.NewKind("the view name '%s' is not correct")
 var ErrMalformedCreateView = errors.NewKind("view definition %#v is not a SELECT query")
 
 // Parses
-// CREATE [OR REPLACE] VIEW [db_name.]view_name [(col1, col2, ...)] AS select_statement
+// CREATE [OR REPLACE] VIEW [db_name.]view_name AS select_statement
 // and returns a NewCreateView node in case of success
 func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 	r := bufio.NewReader(strings.NewReader(s))

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -53,6 +53,11 @@ func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 		return nil, ErrMalformedViewName.New(strings.Join(scopedName, "."))
 	}
 
+	// TODO(agarciamontoro): Add support for explicit column names
+	if len(columns) != 0 {
+		return nil, ErrUnsupportedSyntax.New("the view creation must not specify explicit column names")
+	}
+
 	if len(scopedName) == 1 {
 		viewName = scopedName[0]
 	}
@@ -79,6 +84,6 @@ func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 	subqueryAlias := plan.NewSubqueryAlias(viewName, subqueryNode)
 
 	return plan.NewCreateView(
-		sql.UnresolvedDatabase(databaseName), viewName, columns, subqueryAlias,
+		sql.UnresolvedDatabase(databaseName), viewName, columns, subqueryAlias, isReplace,
 	), nil
 }

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -35,7 +35,7 @@ func parseCreateView(ctx *sql.Context, s string) (sql.Node, error) {
 		skipSpaces,
 		expect("view"),
 		skipSpaces,
-		readScopedIdent('.', &scopedName),
+		readIdentList('.', &scopedName),
 		skipSpaces,
 		maybeList('(', ',', ')', &columns),
 		skipSpaces,

--- a/sql/parse/views_test.go
+++ b/sql/parse/views_test.go
@@ -1,0 +1,77 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCreateView(t *testing.T) {
+	var fixtures = map[string]sql.Node{
+		`CREATE VIEW myview AS SELECT 1`: plan.NewCreateView(
+			sql.UnresolvedDatabase(""),
+			"myview",
+			nil,
+			plan.NewSubqueryAlias("myview",
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
+					plan.NewUnresolvedTable("dual", ""),
+				),
+			),
+			false,
+		),
+		`CREATE VIEW myview AS SELECT * FROM mytable`: plan.NewCreateView(
+			sql.UnresolvedDatabase(""),
+			"myview",
+			nil,
+			plan.NewSubqueryAlias("myview",
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("mytable", ""),
+				),
+			),
+			false,
+		),
+		`CREATE VIEW mydb.myview AS SELECT 1`: plan.NewCreateView(
+			sql.UnresolvedDatabase("mydb"),
+			"myview",
+			nil,
+			plan.NewSubqueryAlias("myview",
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
+					plan.NewUnresolvedTable("dual", ""),
+				),
+			),
+			false,
+		),
+		`CREATE OR REPLACE VIEW mydb.myview AS SELECT 1`: plan.NewCreateView(
+			sql.UnresolvedDatabase("mydb"),
+			"myview",
+			nil,
+			plan.NewSubqueryAlias("myview",
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(1), sql.Int8)},
+					plan.NewUnresolvedTable("dual", ""),
+				),
+			),
+			true,
+		),
+	}
+
+	for query, expectedPlan := range fixtures {
+		t.Run(query, func(t *testing.T) {
+			require := require.New(t)
+
+			ctx := sql.NewEmptyContext()
+			lowerquery := strings.ToLower(query)
+			result, err := parseCreateView(ctx, lowerquery)
+
+			require.NoError(err)
+			require.Equal(expectedPlan, result)
+		})
+	}
+}

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -9,10 +9,10 @@ import (
 
 type CreateView struct {
 	UnaryNode
-	database sql.Database
-	Name     string
-	Columns  []string
-	Catalog  *sql.Catalog
+	database  sql.Database
+	Name      string
+	Columns   []string
+	Catalog   *sql.Catalog
 	IsReplace bool
 }
 
@@ -33,7 +33,13 @@ func NewCreateView(
 	}
 }
 
-// Children implements the Node interface.
+// View returns the view that will be created by this node
+func (create *CreateView) View() sql.View {
+	return sql.NewView(create.Name, create.Child)
+}
+
+// Children implements the Node interface. It returns the Child of the
+// CreateView node; i.e., the definition of the view that will be created.
 func (create *CreateView) Children() []sql.Node {
 	return []sql.Node{create.Child}
 }
@@ -46,10 +52,10 @@ func (create *CreateView) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (create *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	view := sql.View{create.Name, create.Child}
+	view := sql.NewView(create.Name, create.Child)
 
 	if create.IsReplace {
-		_ = create.Catalog.ViewRegistry.Delete(create.database.Name(), view.Name)
+		_ = create.Catalog.ViewRegistry.Delete(create.database.Name(), view.Name())
 	}
 
 	return sql.RowsToRowIter(), create.Catalog.ViewRegistry.Register(create.database.Name(), view)

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -39,78 +39,78 @@ func NewCreateView(
 }
 
 // View returns the view that will be created by this node.
-func (create *CreateView) View() sql.View {
-	return sql.NewView(create.Name, create.Child)
+func (cv *CreateView) View() sql.View {
+	return sql.NewView(cv.Name, cv.Child)
 }
 
 // Children implements the Node interface. It returns the Child of the
 // CreateView node; i.e., the definition of the view that will be created.
-func (create *CreateView) Children() []sql.Node {
-	return []sql.Node{create.Child}
+func (cv *CreateView) Children() []sql.Node {
+	return []sql.Node{cv.Child}
 }
 
 // Resolved implements the Node interface. This node is resolved if and only if
 // the database and the Child are both resolved.
-func (create *CreateView) Resolved() bool {
-	_, ok := create.database.(sql.UnresolvedDatabase)
-	return !ok && create.Child.Resolved()
+func (cv *CreateView) Resolved() bool {
+	_, ok := cv.database.(sql.UnresolvedDatabase)
+	return !ok && cv.Child.Resolved()
 }
 
 // RowIter implements the Node interface. When executed, this function creates
 // (or replaces) the view. It can error if the CraeteView's IsReplace member is
 // set to false and the view already exists. The RowIter returned is always
 // empty.
-func (create *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	view := sql.NewView(create.Name, create.Child)
-	registry := create.Catalog.ViewRegistry
+func (cv *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	view := sql.NewView(cv.Name, cv.Child)
+	registry := cv.Catalog.ViewRegistry
 
-	if create.IsReplace {
-		err := registry.Delete(create.database.Name(), view.Name())
+	if cv.IsReplace {
+		err := registry.Delete(cv.database.Name(), view.Name())
 		if err != nil && !sql.ErrNonExistingView.Is(err) {
 			return sql.RowsToRowIter(), err
 		}
 	}
 
-	return sql.RowsToRowIter(), registry.Register(create.database.Name(), view)
+	return sql.RowsToRowIter(), registry.Register(cv.database.Name(), view)
 }
 
 // Schema implements the Node interface. It always returns nil.
-func (create *CreateView) Schema() sql.Schema { return nil }
+func (cv *CreateView) Schema() sql.Schema { return nil }
 
 // String implements the fmt.Stringer interface, using sql.TreePrinter to
 // generate the string.
-func (create *CreateView) String() string {
+func (cv *CreateView) String() string {
 	pr := sql.NewTreePrinter()
-	_ = pr.WriteNode("CreateView(%s)", create.Name)
+	_ = pr.WriteNode("CreateView(%s)", cv.Name)
 	_ = pr.WriteChildren(
-		fmt.Sprintf("Columns (%s)", strings.Join(create.Columns, ", ")),
-		create.Child.String(),
+		fmt.Sprintf("Columns (%s)", strings.Join(cv.Columns, ", ")),
+		cv.Child.String(),
 	)
 	return pr.String()
 }
 
 // WithChildren implements the Node interface. It only succeeds if the length
 // of the specified children equals 1.
-func (create *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
+func (cv *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
 	if len(children) != 1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(create, len(children), 1)
+		return nil, sql.ErrInvalidChildrenNumber.New(cv, len(children), 1)
 	}
 
-	newCreate := create
+	newCreate := cv
 	newCreate.Child = children[0]
 	return newCreate, nil
 }
 
 // Database implements the Databaser interface, and it returns the database in
 // which CreateView will create the view.
-func (create *CreateView) Database() sql.Database {
-	return create.database
+func (cv *CreateView) Database() sql.Database {
+	return cv.database
 }
 
 // Database implements the Databaser interface, and it returns a copy of this
 // node with the specified database.
-func (create *CreateView) WithDatabase(database sql.Database) (sql.Node, error) {
-	newCreate := *create
+func (cv *CreateView) WithDatabase(database sql.Database) (sql.Node, error) {
+	newCreate := *cv
 	newCreate.database = database
 	return &newCreate, nil
 }

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -3,178 +3,72 @@ package plan
 import (
 	"fmt"
 	"strings"
-	// "time"
 
-	// opentracing "github.com/opentracing/opentracing-go"
-	// otlog "github.com/opentracing/opentracing-go/log"
-	// "github.com/sirupsen/logrus"
 	"github.com/src-d/go-mysql-server/sql"
-	// "github.com/src-d/go-mysql-server/sql/expression"
-	// errors "gopkg.in/src-d/go-errors.v1"
 )
 
 type CreateView struct {
-    Database     sql.Database
-    Name   string
-    Columns []string
-    Definition *SubqueryAlias
+	UnaryNode
+	Database sql.Database
+	Name     string
+	Columns  []string
+	Catalog *sql.Catalog
 }
 
 func NewCreateView(
-	database     sql.Database,
-	name   string,
+	database sql.Database,
+	name string,
 	columns []string,
 	definition *SubqueryAlias,
 ) *CreateView {
 	return &CreateView{
-		Database: database,
-		Name: name,
-		Columns: columns,
-		Definition: definition,
+		UnaryNode{Child: definition},
+		database,
+		name,
+		columns,
+		nil,
 	}
 }
 
 // Children implements the Node interface.
-func (c *CreateView) Children() []sql.Node { return nil }
+func (create *CreateView) Children() []sql.Node {
+	return []sql.Node{create.Child}
+}
 
 // Resolved implements the Node interface.
-func (c *CreateView) Resolved() bool {
-	_, ok := c.Database.(sql.UnresolvedDatabase)
-	return !ok && c.Definition.Resolved()
+func (create *CreateView) Resolved() bool {
+	// TOOD: Check whether the database has been resolved
+	// _, ok := create.Database.(sql.UnresolvedDatabase)
+	return create.Child.Resolved()
 }
-//
-// func getIndexableTable(t sql.Table) (sql.IndexableTable, error) {
-// 	switch t := t.(type) {
-// 	case sql.IndexableTable:
-// 		return t, nil
-// 	case sql.TableWrapper:
-// 		return getIndexableTable(t.Underlying())
-// 	default:
-// 		return nil, ErrNotIndexable.New()
-// 	}
-// }
-//
-// func getChecksumable(t sql.Table) sql.Checksumable {
-// 	switch t := t.(type) {
-// 	case sql.Checksumable:
-// 		return t
-// 	case sql.TableWrapper:
-// 		return getChecksumable(t.Underlying())
-// 	default:
-// 		return nil
-// 	}
-// }
-//
-// RowIter implements the Node interface.
-func (c *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	// TODO: add it to the register
 
-	// table, ok := c.Table.(*ResolvedTable)
-	// if !ok {
-	// 	return nil, ErrNotIndexable.New()
-	// }
-	//
-	// indexable, err := getIndexableTable(table.Table)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// var driver sql.IndexDriver
-	// if c.Driver == "" {
-	// 	driver = c.Catalog.DefaultIndexDriver()
-	// } else {
-	// 	driver = c.Catalog.IndexDriver(c.Driver)
-	// }
-	//
-	// if driver == nil {
-	// 	return nil, ErrInvalidIndexDriver.New(c.Driver)
-	// }
-	//
-	// columns, exprs, err := getColumnsAndPrepareExpressions(c.Exprs)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// for _, e := range exprs {
-	// 	if e.Type() == sql.Blob || e.Type() == sql.JSON {
-	// 		return nil, ErrExprTypeNotIndexable.New(e, e.Type())
-	// 	}
-	// }
-	//
-	// if ch := getChecksumable(table.Table); ch != nil {
-	// 	c.Config[sql.ChecksumKey], err = ch.Checksum()
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// }
-	//
-	// index, err := driver.Create(
-	// 	c.CurrentDatabase,
-	// 	table.Name(),
-	// 	c.Name,
-	// 	exprs,
-	// 	c.Config,
-	// )
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// iter, err := indexable.IndexKeyValues(ctx, columns)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// iter = &evalPartitionKeyValueIter{
-	// 	ctx:     ctx,
-	// 	columns: columns,
-	// 	exprs:   exprs,
-	// 	iter:    iter,
-	// }
-	//
-	// created, ready, err := c.Catalog.AddIndex(index)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// log := logrus.WithFields(logrus.Fields{
-	// 	"id":     index.ID(),
-	// 	"driver": index.Driver(),
-	// })
-	//
-	// createIndex := func() {
-	// 	c.createIndex(ctx, log, driver, index, iter, created, ready)
-	// 	c.Catalog.ProcessList.Done(ctx.Pid())
-	// }
-	//
-	// log.WithField("async", c.Async).Info("starting to save the index")
-	//
-	// if c.Async {
-	// 	go createIndex()
-	// } else {
-	// 	createIndex()
-	// }
+// RowIter implements the Node interface.
+func (create *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: add it to the register
 
 	return sql.RowsToRowIter(), nil
 }
 
 // Schema implements the Node interface.
-func (c *CreateView) Schema() sql.Schema { return nil }
+func (create *CreateView) Schema() sql.Schema { return nil }
 
 func (create *CreateView) String() string {
 	pr := sql.NewTreePrinter()
 	_ = pr.WriteNode("CreateView(%s)", create.Name)
 	_ = pr.WriteChildren(
 		fmt.Sprintf("Columns (%s)", strings.Join(create.Columns, ", ")),
-		fmt.Sprintf("As (%s)", create.Definition.String()),
+		fmt.Sprintf("As (%s)", create.Child.String()),
 	)
 	return pr.String()
 }
 
 // WithChildren implements the Node interface.
-func (c *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
-	if len(children) != 0 {
-		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 0)
+func (create *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(create, len(children), 1)
 	}
 
-	return c, nil
+	newCreate := create
+	newCreate.Child = children[0]
+	return newCreate, nil
 }

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -1,0 +1,180 @@
+package plan
+
+import (
+	"fmt"
+	"strings"
+	// "time"
+
+	// opentracing "github.com/opentracing/opentracing-go"
+	// otlog "github.com/opentracing/opentracing-go/log"
+	// "github.com/sirupsen/logrus"
+	"github.com/src-d/go-mysql-server/sql"
+	// "github.com/src-d/go-mysql-server/sql/expression"
+	// errors "gopkg.in/src-d/go-errors.v1"
+)
+
+type CreateView struct {
+    Database     sql.Database
+    Name   string
+    Columns []string
+    Definition *SubqueryAlias
+}
+
+func NewCreateView(
+	database     sql.Database,
+	name   string,
+	columns []string,
+	definition *SubqueryAlias,
+) *CreateView {
+	return &CreateView{
+		Database: database,
+		Name: name,
+		Columns: columns,
+		Definition: definition,
+	}
+}
+
+// Children implements the Node interface.
+func (c *CreateView) Children() []sql.Node { return nil }
+
+// Resolved implements the Node interface.
+func (c *CreateView) Resolved() bool {
+	_, ok := c.Database.(sql.UnresolvedDatabase)
+	return !ok && c.Definition.Resolved()
+}
+//
+// func getIndexableTable(t sql.Table) (sql.IndexableTable, error) {
+// 	switch t := t.(type) {
+// 	case sql.IndexableTable:
+// 		return t, nil
+// 	case sql.TableWrapper:
+// 		return getIndexableTable(t.Underlying())
+// 	default:
+// 		return nil, ErrNotIndexable.New()
+// 	}
+// }
+//
+// func getChecksumable(t sql.Table) sql.Checksumable {
+// 	switch t := t.(type) {
+// 	case sql.Checksumable:
+// 		return t
+// 	case sql.TableWrapper:
+// 		return getChecksumable(t.Underlying())
+// 	default:
+// 		return nil
+// 	}
+// }
+//
+// RowIter implements the Node interface.
+func (c *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: add it to the register
+
+	// table, ok := c.Table.(*ResolvedTable)
+	// if !ok {
+	// 	return nil, ErrNotIndexable.New()
+	// }
+	//
+	// indexable, err := getIndexableTable(table.Table)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// var driver sql.IndexDriver
+	// if c.Driver == "" {
+	// 	driver = c.Catalog.DefaultIndexDriver()
+	// } else {
+	// 	driver = c.Catalog.IndexDriver(c.Driver)
+	// }
+	//
+	// if driver == nil {
+	// 	return nil, ErrInvalidIndexDriver.New(c.Driver)
+	// }
+	//
+	// columns, exprs, err := getColumnsAndPrepareExpressions(c.Exprs)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// for _, e := range exprs {
+	// 	if e.Type() == sql.Blob || e.Type() == sql.JSON {
+	// 		return nil, ErrExprTypeNotIndexable.New(e, e.Type())
+	// 	}
+	// }
+	//
+	// if ch := getChecksumable(table.Table); ch != nil {
+	// 	c.Config[sql.ChecksumKey], err = ch.Checksum()
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+	//
+	// index, err := driver.Create(
+	// 	c.CurrentDatabase,
+	// 	table.Name(),
+	// 	c.Name,
+	// 	exprs,
+	// 	c.Config,
+	// )
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// iter, err := indexable.IndexKeyValues(ctx, columns)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// iter = &evalPartitionKeyValueIter{
+	// 	ctx:     ctx,
+	// 	columns: columns,
+	// 	exprs:   exprs,
+	// 	iter:    iter,
+	// }
+	//
+	// created, ready, err := c.Catalog.AddIndex(index)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// log := logrus.WithFields(logrus.Fields{
+	// 	"id":     index.ID(),
+	// 	"driver": index.Driver(),
+	// })
+	//
+	// createIndex := func() {
+	// 	c.createIndex(ctx, log, driver, index, iter, created, ready)
+	// 	c.Catalog.ProcessList.Done(ctx.Pid())
+	// }
+	//
+	// log.WithField("async", c.Async).Info("starting to save the index")
+	//
+	// if c.Async {
+	// 	go createIndex()
+	// } else {
+	// 	createIndex()
+	// }
+
+	return sql.RowsToRowIter(), nil
+}
+
+// Schema implements the Node interface.
+func (c *CreateView) Schema() sql.Schema { return nil }
+
+func (create *CreateView) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("CreateView(%s)", create.Name)
+	_ = pr.WriteChildren(
+		fmt.Sprintf("Columns (%s)", strings.Join(create.Columns, ", ")),
+		fmt.Sprintf("As (%s)", create.Definition.String()),
+	)
+	return pr.String()
+}
+
+// WithChildren implements the Node interface.
+func (c *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 0)
+	}
+
+	return c, nil
+}

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -7,6 +7,9 @@ import (
 	"github.com/src-d/go-mysql-server/sql"
 )
 
+// CreateView is a node representing the creation (or replacement) of a view,
+// which is defined by the Child node. The Columns member represent the
+// explicit columns specified by the query, if any.
 type CreateView struct {
 	UnaryNode
 	database  sql.Database
@@ -16,6 +19,8 @@ type CreateView struct {
 	IsReplace bool
 }
 
+// NewCreateView creates a CreateView node with the specified parameters,
+// setting its catalog to nil.
 func NewCreateView(
 	database sql.Database,
 	name string,
@@ -33,7 +38,7 @@ func NewCreateView(
 	}
 }
 
-// View returns the view that will be created by this node
+// View returns the view that will be created by this node.
 func (create *CreateView) View() sql.View {
 	return sql.NewView(create.Name, create.Child)
 }
@@ -44,13 +49,17 @@ func (create *CreateView) Children() []sql.Node {
 	return []sql.Node{create.Child}
 }
 
-// Resolved implements the Node interface.
+// Resolved implements the Node interface. This node is resolved if and only if
+// the database and the Child are both resolved.
 func (create *CreateView) Resolved() bool {
 	_, ok := create.database.(sql.UnresolvedDatabase)
 	return !ok && create.Child.Resolved()
 }
 
-// RowIter implements the Node interface.
+// RowIter implements the Node interface. When executed, this function creates
+// (or replaces) the view. It can error if the CraeteView's IsReplace member is
+// set to false and the view already exists. The RowIter returned is always
+// empty.
 func (create *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	view := sql.NewView(create.Name, create.Child)
 
@@ -61,9 +70,11 @@ func (create *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.RowsToRowIter(), create.Catalog.ViewRegistry.Register(create.database.Name(), view)
 }
 
-// Schema implements the Node interface.
+// Schema implements the Node interface. It always returns nil.
 func (create *CreateView) Schema() sql.Schema { return nil }
 
+// String implements the fmt.Stringer interface, using sql.TreePrinter to
+// generate the string.
 func (create *CreateView) String() string {
 	pr := sql.NewTreePrinter()
 	_ = pr.WriteNode("CreateView(%s)", create.Name)
@@ -74,7 +85,8 @@ func (create *CreateView) String() string {
 	return pr.String()
 }
 
-// WithChildren implements the Node interface.
+// WithChildren implements the Node interface. It only succeeds if the length
+// of the specified children equals 1.
 func (create *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
 	if len(children) != 1 {
 		return nil, sql.ErrInvalidChildrenNumber.New(create, len(children), 1)
@@ -85,10 +97,14 @@ func (create *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
 	return newCreate, nil
 }
 
+// Database implements the Databaser interface, and it returns the database in
+// which CreateView will create the view.
 func (create *CreateView) Database() sql.Database {
 	return create.database
 }
 
+// Database implements the Databaser interface, and it returns a copy of this
+// node with the specified database.
 func (create *CreateView) WithDatabase(database sql.Database) (sql.Node, error) {
 	newCreate := *create
 	newCreate.database = database

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -12,7 +12,7 @@ type CreateView struct {
 	database sql.Database
 	Name     string
 	Columns  []string
-	Catalog *sql.Catalog
+	Catalog  *sql.Catalog
 }
 
 func NewCreateView(
@@ -70,4 +70,14 @@ func (create *CreateView) WithChildren(children ...sql.Node) (sql.Node, error) {
 	newCreate := create
 	newCreate.Child = children[0]
 	return newCreate, nil
+}
+
+func (create *CreateView) Database() sql.Database {
+	return create.database
+}
+
+func (create *CreateView) WithDatabase(database sql.Database) (sql.Node, error) {
+	newCreate := *create
+	newCreate.database = database
+	return &newCreate, nil
 }

--- a/sql/plan/create_view_test.go
+++ b/sql/plan/create_view_test.go
@@ -62,10 +62,11 @@ func TestCreateExistingView(t *testing.T) {
 
 	// Register a view with the same name
 	view := createView.View()
-	createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
+	err := createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
+	require.NoError(err)
 
 	ctx := sql.NewEmptyContext()
-	_, err := createView.RowIter(ctx)
+	_, err = createView.RowIter(ctx)
 	require.Error(err)
 	require.True(sql.ErrExistingView.Is(err))
 }
@@ -79,13 +80,14 @@ func TestReplaceExistingView(t *testing.T) {
 
 	// Register a view with the same name but no child
 	view := sql.NewView(createView.Name, nil)
-	createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
+	err := createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
+	require.NoError(err)
 
 	// Set the IsReplace flag to true
 	createView.IsReplace = true
 
 	ctx := sql.NewEmptyContext()
-	_, err := createView.RowIter(ctx)
+	_, err = createView.RowIter(ctx)
 	require.NoError(err)
 
 	expectedView := createView.View()

--- a/sql/plan/create_view_test.go
+++ b/sql/plan/create_view_test.go
@@ -60,7 +60,6 @@ func TestCreateExistingView(t *testing.T) {
 
 	createView := mockCreateView(false)
 
-	// Register a view with the same name
 	view := createView.View()
 	err := createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
 	require.NoError(err)
@@ -78,12 +77,10 @@ func TestReplaceExistingView(t *testing.T) {
 
 	createView := mockCreateView(true)
 
-	// Register a view with the same name but no child
 	view := sql.NewView(createView.Name, nil)
 	err := createView.Catalog.ViewRegistry.Register(createView.database.Name(), view)
 	require.NoError(err)
 
-	// Set the IsReplace flag to true
 	createView.IsReplace = true
 
 	ctx := sql.NewEmptyContext()

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -12,49 +12,54 @@ var (
 	ErrNonExistingView = errors.NewKind("the view %s.%s does not exist in the registry")
 )
 
-// A View is defined by a Node and has a name
+// A View is defined by a Node and has a name.
 type View struct {
 	name       string
 	definition Node
 }
 
-// Creates a View with the specified name and definition
+// Creates a View with the specified name and definition.
 func NewView(name string, definition Node) View {
 	return View{name, definition}
 }
 
-// Returns the name of the view
+// Returns the name of the view.
 func (view *View) Name() string {
 	return view.name
 }
 
-// Returns the definition of the view
+// Returns the definition of the view.
 func (view *View) Definition() Node {
 	return view.definition
 }
 
 // Views are scoped by the databases in which they were defined, so a key in
-// the view registry is a pair of names: database and view
+// the view registry is a pair of names: database and view.
 type viewKey struct {
 	dbName, viewName string
 }
 
-// Creates a viewKey ensuring both names are lowercase
+// Creates a viewKey ensuring both names are lowercase.
 func newViewKey(databaseName, viewName string) viewKey {
 	return viewKey{strings.ToLower(databaseName), strings.ToLower(viewName)}
 }
 
+// ViewRegistry is a map of viewKey to View whose access is protected by a
+// RWMutex.
 type ViewRegistry struct {
 	mutex sync.RWMutex
 	views map[viewKey]View
 }
 
+// Creates an empty ViewRegistry.
 func NewViewRegistry() *ViewRegistry {
 	return &ViewRegistry{
 		views: make(map[viewKey]View),
 	}
 }
 
+// Adds the view specified by the pair {database, view.Name()}, returning
+// an error if there is already an element with that key.
 func (registry *ViewRegistry) Register(database string, view View) error {
 	registry.mutex.Lock()
 	defer registry.mutex.Unlock()
@@ -70,7 +75,7 @@ func (registry *ViewRegistry) Register(database string, view View) error {
 }
 
 // Deletes the view specified by the pair {databaseName, viewName}, returning
-// an error if it does not exist
+// an error if it does not exist.
 func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
 	registry.mutex.Lock()
 	defer registry.mutex.Unlock()
@@ -85,6 +90,8 @@ func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
 	return nil
 }
 
+// Returns a pointer to the view specified by the pair {databaseName,
+// viewName}, returning an error if it does not exist.
 func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error) {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()
@@ -98,7 +105,7 @@ func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error)
 	return nil, ErrNonExistingView.New(databaseName, viewName)
 }
 
-// Returns the map of all views in the registry
+// Returns the map of all views in the registry.
 func (registry *ViewRegistry) AllViews() map[viewKey]View {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()
@@ -106,7 +113,7 @@ func (registry *ViewRegistry) AllViews() map[viewKey]View {
 	return registry.views
 }
 
-// Returns an array of all the views registered under the specified database
+// Returns an array of all the views registered under the specified database.
 func (registry *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -24,13 +24,13 @@ func NewView(name string, definition Node) View {
 }
 
 // Name returns the name of the view.
-func (view *View) Name() string {
-	return view.name
+func (v *View) Name() string {
+	return v.name
 }
 
 // Definition returns the definition of the view.
-func (view *View) Definition() Node {
-	return view.definition
+func (v *View) Definition() Node {
+	return v.definition
 }
 
 // Views are scoped by the databases in which they were defined, so a key in
@@ -60,45 +60,45 @@ func NewViewRegistry() *ViewRegistry {
 
 // Register adds the view specified by the pair {database, view.Name()},
 // returning an error if there is already an element with that key.
-func (registry *ViewRegistry) Register(database string, view View) error {
-	registry.mutex.Lock()
-	defer registry.mutex.Unlock()
+func (r *ViewRegistry) Register(database string, view View) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	key := newViewKey(database, view.Name())
 
-	if _, ok := registry.views[key]; ok {
+	if _, ok := r.views[key]; ok {
 		return ErrExistingView.New(database, view.Name())
 	}
 
-	registry.views[key] = view
+	r.views[key] = view
 	return nil
 }
 
 // Delete deletes the view specified by the pair {databaseName, viewName},
 // returning an error if it does not exist.
-func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
-	registry.mutex.Lock()
-	defer registry.mutex.Unlock()
+func (r *ViewRegistry) Delete(databaseName, viewName string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	key := newViewKey(databaseName, viewName)
 
-	if _, ok := registry.views[key]; !ok {
+	if _, ok := r.views[key]; !ok {
 		return ErrNonExistingView.New(databaseName, viewName)
 	}
 
-	delete(registry.views, key)
+	delete(r.views, key)
 	return nil
 }
 
 // View returns a pointer to the view specified by the pair {databaseName,
 // viewName}, returning an error if it does not exist.
-func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error) {
-	registry.mutex.RLock()
-	defer registry.mutex.RUnlock()
+func (r *ViewRegistry) View(databaseName, viewName string) (*View, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 
 	key := newViewKey(databaseName, viewName)
 
-	if view, ok := registry.views[key]; ok {
+	if view, ok := r.views[key]; ok {
 		return &view, nil
 	}
 
@@ -106,20 +106,20 @@ func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error)
 }
 
 // AllViews returns the map of all views in the registry.
-func (registry *ViewRegistry) AllViews() map[viewKey]View {
-	registry.mutex.RLock()
-	defer registry.mutex.RUnlock()
+func (r *ViewRegistry) AllViews() map[viewKey]View {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 
-	return registry.views
+	return r.views
 }
 
 // ViewsInDatabase returns an array of all the views registered under the
 // specified database.
-func (registry *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
-	registry.mutex.RLock()
-	defer registry.mutex.RUnlock()
+func (r *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 
-	for key, value := range registry.views {
+	for key, value := range r.views {
 		if key.dbName == databaseName {
 			views = append(views, value)
 		}

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -1,0 +1,81 @@
+package sql
+
+import (
+	"sync"
+
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var ErrExistingView = errors.NewKind("the view %s.%s already exists in the registry")
+var ErrNonExistingView = errors.NewKind("the view %s.%s does not exist in the registry")
+
+type View struct {
+	Name       string
+	Definition Node
+}
+
+type viewKey struct {
+	dbName, viewName string
+}
+
+type ViewRegistry struct {
+	mutex sync.RWMutex
+	views map[viewKey]View
+}
+
+func NewViewRegistry() *ViewRegistry {
+	return &ViewRegistry{
+		views: make(map[viewKey]View),
+	}
+}
+
+func (registry *ViewRegistry) Register(database string, view View) error {
+	registry.mutex.Lock()
+	defer registry.mutex.Unlock()
+
+	key := viewKey{database, view.Name}
+
+	if _, ok := registry.views[key]; ok {
+		return ErrExistingView.New(database, view.Name)
+	}
+
+	registry.views[key] = view
+	return nil
+}
+
+func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
+	key := viewKey{databaseName, viewName}
+
+	if _, ok := registry.views[key]; !ok {
+		return ErrNonExistingView.New(databaseName, viewName)
+	}
+
+	delete(registry.views, key)
+	return nil
+}
+
+func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error) {
+	registry.mutex.RLock()
+	defer registry.mutex.RUnlock()
+
+	key := viewKey{databaseName, viewName}
+
+	if view, ok := registry.views[key]; ok {
+		return &view, nil
+	}
+
+	return nil, ErrNonExistingView.New(databaseName, viewName)
+}
+
+func (registry *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
+	registry.mutex.RLock()
+	defer registry.mutex.RUnlock()
+
+	for key, value := range registry.views {
+		if key.dbName == databaseName {
+			views = append(views, value)
+		}
+	}
+
+	return views
+}

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -12,23 +12,23 @@ var (
 	ErrNonExistingView = errors.NewKind("the view %s.%s does not exist in the registry")
 )
 
-// A View is defined by a Node and has a name.
+// View is defined by a Node and has a name.
 type View struct {
 	name       string
 	definition Node
 }
 
-// Creates a View with the specified name and definition.
+// NewView creates a View with the specified name and definition.
 func NewView(name string, definition Node) View {
 	return View{name, definition}
 }
 
-// Returns the name of the view.
+// Name returns the name of the view.
 func (view *View) Name() string {
 	return view.name
 }
 
-// Returns the definition of the view.
+// Definition returns the definition of the view.
 func (view *View) Definition() Node {
 	return view.definition
 }
@@ -39,7 +39,7 @@ type viewKey struct {
 	dbName, viewName string
 }
 
-// Creates a viewKey ensuring both names are lowercase.
+// newViewKey creates a viewKey ensuring both names are lowercase.
 func newViewKey(databaseName, viewName string) viewKey {
 	return viewKey{strings.ToLower(databaseName), strings.ToLower(viewName)}
 }
@@ -51,15 +51,15 @@ type ViewRegistry struct {
 	views map[viewKey]View
 }
 
-// Creates an empty ViewRegistry.
+// NewViewRegistry creates an empty ViewRegistry.
 func NewViewRegistry() *ViewRegistry {
 	return &ViewRegistry{
 		views: make(map[viewKey]View),
 	}
 }
 
-// Adds the view specified by the pair {database, view.Name()}, returning
-// an error if there is already an element with that key.
+// Register adds the view specified by the pair {database, view.Name()},
+// returning an error if there is already an element with that key.
 func (registry *ViewRegistry) Register(database string, view View) error {
 	registry.mutex.Lock()
 	defer registry.mutex.Unlock()
@@ -74,8 +74,8 @@ func (registry *ViewRegistry) Register(database string, view View) error {
 	return nil
 }
 
-// Deletes the view specified by the pair {databaseName, viewName}, returning
-// an error if it does not exist.
+// Delete deletes the view specified by the pair {databaseName, viewName},
+// returning an error if it does not exist.
 func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
 	registry.mutex.Lock()
 	defer registry.mutex.Unlock()
@@ -90,7 +90,7 @@ func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
 	return nil
 }
 
-// Returns a pointer to the view specified by the pair {databaseName,
+// View returns a pointer to the view specified by the pair {databaseName,
 // viewName}, returning an error if it does not exist.
 func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error) {
 	registry.mutex.RLock()
@@ -105,7 +105,7 @@ func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error)
 	return nil, ErrNonExistingView.New(databaseName, viewName)
 }
 
-// Returns the map of all views in the registry.
+// AllViews returns the map of all views in the registry.
 func (registry *ViewRegistry) AllViews() map[viewKey]View {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()
@@ -113,7 +113,8 @@ func (registry *ViewRegistry) AllViews() map[viewKey]View {
 	return registry.views
 }
 
-// Returns an array of all the views registered under the specified database.
+// ViewsInDatabase returns an array of all the views registered under the
+// specified database.
 func (registry *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -8,15 +8,33 @@ import (
 )
 
 var (
-	ErrExistingView = errors.NewKind("the view %s.%s already exists in the registry")
+	ErrExistingView    = errors.NewKind("the view %s.%s already exists in the registry")
 	ErrNonExistingView = errors.NewKind("the view %s.%s does not exist in the registry")
 )
 
+// A View is defined by a Node and has a name
 type View struct {
-	Name       string
-	Definition Node
+	name       string
+	definition Node
 }
 
+// Creates a View with the specified name and definition
+func NewView(name string, definition Node) View {
+	return View{name, definition}
+}
+
+// Returns the name of the view
+func (view *View) Name() string {
+	return view.name
+}
+
+// Returns the definition of the view
+func (view *View) Definition() Node {
+	return view.definition
+}
+
+// Views are scoped by the databases in which they were defined, so a key in
+// the view registry is a pair of names: database and view
 type viewKey struct {
 	dbName, viewName string
 }
@@ -41,10 +59,10 @@ func (registry *ViewRegistry) Register(database string, view View) error {
 	registry.mutex.Lock()
 	defer registry.mutex.Unlock()
 
-	key := newViewKey(database, view.Name)
+	key := newViewKey(database, view.Name())
 
 	if _, ok := registry.views[key]; ok {
-		return ErrExistingView.New(database, view.Name)
+		return ErrExistingView.New(database, view.Name())
 	}
 
 	registry.views[key] = view
@@ -54,6 +72,9 @@ func (registry *ViewRegistry) Register(database string, view View) error {
 // Deletes the view specified by the pair {databaseName, viewName}, returning
 // an error if it does not exist
 func (registry *ViewRegistry) Delete(databaseName, viewName string) error {
+	registry.mutex.Lock()
+	defer registry.mutex.Unlock()
+
 	key := newViewKey(databaseName, viewName)
 
 	if _, ok := registry.views[key]; !ok {
@@ -77,6 +98,15 @@ func (registry *ViewRegistry) View(databaseName, viewName string) (*View, error)
 	return nil, ErrNonExistingView.New(databaseName, viewName)
 }
 
+// Returns the map of all views in the registry
+func (registry *ViewRegistry) AllViews() map[viewKey]View {
+	registry.mutex.RLock()
+	defer registry.mutex.RUnlock()
+
+	return registry.views
+}
+
+// Returns an array of all the views registered under the specified database
 func (registry *ViewRegistry) ViewsInDatabase(databaseName string) (views []View) {
 	registry.mutex.RLock()
 	defer registry.mutex.RUnlock()

--- a/sql/viewregistry_test.go
+++ b/sql/viewregistry_test.go
@@ -45,7 +45,6 @@ func TestRegisterExistingVIew(t *testing.T) {
 	require.NoError(err)
 	require.Equal(1, len(registry.AllViews()))
 
-	// Try to register the same view once again
 	err = registry.Register(dbName, mockView)
 	require.Error(err)
 	require.True(ErrExistingView.Is(err))

--- a/sql/viewregistry_test.go
+++ b/sql/viewregistry_test.go
@@ -1,0 +1,134 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dbName   = "db"
+	viewName = "myview"
+	mockView = NewView(viewName, nil)
+)
+
+// Tests the creation of an empty ViewRegistry with no views registered.
+func TestNewViewRegistry(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+	require.Equal(0, len(registry.AllViews()))
+}
+
+// Tests that registering a non-existing view succeeds.
+func TestRegisterNonExistingView(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	err := registry.Register(dbName, mockView)
+	require.NoError(err)
+	require.Equal(1, len(registry.AllViews()))
+
+	actualView, err := registry.View(dbName, viewName)
+	require.NoError(err)
+	require.Equal(mockView, *actualView)
+}
+
+// Tests that registering an existing view fails.
+func TestRegisterExistingVIew(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	err := registry.Register(dbName, mockView)
+	require.NoError(err)
+	require.Equal(1, len(registry.AllViews()))
+
+	// Try to register the same view once again
+	err = registry.Register(dbName, mockView)
+	require.Error(err)
+	require.True(ErrExistingView.Is(err))
+}
+
+// Tests that deleting an existing view succeeds.
+func TestDeleteExistingView(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	err := registry.Register(dbName, mockView)
+	require.NoError(err)
+	require.Equal(1, len(registry.AllViews()))
+
+	err = registry.Delete(dbName, viewName)
+	require.NoError(err)
+	require.Equal(0, len(registry.AllViews()))
+}
+
+// Tests that deleting a non-existing view fails.
+func TestDeleteNonExistingView(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	err := registry.Delete("random", "randomer")
+	require.Error(err)
+	require.True(ErrNonExistingView.Is(err))
+}
+
+// Tests that retrieving an existing view succeeds and that the view returned
+// is the correct one.
+func TestGetExistingView(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	err := registry.Register(dbName, mockView)
+	require.NoError(err)
+	require.Equal(1, len(registry.AllViews()))
+
+	actualView, err := registry.View(dbName, viewName)
+	require.NoError(err)
+	require.Equal(mockView, *actualView)
+}
+
+// Tests that retrieving a non-existing view fails.
+func TestGetNonExistingView(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	actualView, err := registry.View(dbName, viewName)
+	require.Error(err)
+	require.Nil(actualView)
+	require.True(ErrNonExistingView.Is(err))
+}
+
+// Tests that retrieving the views registered under a database succeeds,
+// returning the list of all the correct views.
+func TestViewsInDatabase(t *testing.T) {
+	require := require.New(t)
+
+	registry := NewViewRegistry()
+
+	databases := []struct {
+		name     string
+		numViews int
+	}{
+		{"db0", 0},
+		{"db1", 5},
+		{"db2", 10},
+	}
+
+	for _, db := range databases {
+		for i := 0; i < db.numViews; i++ {
+			view := NewView(viewName+string(i), nil)
+			err := registry.Register(db.name, view)
+			require.NoError(err)
+		}
+
+		views := registry.ViewsInDatabase(db.name)
+		require.Equal(db.numViews, len(views))
+	}
+}


### PR DESCRIPTION
This PR adds basic support for VIEWs. In particular:
- Creation of VIEWs is supported through the syntax `CREATE [OR REPLACE} [db_name.]view_name AS select_expr`
- Views are treated as tables, and when using them in a query, the unresolved table node is replaced with the plan analyzed from the definition of the view.

I wanted to publish this PR as it is because it was getting too big, but the following tasks are still pending for a future PR:
- [ ] Add support for DROP VIEW statements.
- [ ] Add support for listing views in SHOW TABLE statements.
- [ ] Add support for permanent storage. Right now the implementation only manages VIEWs created in the same session.
- [ ] Add explicit column naming support.

Fixes #53.