### PR TITLE
Do not cancel context for async queries on success

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -153,6 +153,18 @@ func (e *Engine) Query(
 	return analyzed.Schema(), iter, nil
 }
 
+// Async returns true if the query is async. If there are any errors with the
+// query it returns false
+func (e *Engine) Async(ctx *sql.Context, query string) bool {
+	parsed, err := parse.Parse(ctx, query)
+	if err != nil {
+		return false
+	}
+
+	asyncNode, ok := parsed.(sql.AsyncNode)
+	return ok && asyncNode.IsAsync()
+}
+
 // AddDatabase adds the given database to the catalog.
 func (e *Engine) AddDatabase(db sql.Database) {
 	e.Catalog.AddDatabase(db)

--- a/server/handler.go
+++ b/server/handler.go
@@ -113,9 +113,13 @@ func (h *Handler) ComQuery(
 	callback func(*sqltypes.Result) error,
 ) (err error) {
 	ctx := h.sm.NewContextWithQuery(c, query)
-	newCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	ctx = ctx.WithContext(newCtx)
+
+	if !h.e.Async(ctx, query) {
+		newCtx, cancel := context.WithCancel(ctx)
+		ctx = ctx.WithContext(newCtx)
+
+		defer cancel()
+	}
 
 	handled, err := h.handleKill(c, query)
 	if err != nil {

--- a/sql/core.go
+++ b/sql/core.go
@@ -120,6 +120,12 @@ type OpaqueNode interface {
 	Opaque() bool
 }
 
+// AsyncNode is a node that can be executed asynchronously.
+type AsyncNode interface {
+	// IsAsync reports whether the node is async or not.
+	IsAsync() bool
+}
+
 // Expressioner is a node that contains expressions.
 type Expressioner interface {
 	// Expressions returns the list of expressions contained by the node.

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -282,6 +282,11 @@ func (c *CreateIndex) WithChildren(children ...sql.Node) (sql.Node, error) {
 	return &nc, nil
 }
 
+// IsAsync implements the AsyncNode interface.
+func (c *CreateIndex) IsAsync() bool {
+	return c.Async
+}
+
 // getColumnsAndPrepareExpressions extracts the unique columns required by all
 // those expressions and fixes the indexes of the GetFields in the expressions
 // to match a row with only the returned columns in that same order.


### PR DESCRIPTION
Fix #857.

The code in #806 added a context cancel call when the query handle finishes, https://github.com/src-d/go-mysql-server/blob/68b087cfd6d30a8d711e1f686da60bd80c54f93b/server/handler.go#L117

For an async index creation the driver is called in a goroutine https://github.com/src-d/go-mysql-server/blob/68b087cfd6d30a8d711e1f686da60bd80c54f93b/sql/plan/create_index.go#L173

And when the driver went to do the actual index creation in that goroutine, the query had already exited, and the context was cancelled https://github.com/src-d/go-mysql-server/blob/68b087cfd6d30a8d711e1f686da60bd80c54f93b/sql/index/pilosa/driver.go#L419

The first option discussed in slack ([private link](https://src-d.slack.com/archives/C7UDG0GP6/p1571929601195900)) was to change the context of the `createIndex` function linked above with a `ctx.WithContext(context.Background())`, if the call was made in a goroutine.

This removes the original context cancellation, which fixes the problem, but it also prevents from doing a `KILL QUERY` of the async task afterwards. This would be a regression over the latest stable gitbase release.

The code I propose in this PR instead removes the deferred context cancellation in the handler if the query is async. It feels like the code is kind of mixing responsibilities, making the Handler aware of details about the query that should be handled by the Engine. But this was the cleanest approach I could think of.

I am still trying to figure out how this could be tested, any suggestion would be welcome.