### PR TITLE
Format SHOW PROCESSLIST progress as a tree

### DIFF
--- a/sql/analyzer/process.go
+++ b/sql/analyzer/process.go
@@ -40,21 +40,21 @@ func trackProcess(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 				}
 				total = count
 			}
-			processList.AddProgressItem(ctx.Pid(), name, total)
+			processList.AddTableProgress(ctx.Pid(), name, total)
 
 			seen[name] = struct{}{}
 
 			onPartitionDone := func(partitionName string) {
-				processList.UpdateProgress(ctx.Pid(), name, 1)
-				processList.RemoveProgressItem(ctx.Pid(), partitionName)
+				processList.UpdateTableProgress(ctx.Pid(), name, 1)
+				processList.RemovePartitionProgress(ctx.Pid(), name, partitionName)
 			}
 
 			onPartitionStart := func(partitionName string) {
-				processList.AddProgressItem(ctx.Pid(), partitionName, -1)
+				processList.AddPartitionProgress(ctx.Pid(), name, partitionName, -1)
 			}
 
 			onRowNext := func(partitionName string) {
-				processList.UpdateProgress(ctx.Pid(), partitionName, 1)
+				processList.UpdatePartitionProgress(ctx.Pid(), name, partitionName, 1)
 			}
 
 			var t sql.Table

--- a/sql/analyzer/process_test.go
+++ b/sql/analyzer/process_test.go
@@ -35,10 +35,16 @@ func TestTrackProcess(t *testing.T) {
 	require.Len(processes, 1)
 	require.Equal("SELECT foo", processes[0].Query)
 	require.Equal(sql.QueryProcess, processes[0].Type)
-	require.Equal(map[string]sql.Progress{
-		"foo": sql.Progress{Total: 2},
-		"bar": sql.Progress{Total: 4},
-	}, processes[0].Progress)
+	require.Equal(
+		map[string]sql.TableProgress{
+			"foo": sql.TableProgress{
+				Progress:           sql.Progress{Name: "foo", Done: 0, Total: 2},
+				PartitionsProgress: map[string]sql.PartitionProgress{}},
+			"bar": sql.TableProgress{
+				Progress:           sql.Progress{Name: "bar", Done: 0, Total: 4},
+				PartitionsProgress: map[string]sql.PartitionProgress{}},
+		},
+		processes[0].Progress)
 
 	proc, ok := result.(*plan.QueryProcess)
 	require.True(ok)


### PR DESCRIPTION
This is a sugestion by @ajnavarro, related to #855.

With the changes in this PR the output of SHOW PROCESSLIST shows the progress formatted as a tree:
```
mysql> show processlist\G
*************************** 1. row ***************************
     Id: 2
   User: root
   Host: 127.0.0.1:53116
     db: gitbase
Command: query
   Time: 0
  State: running
   Info: show processlist
*************************** 2. row ***************************
     Id: 1
   User: root
   Host: 127.0.0.1:53116
     db: gitbase
Command: query
   Time: 50
  State: 
SquashedTable(repositories, commits) (0/3 partitions)
 ├─ cangallo (101/? rows)
 ├─ octoprint-tft (101/? rows)
 └─ upsilon (101/? rows)

   Info: select * from repositories natural join commits
2 rows in set (0.01 sec)
```