### PR TITLE
Add support for DROP VIEW

### DIFF
--- a/sql/analyzer/assign_catalog.go
+++ b/sql/analyzer/assign_catalog.go
@@ -64,6 +64,10 @@ func assignCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 			nc := *node
 			nc.Catalog = a.Catalog
 			return &nc, nil
+		case *plan.DropView:
+			nc := *node
+			nc.Catalog = a.Catalog
+			return &nc, nil
 		default:
 			return n, nil
 		}

--- a/sql/analyzer/assign_catalog_test.go
+++ b/sql/analyzer/assign_catalog_test.go
@@ -81,4 +81,10 @@ func TestAssignCatalog(t *testing.T) {
 	cv, ok := node.(*plan.CreateView)
 	require.True(ok)
 	require.Equal(c, cv.Catalog)
+
+	node, err = f.Apply(sql.NewEmptyContext(), a, plan.NewDropView(nil, false))
+	require.NoError(err)
+	dv, ok := node.(*plan.DropView)
+	require.True(ok)
+	require.Equal(c, dv.Catalog)
 }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -37,6 +37,7 @@ var (
 	describeTablesRegex  = regexp.MustCompile(`^(describe|desc)\s+table\s+(.*)`)
 	createIndexRegex     = regexp.MustCompile(`^create\s+index\s+`)
 	createViewRegex      = regexp.MustCompile(`^create\s+(or\s+replace\s+)?view\s+`)
+	dropViewRegex        = regexp.MustCompile(`^drop\s+(if\s+exists\s+)?view\s+`)
 	dropIndexRegex       = regexp.MustCompile(`^drop\s+index\s+`)
 	showIndexRegex       = regexp.MustCompile(`^show\s+(index|indexes|keys)\s+(from|in)\s+\S+\s*`)
 	showCreateRegex      = regexp.MustCompile(`^show create\s+\S+\s*`)
@@ -84,6 +85,8 @@ func Parse(ctx *sql.Context, query string) (sql.Node, error) {
 		return parseCreateIndex(ctx, s)
 	case createViewRegex.MatchString(lowerQuery):
 		return parseCreateView(ctx, s)
+	case dropViewRegex.MatchString(lowerQuery):
+		return parseDropView(ctx, s)
 	case dropIndexRegex.MatchString(lowerQuery):
 		return parseDropIndex(s)
 	case showIndexRegex.MatchString(lowerQuery):

--- a/sql/parse/views.go
+++ b/sql/parse/views.go
@@ -128,7 +128,7 @@ func parseDropView(ctx *sql.Context, s string) (sql.Node, error) {
 
 	plans := make([]sql.Node, len(views))
 	for i, view := range views {
-		plans[i] = plan.NewSingleDropView(sql.UnresolvedDatabase(view.db), view.name)
+		plans[i] = plan.NewSingleDropView(sql.UnresolvedDatabase(view.qualifier), view.name)
 	}
 
 	return plan.NewDropView(plans, ifExists), nil

--- a/sql/plan/drop_view.go
+++ b/sql/plan/drop_view.go
@@ -1,0 +1,148 @@
+package plan
+
+import (
+	"github.com/src-d/go-mysql-server/sql"
+	errors "gopkg.in/src-d/go-errors.v1"
+)
+
+var errDropViewChild = errors.NewKind("any child of DropView must be of type SingleDropView")
+
+type SingleDropView struct {
+	database sql.Database
+	viewName string
+}
+
+// NewSingleDropView creates a SingleDropView.
+func NewSingleDropView(
+	database sql.Database,
+	viewName string,
+) *SingleDropView {
+	return &SingleDropView{database, viewName}
+}
+
+// Children implements the Node interface. It always returns nil.
+func (dv *SingleDropView) Children() []sql.Node {
+	return nil
+}
+
+// Resolved implements the Node interface. This node is resolved if and only if
+// its database is resolved.
+func (dv *SingleDropView) Resolved() bool {
+	_, ok := dv.database.(sql.UnresolvedDatabase)
+	return !ok
+}
+
+// RowIter implements the Node interface. It always returns an empty iterator.
+func (dv *SingleDropView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	return sql.RowsToRowIter(), nil
+}
+
+// Schema implements the Node interface. It always returns nil.
+func (dv *SingleDropView) Schema() sql.Schema { return nil }
+
+// String implements the fmt.Stringer interface, using sql.TreePrinter to
+// generate the string.
+func (dv *SingleDropView) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("SingleDropView(%s.%s)", dv.database.Name(), dv.viewName)
+
+	return pr.String()
+}
+
+// WithChildren implements the Node interface. It only succeeds if the length
+// of the specified children equals 0.
+func (dv *SingleDropView) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(dv, len(children), 0)
+	}
+
+	return dv, nil
+}
+
+// Database implements the Databaser interfacee. It returns the node's database.
+func (dv *SingleDropView) Database() sql.Database {
+	return dv.database
+}
+
+// Database implements the Databaser interface, and it returns a copy of this
+// node with the specified database.
+func (dv *SingleDropView) WithDatabase(database sql.Database) (sql.Node, error) {
+	newDrop := *dv
+	newDrop.database = database
+	return &newDrop, nil
+}
+
+// DropView is a node representing the removal of a list of views, defined by
+// the children member. The flag ifExists represents whether the user wants the
+// node to fail if any of the views in children does not exist.
+type DropView struct {
+	children []sql.Node
+	Catalog  *sql.Catalog
+	ifExists bool
+}
+
+// NewDropView creates a DropView node with the specified parameters,
+// setting its catalog to nil.
+func NewDropView(children []sql.Node, ifExists bool) *DropView {
+	return &DropView{children, nil, ifExists}
+}
+
+// Children implements the Node interface. It returns the children of the
+// CreateView node; i.e., all the views that will be dropped.
+func (dvs *DropView) Children() []sql.Node {
+	return dvs.children
+}
+
+// Resolved implements the Node interface. This node is resolved if and only if
+// all of its children are resolved.
+func (dvs *DropView) Resolved() bool {
+	for _, child := range dvs.children {
+		if !child.Resolved() {
+			return false
+		}
+	}
+	return true
+}
+
+// RowIter implements the Node interface. When executed, this function drops
+// all the views defined by the node's children. It errors if the flag ifExists
+// is set to false and there is some view that does not exist.
+func (dvs *DropView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	viewList := make([]sql.ViewKey, len(dvs.children))
+	for i, child := range dvs.children {
+		drop, ok := child.(*SingleDropView)
+		if !ok {
+			return sql.RowsToRowIter(), errDropViewChild.New()
+		}
+
+		viewList[i] = sql.NewViewKey(drop.database.Name(), drop.viewName)
+	}
+
+	return sql.RowsToRowIter(), dvs.Catalog.ViewRegistry.DeleteList(viewList, !dvs.ifExists)
+}
+
+// Schema implements the Node interface. It always returns nil.
+func (dvs *DropView) Schema() sql.Schema { return nil }
+
+// String implements the fmt.Stringer interface, using sql.TreePrinter to
+// generate the string.
+func (dvs *DropView) String() string {
+	childrenStrings := make([]string, len(dvs.children))
+	for i, child := range dvs.children {
+		childrenStrings[i] = child.String()
+	}
+
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("DropView")
+	_ = pr.WriteChildren(childrenStrings...)
+
+	return pr.String()
+}
+
+// WithChildren implements the Node interface. It always suceeds, returning a
+// copy of this node with the new array of nodes as children.
+func (dvs *DropView) WithChildren(children ...sql.Node) (sql.Node, error) {
+	newDrop := dvs
+	newDrop.children = children
+	return newDrop, nil
+}

--- a/sql/plan/drop_view_test.go
+++ b/sql/plan/drop_view_test.go
@@ -1,0 +1,94 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/src-d/go-mysql-server/memory"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Generates a database with a single table called mytable and a catalog with
+// the view that is also returned. The context returned is the one used to
+// create the view.
+func mockData(require *require.Assertions) (sql.Database, *sql.Catalog, *sql.Context, sql.View) {
+	table := memory.NewTable("mytable", sql.Schema{
+		{Name: "i", Source: "mytable", Type: sql.Int32},
+		{Name: "s", Source: "mytable", Type: sql.Text},
+	})
+
+	db := memory.NewDatabase("db")
+	db.AddTable("db", table)
+
+	catalog := sql.NewCatalog()
+	catalog.AddDatabase(db)
+
+	subqueryAlias := NewSubqueryAlias("myview",
+		NewProject(
+			[]sql.Expression{
+				expression.NewGetFieldWithTable(1, sql.Int32, table.Name(), "i", true),
+			},
+			NewUnresolvedTable("dual", ""),
+		),
+	)
+
+	createView := NewCreateView(db, subqueryAlias.Name(), nil, subqueryAlias, false)
+	createView.Catalog = catalog
+
+	ctx := sql.NewEmptyContext()
+
+	_, err := createView.RowIter(ctx)
+	require.NoError(err)
+
+	return db, catalog, ctx, createView.View()
+}
+
+// Tests that DropView works as expected and that the view is dropped in
+// the catalog when RowIter is called, regardless of the value of ifExists
+func TestDropExistingView(t *testing.T) {
+	require := require.New(t)
+
+	test := func(ifExists bool) {
+		db, catalog, ctx, view := mockData(require)
+
+		singleDropView := NewSingleDropView(db, view.Name())
+		dropView := NewDropView([]sql.Node{singleDropView}, ifExists)
+		dropView.Catalog = catalog
+
+		_, err := dropView.RowIter(ctx)
+		require.NoError(err)
+
+		require.False(catalog.ViewRegistry.Exists(db.Name(), view.Name()))
+	}
+
+	test(false)
+	test(true)
+}
+
+// Tests that DropView errors when trying to delete a non-existing view if and
+// only if the flag ifExists is set to false
+func TestDropNonExistingView(t *testing.T) {
+	require := require.New(t)
+
+	test := func(ifExists bool) error {
+		db, catalog, ctx, view := mockData(require)
+
+		singleDropView := NewSingleDropView(db, "non-existing-view")
+		dropView := NewDropView([]sql.Node{singleDropView}, ifExists)
+		dropView.Catalog = catalog
+
+		_, err := dropView.RowIter(ctx)
+
+		require.True(catalog.ViewRegistry.Exists(db.Name(), view.Name()))
+
+		return err
+	}
+
+	err := test(true)
+	require.NoError(err)
+
+	err = test(false)
+	require.Error(err)
+}

--- a/sql/viewregistry.go
+++ b/sql/viewregistry.go
@@ -35,26 +35,26 @@ func (v *View) Definition() Node {
 
 // Views are scoped by the databases in which they were defined, so a key in
 // the view registry is a pair of names: database and view.
-type viewKey struct {
+type ViewKey struct {
 	dbName, viewName string
 }
 
-// newViewKey creates a viewKey ensuring both names are lowercase.
-func newViewKey(databaseName, viewName string) viewKey {
-	return viewKey{strings.ToLower(databaseName), strings.ToLower(viewName)}
+// NewViewKey creates a ViewKey ensuring both names are lowercase.
+func NewViewKey(databaseName, viewName string) ViewKey {
+	return ViewKey{strings.ToLower(databaseName), strings.ToLower(viewName)}
 }
 
-// ViewRegistry is a map of viewKey to View whose access is protected by a
+// ViewRegistry is a map of ViewKey to View whose access is protected by a
 // RWMutex.
 type ViewRegistry struct {
 	mutex sync.RWMutex
-	views map[viewKey]View
+	views map[ViewKey]View
 }
 
 // NewViewRegistry creates an empty ViewRegistry.
 func NewViewRegistry() *ViewRegistry {
 	return &ViewRegistry{
-		views: make(map[viewKey]View),
+		views: make(map[ViewKey]View),
 	}
 }
 
@@ -64,7 +64,7 @@ func (r *ViewRegistry) Register(database string, view View) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	key := newViewKey(database, view.Name())
+	key := NewViewKey(database, view.Name())
 
 	if _, ok := r.views[key]; ok {
 		return ErrExistingView.New(database, view.Name())
@@ -80,7 +80,7 @@ func (r *ViewRegistry) Delete(databaseName, viewName string) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	key := newViewKey(databaseName, viewName)
+	key := NewViewKey(databaseName, viewName)
 
 	if _, ok := r.views[key]; !ok {
 		return ErrNonExistingView.New(databaseName, viewName)
@@ -96,7 +96,7 @@ func (r *ViewRegistry) View(databaseName, viewName string) (*View, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	key := newViewKey(databaseName, viewName)
+	key := NewViewKey(databaseName, viewName)
 
 	if view, ok := r.views[key]; ok {
 		return &view, nil
@@ -106,7 +106,7 @@ func (r *ViewRegistry) View(databaseName, viewName string) (*View, error) {
 }
 
 // AllViews returns the map of all views in the registry.
-func (r *ViewRegistry) AllViews() map[viewKey]View {
+func (r *ViewRegistry) AllViews() map[ViewKey]View {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 


### PR DESCRIPTION
This PR adds support for `DROP VIEW` statements, as in

```sql
DROP VIEW [IF EXISTS] [db_name1.]view_name1 [, [db_name2.]view_name2, ...] [RESTRICT] [CASCADE]
```

As each view in the statement may come from a different database, I have decided to model the plan as follows:

- There is a parent node, `DropView`, that just contains a list of children of type `SingleDropView`.
- The nodes `SingleDropView` implement the `Databaser` interface so the analyzer can resolve the database in each of them.

The actual removal of the views happen in the `RowIter` from `DropView`, as we need to:

1. Retrieve the ViewRegistry mutex.
2. Check that all views in the children member of `DropView` can be deleted (i.e., they exist or they do not exist but the user has added the `IF EXISTS` keyword to the statement)
3. Delete all of the views listed if the previous step raised no error.
4. Release the mutex.

I first started implementing the removal in the `SingleDropView` nodes, but then it was difficult to check that all views could be deleted and then delete them, all in an atomic operation. The final implementation makes this easy with the new `DeleteList` from `ViewRegistry`.